### PR TITLE
feat: MCP-I protocol reference implementation — DIF TAAWG submission

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -1,0 +1,321 @@
+# MCP-I Conformance Requirements
+
+**Model Context Protocol Identity Extension — Compliance Levels**
+
+Version: 1.0.0-draft
+Status: Draft
+
+---
+
+## Overview
+
+This document defines three compliance levels for MCP-I implementations. Each level builds on the previous, with increasing capability requirements. Implementations MUST pass all tests for a given level to claim conformance at that level.
+
+---
+
+## Level 1 — Core Crypto
+
+Level 1 establishes the cryptographic foundation. An implementation at this level can generate identities, sign data, verify signatures, and expose discovery metadata.
+
+### Requirements
+
+| ID | Requirement | Test File | Test Name |
+|----|-------------|-----------|-----------|
+| L1.1 | Generate Ed25519 key pair and derive a `did:key` DID | `src/utils/__tests__/did-helpers.test.ts` | `generateDidKeyFromBytes` / `generateDidKeyFromBase64` |
+| L1.2 | Implement SHA-256 hashing of canonicalized JSON (RFC 8785 JCS) | `src/proof/__tests__/proof-generator.test.ts` | `Canonical Hash Generation > should generate SHA-256 hashes with correct format` |
+| L1.3 | Sign data with EdDSA (JWS compact serialization) | `src/proof/__tests__/proof-generator.test.ts` | `JWS Generation > should generate compact JWS in correct format` |
+| L1.4 | Verify EdDSA signatures | `src/proof/__tests__/proof-generator.test.ts` | `Proof Verification > should verify valid proof structure` |
+| L1.5 | Use EdDSA algorithm identifier in JWS header | `src/proof/__tests__/proof-generator.test.ts` | `JWS Generation > should use EdDSA algorithm` |
+| L1.6 | Resolve `did:key` DIDs to DID Documents | `src/delegation/__tests__/did-key-resolver.test.ts` | `createDidKeyResolver > should resolve Ed25519 did:key to DID Document` |
+| L1.7 | Extract Ed25519 public key from `did:key` | `src/delegation/__tests__/did-key-resolver.test.ts` | `extractPublicKeyFromDidKey > should extract public key bytes from valid did:key` |
+| L1.8 | Convert public key bytes to JWK format | `src/delegation/__tests__/did-key-resolver.test.ts` | `publicKeyToJwk > should convert public key bytes to JWK format` |
+| L1.9 | Implement base58btc encoding/decoding | `src/delegation/__tests__/did-key-resolver.test.ts` | `Base58 Utilities` (all tests) |
+| L1.10 | Expose `/.well-known/mcpi` endpoint (recommended) | — | Implementation-specific |
+
+### Detailed Requirements
+
+#### L1.1 — Ed25519 Key Generation
+
+Implementation MUST:
+- Generate cryptographically secure random 32-byte private seed
+- Derive 32-byte public key from seed
+- Derive `did:key` DID from public key using multicodec prefix `0xed01` and base58btc encoding
+- Key ID format: `<did>#keys-1`
+
+#### L1.2 — SHA-256 Hashing
+
+Implementation MUST:
+- Accept arbitrary JSON input
+- Canonicalize according to RFC 8785 (JCS): sorted keys, no whitespace, specific escaping
+- Compute SHA-256 hash of UTF-8 encoded canonical JSON
+- Return hash in format: `sha256:<64-char-lowercase-hex>`
+
+#### L1.3 — EdDSA Signing
+
+Implementation MUST:
+- Accept data bytes and Ed25519 private key
+- Produce JWS compact serialization: `<header>.<payload>.<signature>`
+- Header MUST include `"alg": "EdDSA"` and `"kid": "<key-id>"`
+- Signature MUST be 64 bytes, base64url-encoded
+
+#### L1.4 — EdDSA Verification
+
+Implementation MUST:
+- Accept JWS compact string and public key (JWK format)
+- Verify signature against payload
+- Verify `kid` in header matches expected key
+- Return boolean result
+
+---
+
+## Level 2 — Full Session
+
+Level 2 adds session management with replay prevention and proof generation. An implementation at this level can establish secure sessions and generate non-repudiation proofs.
+
+### Requirements
+
+All Level 1 requirements, plus:
+
+| ID | Requirement | Test File | Test Name |
+|----|-------------|-----------|-----------|
+| L2.1 | Implement handshake request validation | `src/session/__tests__/session-manager.test.ts` | `Handshake validation > should create a valid session on correct handshake` |
+| L2.2 | Validate nonce format (base64url, 22+ chars) | `src/session/__tests__/session-manager.test.ts` | `Nonce format > should generate nonce as base64url string` |
+| L2.3 | Enforce timestamp skew ≤120 seconds (default) | `src/session/__tests__/session-manager.test.ts` | `Handshake validation > should reject request with stale timestamp` |
+| L2.4 | Accept requests within timestamp skew | `src/session/__tests__/session-manager.test.ts` | `Handshake validation > should accept request within timestamp skew` |
+| L2.5 | Enforce nonce uniqueness (replay prevention) | `src/session/__tests__/session-manager.test.ts` | `Handshake validation > should reject replayed nonce` |
+| L2.6 | Generate unique nonces | `src/session/__tests__/session-manager.test.ts` | `Nonce format > should generate unique nonces` |
+| L2.7 | Generate session IDs with `mcpi_` prefix | `src/session/__tests__/session-manager.test.ts` | `Handshake validation > should return session ID with mcpi_ prefix` |
+| L2.8 | Maintain session TTL | `src/session/__tests__/session-manager.test.ts` | `Session expiry — TTL behaviour > should expire idle sessions after TTL` |
+| L2.9 | Support configurable timestamp skew | `src/session/__tests__/session-manager.test.ts` | `Custom timestamp skew > should use custom timestampSkewSeconds when provided` |
+| L2.10 | Update session `lastActivity` on access | `src/session/__tests__/session-manager.test.ts` | `Session lookup — getSession > should update lastActivity on each getSession call` |
+| L2.11 | Generate detached proof with request/response hashes | `src/proof/__tests__/proof-generator.test.ts` | `Proof Metadata > should include all required metadata fields` |
+| L2.12 | Include session context in proof metadata | `src/proof/__tests__/proof-generator.test.ts` | `Proof Metadata > should include all required metadata fields` |
+| L2.13 | Verify proof against request/response | `src/proof/__tests__/proof-generator.test.ts` | `Proof Verification > should reject proof with mismatched request` |
+| L2.14 | Validate handshake request format | `src/session/__tests__/session-manager.test.ts` | `validateHandshakeFormat` (all tests) |
+| L2.15 | Create handshake request with current timestamp | `src/session/__tests__/session-manager.test.ts` | `createHandshakeRequest > should use current timestamp` |
+
+### Detailed Requirements
+
+#### L2.1 — Handshake Validation
+
+Implementation MUST validate:
+- `nonce`: Non-empty string, base64url format, minimum 16 bytes entropy
+- `audience`: Non-empty string matching server identity
+- `timestamp`: Positive integer, within skew tolerance of server time
+- `agentDid` (optional): Valid DID format if present
+
+#### L2.5 — Nonce Replay Prevention
+
+Implementation MUST:
+- Store (nonce, agentDid) tuples for at least `sessionTtlMinutes + 1 minute`
+- Reject any request with a previously-seen nonce for the same agentDid
+- Support cleanup of expired nonces
+
+#### L2.11 — Detached Proof Generation
+
+Proof metadata MUST include:
+- `did`: Signer's DID
+- `kid`: Key ID used for signing
+- `ts`: Unix epoch seconds
+- `nonce`: Session nonce
+- `audience`: Session audience
+- `sessionId`: Session identifier
+- `requestHash`: SHA-256 of canonicalized request (`sha256:<hex>`)
+- `responseHash`: SHA-256 of canonicalized response (`sha256:<hex>`)
+
+---
+
+## Level 3 — Full Delegation
+
+Level 3 adds W3C Verifiable Credential-based delegation with revocation support. An implementation at this level can issue, verify, and revoke delegations, and propagate delegation context on outbound calls.
+
+### Requirements
+
+All Level 2 requirements, plus:
+
+| ID | Requirement | Test File | Test Name |
+|----|-------------|-----------|-----------|
+| L3.1 | Issue W3C DelegationCredentials | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should issue a signed delegation credential` |
+| L3.2 | Wrap DelegationRecord in VC structure | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should call wrapDelegationAsVC with delegation record` |
+| L3.3 | Support issuance options (id, dates, status) | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should pass options to wrapDelegationAsVC` |
+| L3.4 | Canonicalize VC before signing | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should canonicalize VC before signing` |
+| L3.5 | Verify DelegationCredential basic properties | `src/delegation/__tests__/vc-verifier.test.ts` | `verifyDelegationCredential - Basic Validation Stage` (all tests) |
+| L3.6 | Reject expired credentials | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject expired credentials` |
+| L3.7 | Reject not-yet-valid credentials | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject not-yet-valid credentials` |
+| L3.8 | Reject revoked credentials (status field) | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject revoked credentials` |
+| L3.9 | Verify credential signature | `src/delegation/__tests__/vc-verifier.test.ts` | `Signature Verification > should succeed when signature verification passes` |
+| L3.10 | Resolve issuer DID for signature verification | `src/delegation/__tests__/vc-verifier.test.ts` | `Signature Verification > should fail when DID resolution fails` |
+| L3.11 | Check credential status via StatusList2021 | `src/delegation/__tests__/vc-verifier.test.ts` | `Status Checking > should fail when credential is revoked` |
+| L3.12 | Cache verification results | `src/delegation/__tests__/vc-verifier.test.ts` | `Caching > should return cached result when available` |
+| L3.13 | Enforce CRISP scope constraints | `src/delegation/__tests__/audience-validator.test.ts` | All tests |
+| L3.14 | Register delegation in graph | `src/delegation/__tests__/delegation-graph.test.ts` | `registerDelegation > should register a root delegation` |
+| L3.15 | Link child to parent in delegation graph | `src/delegation/__tests__/delegation-graph.test.ts` | `registerDelegation > should register a child delegation and link to parent` |
+| L3.16 | Validate delegation chain (issuer/subject continuity) | `src/delegation/__tests__/delegation-graph.test.ts` | `validateChain > should validate correct chain` |
+| L3.17 | Detect chain with mismatched issuer/subject | `src/delegation/__tests__/delegation-graph.test.ts` | `validateChain > should invalidate chain with mismatched issuer/subject` |
+| L3.18 | Get delegation chain from leaf to root | `src/delegation/__tests__/delegation-graph.test.ts` | `getChain > should return chain from root to node` |
+| L3.19 | Get all descendants of a delegation | `src/delegation/__tests__/delegation-graph.test.ts` | `getDescendants > should return all descendants recursively` |
+| L3.20 | Create StatusList2021 credential | `src/delegation/__tests__/statuslist-manager.test.ts` | (StatusList2021Manager tests) |
+| L3.21 | Set/check revocation status by index | `src/delegation/__tests__/bitstring.test.ts` | All tests |
+| L3.22 | Cascading revocation of descendant delegations | `src/delegation/__tests__/cascading-revocation.test.ts` | All tests |
+| L3.23 | Build delegation proof JWT for outbound calls | `src/delegation/__tests__/outbound-proof.test.ts` | All tests |
+| L3.24 | Build delegation chain string | `src/delegation/__tests__/outbound-proof.test.ts` | `buildChainString` tests |
+| L3.25 | Return `needs_authorization` hints | Implementation-specific | — |
+
+### Detailed Requirements
+
+#### L3.1 — VC Issuance
+
+Implementation MUST:
+- Produce valid W3C Verifiable Credential structure
+- Include `@context` with VC v1 and MCP-I delegation context
+- Include `type` array with `VerifiableCredential` and `DelegationCredential`
+- Include `issuer` as DID string or object with `id`
+- Include `issuanceDate` in ISO 8601 format
+- Include `credentialSubject` with delegation details
+- Include `proof` with Ed25519Signature2020 or equivalent
+
+#### L3.5 — VC Verification
+
+Implementation MUST validate:
+- `@context` starts with W3C VC v1 context
+- `type` includes required types
+- `issuer` is present and valid
+- `issuanceDate` is present and in the past
+- `expirationDate` (if present) is in the future
+- `credentialSubject.delegation` has required fields
+- `proof` is present
+
+#### L3.11 — StatusList2021 Checking
+
+Implementation MUST:
+- Fetch StatusList2021 credential from `credentialStatus.statusListCredential`
+- Decompress and decode the bitstring
+- Check bit at `statusListIndex`
+- Return revoked status if bit is 1
+
+#### L3.22 — Cascading Revocation
+
+When revoking a delegation, implementation MUST:
+- Mark the target delegation as revoked
+- Recursively mark all descendants as revoked
+- Update StatusList2021 for each revoked delegation
+- Emit revocation events (implementation-specific)
+
+---
+
+## Running Conformance Tests
+
+### Prerequisites
+
+```bash
+# Install dependencies
+pnpm install
+
+# Or with npm
+npm install
+```
+
+### Running All Tests
+
+```bash
+# Run all tests
+pnpm test
+
+# Or with npx
+npx vitest run
+```
+
+### Running Specific Test Files
+
+```bash
+# Level 1 - Core Crypto
+npx vitest run src/delegation/__tests__/did-key-resolver.test.ts
+npx vitest run src/utils/__tests__/did-helpers.test.ts
+npx vitest run src/utils/__tests__/base58.test.ts
+
+# Level 2 - Session
+npx vitest run src/session/__tests__/session-manager.test.ts
+npx vitest run src/proof/__tests__/proof-generator.test.ts
+
+# Level 3 - Delegation
+npx vitest run src/delegation/__tests__/vc-issuer.test.ts
+npx vitest run src/delegation/__tests__/vc-verifier.test.ts
+npx vitest run src/delegation/__tests__/delegation-graph.test.ts
+npx vitest run src/delegation/__tests__/cascading-revocation.test.ts
+npx vitest run src/delegation/__tests__/statuslist-manager.test.ts
+npx vitest run src/delegation/__tests__/bitstring.test.ts
+npx vitest run src/delegation/__tests__/outbound-proof.test.ts
+npx vitest run src/delegation/__tests__/audience-validator.test.ts
+```
+
+### Test Coverage
+
+```bash
+# Run tests with coverage
+pnpm test:coverage
+
+# Or
+npx vitest run --coverage
+```
+
+---
+
+## Submitting Conformance Results
+
+To submit conformance results for your implementation:
+
+1. Fork the `mcp-i-core` repository
+2. Run the test suite against your implementation
+3. Capture test output and coverage report
+4. Open a GitHub issue at https://github.com/modelcontextprotocol-identity/mcp-i-core/issues with:
+   - Implementation name and version
+   - Target conformance level (1, 2, or 3)
+   - Test results (pass/fail counts)
+   - Coverage report
+   - Platform/runtime information
+   - Any deviations or extensions
+
+### Issue Template
+
+```markdown
+## MCP-I Conformance Submission
+
+**Implementation**: [Name] v[Version]
+**Conformance Level**: [1 | 2 | 3]
+**Platform**: [Node.js 20.x | Cloudflare Workers | etc.]
+
+### Test Results
+
+- Total Tests: X
+- Passed: X
+- Failed: X
+- Skipped: X
+
+### Coverage
+
+[Attach or link coverage report]
+
+### Deviations
+
+[List any deviations from the specification]
+
+### Extensions
+
+[List any extensions beyond the specification]
+```
+
+---
+
+## Conformance Badges
+
+Implementations that pass conformance testing may display badges:
+
+- **MCP-I Level 1 Conformant** — Core cryptographic operations
+- **MCP-I Level 2 Conformant** — Session management and proofs
+- **MCP-I Level 3 Conformant** — Full delegation support
+
+Badge assets will be provided upon successful conformance submission.
+
+---
+
+*End of Conformance Requirements*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Spec: [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.i
 
 | Module | Description |
 |--------|-------------|
-| **delegation** | W3C VC delegation issuance (`DelegationCredentialIssuer`), verification (`DelegationCredentialVerifier`), graph management, StatusList2021 revocation, cascading revocation, and DID:key resolution (`createDidKeyResolver`) |
+| **delegation** | W3C VC delegation issuance (`DelegationCredentialIssuer`), verification (`DelegationCredentialVerifier`), graph management, StatusList2021 revocation, cascading revocation, DID:key resolution (`createDidKeyResolver`), and DID:web resolution (`createDidWebResolver`) |
 | **proof** | Platform-agnostic proof generation (`ProofGenerator`) and server-side verification (`ProofVerifier`) — JCS canonicalization, SHA-256 hashing, Ed25519 JWS signing/verification |
 | **session** | Handshake validation and session management (`SessionManager`) with nonce replay prevention |
 | **auth** | Authorization handshake orchestration (`verifyOrHints`) — checks delegation and returns authorization hints |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,743 @@
+# MCP-I Protocol Specification
+
+**Model Context Protocol Identity Extension**
+
+Version: 1.0.0-draft
+Status: Draft
+Editors: MCP-I Working Group
+Repository: https://github.com/modelcontextprotocol-identity/mcp-i-core
+
+---
+
+## Abstract
+
+MCP-I (Model Context Protocol Identity) is a protocol extension for the Model Context Protocol (MCP) that adds cryptographic identity, delegation chains, and non-repudiation proofs to AI agent interactions. MCP-I enables MCP servers to verify *who* is calling (agent DID), *on whose behalf* (user delegation via W3C Verifiable Credentials), and *what* was done (signed proof for audit trails). The protocol uses Decentralized Identifiers (DIDs) for agent identity, W3C Verifiable Credentials for delegation, Ed25519 signatures for cryptographic operations, and StatusList2021 for revocation.
+
+---
+
+## Status
+
+**Draft** — Submitted to DIF TAAWG (Decentralized Identity Foundation, Trust and Authorization for AI Agents Working Group) for review. Not yet a standard.
+
+---
+
+## 1. Motivation
+
+The Model Context Protocol (MCP) defines a standard interface for AI agents to interact with tools and resources. However, MCP lacks an identity layer, creating several security vulnerabilities:
+
+1. **Agent Impersonation**: Without identity verification, any process can claim to be a particular agent. Malicious actors can impersonate trusted agents to gain unauthorized access to sensitive tools.
+
+2. **Prompt Injection with Forged Identity**: Attackers can inject prompts that include fabricated identity claims. Without cryptographic verification, servers cannot distinguish legitimate identity assertions from forged ones.
+
+3. **No Delegation Chain**: When Agent A delegates to Agent B, there is no standard mechanism to prove the delegation occurred or verify the delegation constraints. This prevents secure hierarchical agent architectures.
+
+4. **No Audit Trail**: Tool calls leave no cryptographic evidence of what was requested, what was returned, or who was responsible. This makes compliance, debugging, and incident response difficult.
+
+5. **Replay Attacks**: Without nonce-based session establishment, captured tool call payloads can be replayed by attackers.
+
+DIDs and Verifiable Credentials are the right fit for this problem:
+
+- **DIDs** provide decentralized, cryptographically-verifiable identifiers that agents control. They do not require a central authority and support multiple resolution methods (did:key for ephemeral, did:web for persistent organizational identity).
+
+- **Verifiable Credentials** provide a W3C standard for expressing cryptographically-signed claims. Delegation credentials can express scope constraints, temporal bounds, budget limits, and revocation status in an interoperable format.
+
+- **EdDSA/Ed25519** provides high-performance, deterministic signatures suitable for high-throughput agent interactions with no reliance on hash function collision resistance.
+
+---
+
+## 2. Terminology
+
+| Term | Definition |
+|------|------------|
+| **Agent DID** | A Decentralized Identifier (DID) that uniquely identifies an AI agent. MCP-I supports `did:key` (self-certifying, ephemeral) and `did:web` (organization-hosted, persistent). |
+| **Delegation Chain** | An ordered sequence of Delegation Credentials from a root delegator to the current agent, where each credential's subject is the next credential's issuer. |
+| **Delegation Credential** | A W3C Verifiable Credential that grants specific permissions from an issuer (delegator) to a subject (delegate). Contains CRISP constraints defining allowed operations. |
+| **Detached Proof** | A JWS (JSON Web Signature) that cryptographically binds a tool request and response together, enabling non-repudiation and audit. Attached to responses in the `_meta` field. |
+| **CRISP Constraints** | **C**onstraints, **R**esources, **I**dentity, **S**cope, **P**olicy — a structured envelope defining what operations a delegation permits: allowed scopes, budget caps, temporal bounds, and audience restrictions. |
+| **Session** | A validated, time-bounded context established via handshake. Sessions prevent replay attacks and provide a stable context for proof generation. |
+| **Handshake Nonce** | A cryptographically random value provided by the client during session establishment. Used once; prevents replay attacks. |
+| **Audience** | The intended recipient of a credential or proof, typically the MCP server's DID or domain. Prevents credential/proof misuse across different servers. |
+
+---
+
+## 3. Protocol Overview
+
+The following diagram illustrates the MCP-I protocol flow:
+
+```
+┌─────────────────┐                              ┌─────────────────┐
+│  Client Agent   │                              │   MCP Server    │
+│  (did:key:z...) │                              │ (did:web:srv)   │
+└────────┬────────┘                              └────────┬────────┘
+         │                                                │
+         │  ┌──────────────────────────────────────────┐  │
+         │  │ 1. HANDSHAKE REQUEST                     │  │
+         │  │    - nonce: <22-char base64url>          │  │
+         │  │    - audience: "did:web:srv"             │  │
+         │  │    - timestamp: <unix epoch seconds>     │  │
+         │  │    - agentDid: "did:key:z6Mk..."         │  │
+         ├──┴──────────────────────────────────────────┴──►
+         │                                                │
+         │         ┌─ Validate:                           │
+         │         │  • timestamp within ±120s            │
+         │         │  • nonce not seen before             │
+         │         │  • audience matches server DID       │
+         │         └──────────────────────────────────────┤
+         │                                                │
+         │  ┌──────────────────────────────────────────┐  │
+         │  │ 2. HANDSHAKE RESPONSE                    │  │
+         │  │    - sessionId: "mcpi_<uuid>"            │  │
+         │  │    - serverDid: "did:web:srv"            │  │
+         │  │    - ttlMinutes: 30                      │  │
+         ◄──┴──────────────────────────────────────────┴──┤
+         │                                                │
+         │  ┌──────────────────────────────────────────┐  │
+         │  │ 3. TOOL CALL REQUEST                     │  │
+         │  │    method: "tools/call"                  │  │
+         │  │    params:                               │  │
+         │  │      name: "read_file"                   │  │
+         │  │      arguments: { path: "/etc/hosts" }   │  │
+         │  │      sessionId: "mcpi_..."               │  │
+         │  │      delegation: <DelegationCredential>  │◄── Optional
+         ├──┴──────────────────────────────────────────┴──►
+         │                                                │
+         │         ┌─ Process:                            │
+         │         │  • Validate session                  │
+         │         │  • Verify delegation (if present)    │
+         │         │  • Execute tool                      │
+         │         │  • Generate detached proof           │
+         │         └──────────────────────────────────────┤
+         │                                                │
+         │  ┌──────────────────────────────────────────┐  │
+         │  │ 4. TOOL CALL RESPONSE                    │  │
+         │  │    content: [ { type: "text", ... } ]    │  │
+         │  │    _meta:                                │  │
+         │  │      proof:                              │  │
+         │  │        jws: "eyJhbGciOiJFZERTQSI..."     │  │
+         │  │        meta:                             │  │
+         │  │          did: "did:web:srv"              │  │
+         │  │          kid: "did:web:srv#key-1"        │  │
+         │  │          ts: 1710288000                  │  │
+         │  │          nonce: "..."                    │  │
+         │  │          requestHash: "sha256:..."       │  │
+         │  │          responseHash: "sha256:..."      │  │
+         ◄──┴──────────────────────────────────────────┴──┤
+         │                                                │
+         ▼                                                ▼
+```
+
+---
+
+## 4. Agent Identity
+
+### 4.1 Supported DID Methods
+
+MCP-I implementations MUST support:
+
+| Method | Use Case | Resolution |
+|--------|----------|------------|
+| `did:key` | Ephemeral agents, development, testing | Local derivation from public key bytes |
+| `did:web` | Production servers, organizational identity | HTTPS fetch of `/.well-known/did.json` or path-based document |
+
+Implementations MAY support additional DID methods.
+
+### 4.2 Key Material
+
+MCP-I uses Ed25519 (EdDSA over Curve25519) for all cryptographic operations:
+
+- **Key Size**: 32-byte private seed, 32-byte public key
+- **Signature Size**: 64 bytes
+- **Algorithm Identifier**: `EdDSA` (in JWS headers)
+- **JWK Key Type**: `OKP` (Octet Key Pair)
+- **JWK Curve**: `Ed25519`
+
+### 4.3 did:key Derivation
+
+A `did:key` DID is derived from an Ed25519 public key as follows:
+
+1. Prepend the Ed25519 multicodec prefix `0xed01` to the 32-byte public key
+2. Encode the result using base58btc
+3. Prepend the multibase prefix `z`
+4. Construct the DID: `did:key:z<base58btc-encoded-bytes>`
+
+Example:
+```
+Public Key (hex): 8076ee2cfc1a...32 bytes...
+Multicodec:       ed01 + 8076ee2cfc1a...
+Base58btc:        6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK
+DID:              did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK
+```
+
+The verification method ID is `<did>#keys-1`.
+
+### 4.4 did:web Resolution
+
+A `did:web` DID resolves to a DID Document via HTTPS:
+
+| DID | Resolution URL |
+|-----|---------------|
+| `did:web:example.com` | `https://example.com/.well-known/did.json` |
+| `did:web:example.com:agents:bot1` | `https://example.com/agents/bot1/did.json` |
+
+The DID Document MUST contain at least one verification method with `publicKeyJwk` in Ed25519 format:
+
+```json
+{
+  "id": "did:web:example.com",
+  "verificationMethod": [{
+    "id": "did:web:example.com#key-1",
+    "type": "Ed25519VerificationKey2020",
+    "controller": "did:web:example.com",
+    "publicKeyJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "<base64url-encoded-32-byte-public-key>"
+    }
+  }],
+  "authentication": ["did:web:example.com#key-1"],
+  "assertionMethod": ["did:web:example.com#key-1"]
+}
+```
+
+---
+
+## 5. Session Lifecycle
+
+### 5.1 Handshake Request
+
+To establish a session, the client sends a handshake request:
+
+```typescript
+interface HandshakeRequest {
+  nonce: string;      // 16 bytes, base64url-encoded (22 chars, no padding)
+  audience: string;   // Server DID or domain
+  timestamp: number;  // Unix epoch seconds
+  agentDid?: string;  // Client's DID (optional for anonymous sessions)
+  clientInfo?: {      // Optional client metadata
+    name: string;
+    version?: string;
+    platform?: string;
+  };
+}
+```
+
+### 5.2 Validation Rules
+
+The server MUST validate the handshake request:
+
+1. **Timestamp Skew**: `|server_time - request.timestamp| <= 120 seconds`
+   - Reject if outside this window
+   - Remediation: "Check NTP sync on client and server"
+
+2. **Nonce Uniqueness**: The (nonce, agentDid) pair MUST NOT have been seen before
+   - Reject with "Nonce already used (replay attack prevention)"
+   - Nonces MUST be cached for at least `sessionTtlMinutes + 1 minute`
+
+3. **Audience Match**: `request.audience` MUST match the server's DID or expected domain
+   - Prevents credential forwarding attacks
+
+### 5.3 Session Creation
+
+On successful validation, the server creates a session:
+
+```typescript
+interface SessionContext {
+  sessionId: string;         // Format: "mcpi_<uuid-v4>"
+  audience: string;          // Echoed from request
+  nonce: string;             // Echoed from request
+  timestamp: number;         // Request timestamp
+  createdAt: number;         // Server timestamp at creation
+  lastActivity: number;      // Updated on each request
+  ttlMinutes: number;        // Default: 30
+  agentDid?: string;         // Client DID if provided
+  serverDid?: string;        // Server's DID
+  identityState: 'anonymous' | 'authenticated';
+}
+```
+
+### 5.4 Session TTL and Expiry
+
+- **Idle Timeout**: Sessions expire after `ttlMinutes` of inactivity
+- **Absolute Lifetime**: Implementations MAY enforce a maximum session lifetime
+- **Activity Update**: `lastActivity` is updated on each valid request
+
+### 5.5 Replay Prevention
+
+The nonce cache implementation MUST:
+- Store (nonce, agentDid, expiry) tuples
+- Support TTL-based automatic expiry
+- Be atomic to prevent race conditions in concurrent environments
+- For distributed deployments: use Redis, DynamoDB, or Cloudflare KV (not in-memory)
+
+---
+
+## 6. Delegation
+
+### 6.1 DelegationRecord Structure
+
+Internal representation of a delegation:
+
+```typescript
+interface DelegationRecord {
+  id: string;                    // Unique delegation identifier
+  issuerDid: string;             // DID of the delegator
+  subjectDid: string;            // DID of the delegate
+  controller?: string;           // DID that can revoke this delegation
+  vcId: string;                  // URN of the Verifiable Credential
+  parentId?: string;             // Parent delegation ID (for chains)
+  constraints: DelegationConstraints;
+  signature: string;             // Extracted from VC proof
+  status: 'active' | 'revoked' | 'expired';
+  createdAt?: number;
+  revokedAt?: number;
+  revokedReason?: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+### 6.2 DelegationCredential as W3C VC
+
+Delegations are issued as W3C Verifiable Credentials:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation.v1.0.0.json"
+  ],
+  "id": "urn:uuid:d7f8a9b0-1234-5678-9abc-def012345678",
+  "type": ["VerifiableCredential", "DelegationCredential"],
+  "issuer": "did:key:z6MkIssuer...",
+  "issuanceDate": "2024-03-01T12:00:00Z",
+  "expirationDate": "2024-03-02T12:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkDelegate...",
+    "delegation": {
+      "id": "del-001",
+      "issuerDid": "did:key:z6MkIssuer...",
+      "subjectDid": "did:key:z6MkDelegate...",
+      "constraints": {
+        "scopes": ["tool:read_file", "tool:list_directory"],
+        "notBefore": 1709294400,
+        "notAfter": 1709380800,
+        "audience": "did:web:mcp-server.example.com"
+      },
+      "status": "active"
+    }
+  },
+  "credentialStatus": {
+    "id": "https://example.com/status/1#42",
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "42",
+    "statusListCredential": "https://example.com/status/1"
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2024-03-01T12:00:00Z",
+    "verificationMethod": "did:key:z6MkIssuer...#keys-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "<base64url-encoded-signature>"
+  }
+}
+```
+
+### 6.3 CRISP Constraint Envelope
+
+```typescript
+interface DelegationConstraints {
+  // Temporal bounds (Unix epoch seconds)
+  notBefore?: number;
+  notAfter?: number;
+
+  // Simple scope list (tool names, resource patterns)
+  scopes?: string[];
+
+  // Audience restriction (server DID or domain)
+  audience?: string | string[];
+
+  // Extended CRISP constraints
+  crisp?: {
+    budget?: {
+      unit: 'USD' | 'ops' | 'points';
+      cap: number;
+      window?: {
+        kind: 'rolling' | 'fixed';
+        durationSec: number;
+      };
+    };
+    scopes: Array<{
+      resource: string;
+      matcher: 'exact' | 'prefix' | 'regex';
+      constraints?: Record<string, unknown>;
+    }>;
+  };
+}
+```
+
+### 6.4 Delegation Graph
+
+Delegations form a directed acyclic graph (DAG):
+
+```
+     [Root: User → Agent A]
+            │
+     ┌──────┴──────┐
+     ▼             ▼
+[A → B]        [A → C]
+     │
+     ▼
+[B → D]
+```
+
+- Each node is a `DelegationCredential`
+- `parentId` links to the parent delegation
+- Child delegation's `issuerDid` MUST equal parent's `subjectDid`
+- Scope constraints MUST be equal to or narrower than parent's constraints
+
+### 6.5 Cascading Revocation
+
+When a delegation is revoked:
+
+1. Mark the delegation as `revoked` in the delegation graph
+2. Recursively mark all descendant delegations as `revoked`
+3. Update StatusList2021 credential for each revoked delegation
+4. Emit revocation events for audit logging
+
+### 6.6 StatusList2021 Revocation
+
+MCP-I uses the W3C StatusList2021 specification for revocation:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/vc/status-list/2021/v1"
+  ],
+  "id": "https://example.com/status/1",
+  "type": ["VerifiableCredential", "StatusList2021Credential"],
+  "issuer": "did:web:example.com",
+  "issuanceDate": "2024-03-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "https://example.com/status/1#list",
+    "type": "StatusList2021",
+    "statusPurpose": "revocation",
+    "encodedList": "<gzip-compressed-base64-bitstring>"
+  }
+}
+```
+
+- Each delegation is assigned a `statusListIndex` (0 to 131071)
+- Bit at index is 0 = valid, 1 = revoked
+- Bitstring is gzip-compressed and base64-encoded
+
+---
+
+## 7. Proof Generation
+
+### 7.1 Purpose
+
+Detached proofs provide:
+
+- **Non-repudiation**: Cryptographic evidence that the server processed the request
+- **Integrity**: Hashes bind the exact request and response together
+- **Audit Trail**: Proofs can be stored and verified offline
+
+### 7.2 ProofMeta Fields
+
+```typescript
+interface ProofMeta {
+  did: string;          // Server's DID (signer)
+  kid: string;          // Key ID used for signing
+  ts: number;           // Unix epoch seconds when proof was generated
+  nonce: string;        // Session nonce (prevents cross-session replay)
+  audience: string;     // Session audience
+  sessionId: string;    // Session identifier
+  requestHash: string;  // SHA-256 of canonicalized request
+  responseHash: string; // SHA-256 of canonicalized response
+  scopeId?: string;     // Scope under which the call was made
+  delegationRef?: string; // Reference to delegation credential
+  clientDid?: string;   // Client's DID if authenticated
+}
+```
+
+### 7.3 Hash Generation
+
+1. **Canonicalize**: Convert request/response to RFC 8785 (JCS) canonical JSON
+2. **Hash**: Compute SHA-256 of the canonical JSON bytes (UTF-8 encoded)
+3. **Format**: `sha256:<64-char-lowercase-hex>`
+
+Request canonicalization includes:
+```json
+{
+  "method": "tools/call",
+  "params": { /* sorted keys, no whitespace */ }
+}
+```
+
+Response canonicalization is the `data` field only (excludes `_meta`).
+
+### 7.4 JWS Compact Serialization
+
+The proof JWS is generated as:
+
+```
+BASE64URL(header) . BASE64URL(payload) . BASE64URL(signature)
+```
+
+**Header**:
+```json
+{
+  "alg": "EdDSA",
+  "kid": "did:web:server.example.com#key-1"
+}
+```
+
+**Payload** (canonicalized):
+```json
+{
+  "aud": "did:web:server.example.com",
+  "iss": "did:web:server.example.com",
+  "nonce": "...",
+  "requestHash": "sha256:...",
+  "responseHash": "sha256:...",
+  "sessionId": "mcpi_...",
+  "sub": "did:web:server.example.com",
+  "ts": 1710288000
+}
+```
+
+### 7.5 _meta Attachment
+
+The proof is attached to tool responses in the `_meta` field:
+
+```json
+{
+  "content": [{ "type": "text", "text": "File contents..." }],
+  "_meta": {
+    "proof": {
+      "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6Ii4uLiJ9.eyJhdWQiOi4uLn0.c2ln...",
+      "meta": {
+        "did": "did:web:server.example.com",
+        "kid": "did:web:server.example.com#key-1",
+        "ts": 1710288000,
+        "nonce": "abc123...",
+        "audience": "did:web:server.example.com",
+        "sessionId": "mcpi_d7f8a9b0-...",
+        "requestHash": "sha256:a1b2c3...",
+        "responseHash": "sha256:d4e5f6..."
+      }
+    }
+  }
+}
+```
+
+---
+
+## 8. Outbound Delegation Propagation
+
+When an MCP server calls downstream services (APIs, other MCP servers), it MUST forward delegation context.
+
+### 8.1 HTTP Headers
+
+| Header | Value |
+|--------|-------|
+| `X-Agent-DID` | Original agent's DID |
+| `X-Delegation-Chain` | Comma-separated list of delegation IDs from root to current |
+| `X-Session-ID` | MCP-I session ID |
+| `X-Delegation-Proof` | Signed JWT proving delegation authority |
+| `X-Scopes` | Comma-separated list of granted scopes |
+
+### 8.2 Delegation Proof JWT
+
+```typescript
+interface DelegationProofJWT {
+  // Standard JWT claims
+  iss: string;   // Server DID (JWT issuer)
+  sub: string;   // User DID (on whose behalf)
+  aud: string;   // Target service hostname
+  iat: number;   // Issued at (Unix epoch)
+  exp: number;   // Expires at (iat + 60 seconds)
+  jti: string;   // Unique JWT ID (UUID)
+
+  // MCP-I claims
+  delegation_id: string;    // Current delegation ID
+  delegation_chain: string; // Chain path (vcId>delegationId)
+  scope: string;            // Comma-separated scopes
+}
+```
+
+The JWT is signed with EdDSA using the server's private key.
+
+### 8.3 Chain String Format
+
+```
+<vcId>><delegationId>
+```
+
+Example: `urn:uuid:d7f8a9b0-1234-5678-9abc-def012345678>del-001`
+
+---
+
+## 9. Authorization Flow
+
+### 9.1 verifyOrHints Pattern
+
+When a tool call requires authorization:
+
+1. Server checks for valid delegation in the request
+2. If delegation is valid and covers required scopes: proceed
+3. If delegation is missing or insufficient: return `needs_authorization` error
+
+### 9.2 needs_authorization Error Structure
+
+```typescript
+interface NeedsAuthorizationError {
+  error: 'needs_authorization';
+  message: string;
+  authorizationUrl: string;  // URL where user can grant authorization
+  resumeToken: string;       // Token to resume flow after authorization
+  expiresAt: number;         // Unix epoch when resumeToken expires
+  scopes: string[];          // Scopes being requested
+  display?: {
+    title?: string;
+    hint?: Array<'link' | 'qr' | 'code'>;
+    authorizationCode?: string;
+    qrUrl?: string;
+  };
+}
+```
+
+### 9.3 Resume Flow
+
+1. Client receives `needs_authorization` error
+2. Client directs user to `authorizationUrl`
+3. User authenticates and grants authorization
+4. Authorization service issues DelegationCredential
+5. Client retries request with `resumeToken` and new delegation
+6. Server validates delegation and processes request
+
+---
+
+## 10. Well-Known Endpoint
+
+MCP-I servers SHOULD expose `/.well-known/mcpi`:
+
+```json
+{
+  "did": "did:web:mcp-server.example.com",
+  "version": "1.0.0",
+  "capabilities": {
+    "delegation": true,
+    "proof": true,
+    "revocation": true
+  },
+  "supported_did_methods": ["did:key", "did:web"],
+  "proof_algorithms": ["EdDSA"],
+  "endpoints": {
+    "handshake": "/_mcpi/handshake",
+    "status_list": "/.well-known/status/1"
+  }
+}
+```
+
+---
+
+## 11. Security Considerations
+
+### 11.1 Nonce Replay Attacks
+
+- Nonces MUST be cryptographically random (16 bytes minimum entropy)
+- Nonce cache MUST persist across server restarts (use external storage)
+- Nonce cache TTL MUST exceed session TTL
+- Distributed deployments MUST use atomic check-and-set operations
+
+### 11.2 Timestamp Skew Attacks
+
+- Default skew tolerance is 120 seconds
+- Servers MAY reduce this for high-security deployments
+- Servers SHOULD use NTP for time synchronization
+- Timestamps in proofs allow detection of delayed replay attempts
+
+### 11.3 Delegation Scope Escalation
+
+- Child delegations MUST NOT exceed parent scope
+- Servers MUST validate entire delegation chain, not just leaf
+- Scope comparison MUST be performed at each chain link
+- Use CRISP `matcher: 'exact'` for sensitive resources
+
+### 11.4 Key Rotation
+
+- did:key: Generate new DID (no rotation mechanism)
+- did:web: Update `did.json` with new verification method
+- Old keys SHOULD remain in `did.json` for proof verification
+- Delegation credentials reference specific key IDs; reissue after rotation
+
+### 11.5 Revocation Freshness
+
+- StatusList2021 credentials have cache-control considerations
+- Servers SHOULD set appropriate `Cache-Control` headers
+- High-security deployments MAY require real-time revocation checks
+- Cascading revocation MUST be atomic
+
+---
+
+## 12. Conformance
+
+Implementation conformance requirements are defined in `CONFORMANCE.md`. Three compliance levels are specified:
+
+- **Level 1 — Core Crypto**: Basic key generation, signing, verification, and well-known endpoint
+- **Level 2 — Full Session**: Session handshake, nonce replay prevention, proof generation
+- **Level 3 — Full Delegation**: VC issuance/verification, delegation graphs, revocation, outbound propagation
+
+See `CONFORMANCE.md` for detailed requirements and test references.
+
+---
+
+## 13. References
+
+### Normative References
+
+- **[DID-CORE]** W3C. *Decentralized Identifiers (DIDs) v1.0*. https://www.w3.org/TR/did-core/
+- **[VC-DATA-MODEL]** W3C. *Verifiable Credentials Data Model v1.1*. https://www.w3.org/TR/vc-data-model/
+- **[DID-KEY]** W3C CCG. *did:key Method Specification*. https://w3c-ccg.github.io/did-method-key/
+- **[DID-WEB]** W3C CCG. *did:web Method Specification*. https://w3c-ccg.github.io/did-method-web/
+- **[STATUS-LIST-2021]** W3C CCG. *Status List 2021*. https://w3c-ccg.github.io/vc-status-list-2021/
+- **[RFC8037]** IETF. *CFRG Elliptic Curve Diffie-Hellman (ECDH) and Signatures in JOSE*. https://datatracker.ietf.org/doc/html/rfc8037
+- **[RFC7517]** IETF. *JSON Web Key (JWK)*. https://datatracker.ietf.org/doc/html/rfc7517
+- **[RFC7515]** IETF. *JSON Web Signature (JWS)*. https://datatracker.ietf.org/doc/html/rfc7515
+- **[RFC8785]** IETF. *JSON Canonicalization Scheme (JCS)*. https://datatracker.ietf.org/doc/html/rfc8785
+
+### Informative References
+
+- **[MCP]** Anthropic. *Model Context Protocol Specification*. https://spec.modelcontextprotocol.io/
+- **[MULTICODEC]** Multiformats. *Multicodec Table*. https://github.com/multiformats/multicodec
+- **[MULTIBASE]** Multiformats. *Multibase Specification*. https://github.com/multiformats/multibase
+
+---
+
+## Appendix A: Error Codes
+
+| Code | Description |
+|------|-------------|
+| `XMCP_I_EHANDSHAKE` | Handshake validation failed (timestamp, nonce, or audience) |
+| `XMCP_I_ESESSION` | Session not found or expired |
+| `XMCP_I_EDELEGATION` | Delegation verification failed |
+| `XMCP_I_ESCOPE` | Requested operation outside delegated scope |
+| `XMCP_I_EREVOKED` | Delegation has been revoked |
+| `XMCP_I_EPROOF` | Proof verification failed |
+| `XMCP_I_EDID` | DID resolution failed |
+
+---
+
+## Appendix B: Base58btc Alphabet
+
+```
+123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
+```
+
+Note: Excludes `0`, `O`, `I`, `l` to avoid visual ambiguity.
+
+---
+
+*End of Specification*

--- a/examples/node-server/issue-delegation.ts
+++ b/examples/node-server/issue-delegation.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env npx tsx
+/**
+ * Run this to get a delegation VC you can pass to restricted_greet.
+ *
+ * Usage:
+ *   npx tsx examples/node-server/issue-delegation.ts
+ *
+ * Then copy the printed JSON and pass it as `_mcpi_delegation` when calling
+ * restricted_greet via MCP Inspector.
+ */
+
+import { NodeCryptoProvider } from './node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../src/utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../../src/delegation/vc-issuer.js';
+import type { Proof } from '../../src/types/protocol.js';
+import { base64urlEncodeFromBytes } from '../../src/utils/base64.js';
+
+async function main() {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  // Use #keys-1 to match the did-key-resolver verification method ID
+  const kid = `${did}#keys-1`;
+
+  process.stderr.write(`[issue-delegation] Issuer DID: ${did}\n`);
+
+  const signingFunction = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kidArg: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, keyPair.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kidArg,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => did,
+      getKeyId: () => kid,
+      getPrivateKey: () => keyPair.privateKey,
+    },
+    signingFunction,
+  );
+
+  const delegationId = `delegation-${Date.now()}`;
+  const vc = await issuer.createAndIssueDelegation(
+    {
+      id: delegationId,
+      issuerDid: did,
+      subjectDid: did,
+      constraints: {
+        scopes: ['greeting:restricted'],
+        notAfter: Math.floor(Date.now() / 1000) + 3600, // valid for 1 hour
+      },
+    },
+  );
+
+  process.stdout.write(JSON.stringify(vc, null, 2) + '\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -4,15 +4,19 @@
  *
  * Demonstrates the MCP-I protocol:
  *   1. greet           — open tool with signed proof (via _meta)
- *   2. restricted_greet — protected tool requiring delegation
+ *   2. restricted_greet — protected tool requiring a W3C Delegation Credential
  *
  * Sessions are created automatically — no manual handshake needed.
  * In production, MCP-I-aware clients handle the handshake transparently.
  *
- * Start server:
- *   npx tsx examples/node-server/server.ts
- *
- * Then connect MCP Inspector (SSE) to http://localhost:3001/sse
+ * Full demo flow:
+ *   1. Start server:
+ *        npx tsx examples/node-server/server.ts
+ *   2. Issue a delegation VC:
+ *        npx tsx examples/node-server/issue-delegation.ts > delegation.json
+ *   3. Connect MCP Inspector to http://localhost:3001/sse
+ *   4. Call `restricted_greet` with `_mcpi_delegation` = contents of delegation.json
+ *   5. Watch it verify the VC and return the greeting with a signed proof
  */
 
 import http from 'node:http';
@@ -27,16 +31,6 @@ import { createMCPIMiddleware } from '../../src/middleware/with-mcpi.js';
 import { generateDidKeyFromBase64 } from '../../src/utils/did-helpers.js';
 import { NodeCryptoProvider } from './node-crypto.js';
 
-// ── Tool protection config ─────────────────────────────────────────
-// In production this comes from AgentShield remote config.
-// Here we hard-code it to demonstrate the architecture.
-const TOOL_PROTECTION: Record<string, { scopeId: string; consentUrl: string }> = {
-  restricted_greet: {
-    scopeId: 'greeting:restricted',
-    consentUrl: 'https://example.com/consent?scope=greeting:restricted',
-  },
-};
-
 function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
   const server = new Server(
     { name: 'mcpi-example', version: '1.0.0' },
@@ -48,6 +42,18 @@ function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
   const greetHandler = mcpi.wrapWithProof('greet', async (args) => ({
     content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}!` }],
   }));
+
+  // restricted_greet: verify delegation VC, then attach proof on success
+  const restrictedGreetHandler = mcpi.wrapWithDelegation(
+    'restricted_greet',
+    {
+      scopeId: 'greeting:restricted',
+      consentUrl: 'https://example.com/consent?scope=greeting:restricted',
+    },
+    mcpi.wrapWithProof('restricted_greet', async (args) => ({
+      content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}! (delegation verified)` }],
+    })),
+  );
 
   // ── Request handlers ────────────────────────────────────────────
 
@@ -70,6 +76,10 @@ function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
           type: 'object' as const,
           properties: {
             name: { type: 'string', description: 'Name to greet' },
+            _mcpi_delegation: {
+              type: 'object',
+              description: 'W3C Delegation Credential granting scope greeting:restricted',
+            },
           },
         },
       },
@@ -84,26 +94,14 @@ function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
       return mcpi.handleHandshake(args as Record<string, unknown>);
     }
 
-    // ── Tool protection check ───────────────────────────────────
-    const protection = TOOL_PROTECTION[name];
-    if (protection) {
-      // In production, MCP-I checks the delegation chain via the verifier.
-      // Without a valid delegation credential, the server returns a consent
-      // URL that the agent can present to the user for authorization.
-      const consentLink = `[Authorize ${name}](${protection.consentUrl})`;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Authorization required.\n\n${consentLink}\n\nRetry after authorizing.`,
-          },
-        ],
-      };
-    }
-
     // ── Open tools ──────────────────────────────────────────────
     if (name === 'greet') {
       return greetHandler(args as Record<string, unknown>);
+    }
+
+    // ── Protected tools (delegation required) ───────────────────
+    if (name === 'restricted_greet') {
+      return restrictedGreetHandler(args as Record<string, unknown>);
     }
 
     return {

--- a/src/delegation/__tests__/did-web-resolver.test.ts
+++ b/src/delegation/__tests__/did-web-resolver.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  DidWebResolver,
+  createDidWebResolver,
+  isDidWeb,
+  parseDidWeb,
+  didWebToUrl,
+} from '../did-web-resolver.js';
+import type { FetchProvider } from '../../providers/base.js';
+import type { DIDDocument } from '../vc-verifier.js';
+
+/**
+ * Tests for did:web resolver
+ *
+ * These tests verify the did:web resolution functionality:
+ * - URL construction for root domain DIDs
+ * - URL construction for path-based DIDs
+ * - Successful resolution with mocked fetch
+ * - Null return on 404
+ * - Null return on invalid JSON
+ * - Null return on missing `id` field in response
+ */
+
+describe('did:web URL Construction', () => {
+  describe('isDidWeb', () => {
+    it('should return true for did:web DIDs', () => {
+      expect(isDidWeb('did:web:example.com')).toBe(true);
+      expect(isDidWeb('did:web:example.com:path')).toBe(true);
+      expect(isDidWeb('did:web:sub.example.com')).toBe(true);
+    });
+
+    it('should return false for non-did:web DIDs', () => {
+      expect(isDidWeb('did:key:z6Mk...')).toBe(false);
+      expect(isDidWeb('did:example:123')).toBe(false);
+      expect(isDidWeb('not-a-did')).toBe(false);
+      expect(isDidWeb('')).toBe(false);
+    });
+  });
+
+  describe('parseDidWeb', () => {
+    it('should parse root domain DID', () => {
+      const result = parseDidWeb('did:web:example.com');
+      expect(result).not.toBeNull();
+      expect(result?.domain).toBe('example.com');
+      expect(result?.path).toEqual([]);
+    });
+
+    it('should parse path-based DID', () => {
+      const result = parseDidWeb('did:web:example.com:path:to:doc');
+      expect(result).not.toBeNull();
+      expect(result?.domain).toBe('example.com');
+      expect(result?.path).toEqual(['path', 'to', 'doc']);
+    });
+
+    it('should handle URL-encoded components', () => {
+      // %3A is URL-encoded colon, which would be used for port numbers
+      const result = parseDidWeb('did:web:example.com%3A8080');
+      expect(result).not.toBeNull();
+      expect(result?.domain).toBe('example.com:8080');
+      expect(result?.path).toEqual([]);
+    });
+
+    it('should return null for invalid DIDs', () => {
+      expect(parseDidWeb('did:key:z6Mk...')).toBeNull();
+      expect(parseDidWeb('did:web:')).toBeNull();
+      expect(parseDidWeb('')).toBeNull();
+    });
+  });
+
+  describe('didWebToUrl', () => {
+    it('should convert root domain DID to .well-known URL', () => {
+      const url = didWebToUrl('did:web:example.com');
+      expect(url).toBe('https://example.com/.well-known/did.json');
+    });
+
+    it('should convert subdomain DID to .well-known URL', () => {
+      const url = didWebToUrl('did:web:agents.example.com');
+      expect(url).toBe('https://agents.example.com/.well-known/did.json');
+    });
+
+    it('should convert single path component DID to path URL', () => {
+      const url = didWebToUrl('did:web:example.com:user');
+      expect(url).toBe('https://example.com/user/did.json');
+    });
+
+    it('should convert multi-path DID to path URL', () => {
+      const url = didWebToUrl('did:web:example.com:path:to:doc');
+      expect(url).toBe('https://example.com/path/to/doc/did.json');
+    });
+
+    it('should handle agents path pattern', () => {
+      const url = didWebToUrl('did:web:example.com:agents:bot1');
+      expect(url).toBe('https://example.com/agents/bot1/did.json');
+    });
+
+    it('should handle URL-encoded port number', () => {
+      const url = didWebToUrl('did:web:example.com%3A8080');
+      expect(url).toBe('https://example.com:8080/.well-known/did.json');
+    });
+
+    it('should handle URL-encoded port number with path', () => {
+      const url = didWebToUrl('did:web:example.com%3A3000:users:alice');
+      expect(url).toBe('https://example.com:3000/users/alice/did.json');
+    });
+
+    it('should return null for invalid DIDs', () => {
+      expect(didWebToUrl('did:key:z6Mk...')).toBeNull();
+      expect(didWebToUrl('did:web:')).toBeNull();
+      expect(didWebToUrl('')).toBeNull();
+    });
+  });
+});
+
+describe('DidWebResolver', () => {
+  let mockFetchProvider: FetchProvider;
+  let resolver: DidWebResolver;
+
+  const validDIDDocument: DIDDocument = {
+    id: 'did:web:example.com',
+    verificationMethod: [
+      {
+        id: 'did:web:example.com#key-1',
+        type: 'Ed25519VerificationKey2020',
+        controller: 'did:web:example.com',
+        publicKeyJwk: {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: 'test-public-key-base64url',
+        },
+      },
+    ],
+    authentication: ['did:web:example.com#key-1'],
+    assertionMethod: ['did:web:example.com#key-1'],
+  };
+
+  const createMockFetchProvider = (
+    responseBody: unknown,
+    status = 200
+  ): FetchProvider => {
+    return {
+      resolveDID: vi.fn(),
+      fetchStatusList: vi.fn(),
+      fetchDelegationChain: vi.fn(),
+      fetch: vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        json: vi.fn().mockResolvedValue(responseBody),
+      }),
+    };
+  };
+
+  const createMockFetchProviderWithJsonError = (): FetchProvider => {
+    return {
+      resolveDID: vi.fn(),
+      fetchStatusList: vi.fn(),
+      fetchDelegationChain: vi.fn(),
+      fetch: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+      }),
+    };
+  };
+
+  const createMockFetchProviderWithNetworkError = (): FetchProvider => {
+    return {
+      resolveDID: vi.fn(),
+      fetchStatusList: vi.fn(),
+      fetchDelegationChain: vi.fn(),
+      fetch: vi.fn().mockRejectedValue(new Error('Network error')),
+    };
+  };
+
+  beforeEach(() => {
+    mockFetchProvider = createMockFetchProvider(validDIDDocument);
+    resolver = new DidWebResolver(mockFetchProvider, { cacheTtl: 1000 });
+  });
+
+  describe('successful resolution', () => {
+    it('should resolve did:web:example.com', async () => {
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('did:web:example.com');
+      expect(result?.verificationMethod).toHaveLength(1);
+      expect(result?.verificationMethod?.[0]?.type).toBe('Ed25519VerificationKey2020');
+      expect(mockFetchProvider.fetch).toHaveBeenCalledWith(
+        'https://example.com/.well-known/did.json'
+      );
+    });
+
+    it('should resolve path-based DID', async () => {
+      const pathDIDDocument: DIDDocument = {
+        ...validDIDDocument,
+        id: 'did:web:example.com:agents:bot1',
+        verificationMethod: [
+          {
+            ...validDIDDocument.verificationMethod![0]!,
+            id: 'did:web:example.com:agents:bot1#key-1',
+            controller: 'did:web:example.com:agents:bot1',
+          },
+        ],
+      };
+
+      mockFetchProvider = createMockFetchProvider(pathDIDDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com:agents:bot1');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('did:web:example.com:agents:bot1');
+      expect(mockFetchProvider.fetch).toHaveBeenCalledWith(
+        'https://example.com/agents/bot1/did.json'
+      );
+    });
+
+    it('should cache successful resolutions', async () => {
+      await resolver.resolve('did:web:example.com');
+      await resolver.resolve('did:web:example.com');
+
+      // Should only fetch once due to caching
+      expect(mockFetchProvider.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return cached result', async () => {
+      const result1 = await resolver.resolve('did:web:example.com');
+      const result2 = await resolver.resolve('did:web:example.com');
+
+      expect(result1).toEqual(result2);
+    });
+  });
+
+  describe('null return on 404', () => {
+    it('should return null for 404 response', async () => {
+      mockFetchProvider = createMockFetchProvider({}, 404);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for 500 response', async () => {
+      mockFetchProvider = createMockFetchProvider({}, 500);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('null return on invalid JSON', () => {
+    it('should return null when JSON parsing fails', async () => {
+      mockFetchProvider = createMockFetchProviderWithJsonError();
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('null return on missing id field', () => {
+    it('should return null when id field is missing', async () => {
+      const invalidDocument = {
+        verificationMethod: [],
+      };
+
+      mockFetchProvider = createMockFetchProvider(invalidDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when id field is empty string', async () => {
+      const invalidDocument = {
+        id: '',
+        verificationMethod: [],
+      };
+
+      mockFetchProvider = createMockFetchProvider(invalidDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when id does not match requested DID', async () => {
+      const mismatchedDocument: DIDDocument = {
+        ...validDIDDocument,
+        id: 'did:web:other.com',
+      };
+
+      mockFetchProvider = createMockFetchProvider(mismatchedDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('null return on network error', () => {
+    it('should return null when fetch throws', async () => {
+      mockFetchProvider = createMockFetchProviderWithNetworkError();
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('null return for non-did:web', () => {
+    it('should return null for did:key', async () => {
+      const result = await resolver.resolve(
+        'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      );
+
+      expect(result).toBeNull();
+      expect(mockFetchProvider.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return null for invalid DID format', async () => {
+      const result = await resolver.resolve('not-a-did');
+
+      expect(result).toBeNull();
+      expect(mockFetchProvider.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('invalid DID document structure', () => {
+    it('should return null when response is not an object', async () => {
+      mockFetchProvider = createMockFetchProvider('not an object');
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when response is null', async () => {
+      mockFetchProvider = createMockFetchProvider(null);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when verificationMethod is not an array', async () => {
+      const invalidDocument = {
+        id: 'did:web:example.com',
+        verificationMethod: 'not an array',
+      };
+
+      mockFetchProvider = createMockFetchProvider(invalidDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when verificationMethod entry is invalid', async () => {
+      const invalidDocument = {
+        id: 'did:web:example.com',
+        verificationMethod: [
+          {
+            // Missing required id field
+            type: 'Ed25519VerificationKey2020',
+            controller: 'did:web:example.com',
+          },
+        ],
+      };
+
+      mockFetchProvider = createMockFetchProvider(invalidDocument);
+      resolver = new DidWebResolver(mockFetchProvider);
+
+      const result = await resolver.resolve('did:web:example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('cache management', () => {
+    it('should clear all cache entries', async () => {
+      await resolver.resolve('did:web:example.com');
+
+      resolver.clearCache();
+
+      // Next call should fetch again
+      await resolver.resolve('did:web:example.com');
+
+      expect(mockFetchProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear specific cache entry', async () => {
+      await resolver.resolve('did:web:example.com');
+
+      resolver.clearCacheEntry('did:web:example.com');
+
+      // Next call should fetch again
+      await resolver.resolve('did:web:example.com');
+
+      expect(mockFetchProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should expire cached entries after TTL', async () => {
+      // Use very short TTL
+      resolver = new DidWebResolver(mockFetchProvider, { cacheTtl: 10 });
+
+      await resolver.resolve('did:web:example.com');
+
+      // Wait for cache to expire
+      await new Promise((resolve) => setTimeout(resolve, 15));
+
+      await resolver.resolve('did:web:example.com');
+
+      expect(mockFetchProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('createDidWebResolver', () => {
+  it('should create a resolver instance', () => {
+    const mockFetchProvider: FetchProvider = {
+      resolveDID: vi.fn(),
+      fetchStatusList: vi.fn(),
+      fetchDelegationChain: vi.fn(),
+      fetch: vi.fn(),
+    };
+
+    const resolver = createDidWebResolver(mockFetchProvider);
+
+    expect(resolver).toBeDefined();
+    expect(typeof resolver.resolve).toBe('function');
+  });
+
+  it('should pass options to resolver', async () => {
+    const validDIDDocument: DIDDocument = {
+      id: 'did:web:example.com',
+      verificationMethod: [],
+    };
+
+    const mockFetchProvider: FetchProvider = {
+      resolveDID: vi.fn(),
+      fetchStatusList: vi.fn(),
+      fetchDelegationChain: vi.fn(),
+      fetch: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(validDIDDocument),
+      }),
+    };
+
+    const resolver = createDidWebResolver(mockFetchProvider, { cacheTtl: 5000 });
+
+    const result = await resolver.resolve('did:web:example.com');
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/delegation/did-web-resolver.ts
+++ b/src/delegation/did-web-resolver.ts
@@ -1,0 +1,270 @@
+/**
+ * DID:web Resolver
+ *
+ * Resolves did:web DIDs by fetching /.well-known/did.json from the domain.
+ * Supports both root domain DIDs and path-based DIDs.
+ *
+ * Examples:
+ *   did:web:example.com → https://example.com/.well-known/did.json
+ *   did:web:example.com:agents:bot1 → https://example.com/agents/bot1/did.json
+ *
+ * @see https://w3c-ccg.github.io/did-method-web/
+ */
+
+import type { FetchProvider } from '../providers/base.js';
+import type { DIDResolver, DIDDocument, VerificationMethod } from './vc-verifier.js';
+import { logger } from '../logging/index.js';
+
+/**
+ * Parsed components of a did:web DID
+ */
+interface ParsedDidWeb {
+  domain: string;
+  path: string[];
+}
+
+/**
+ * Type guard for checking if value is a valid DID Document structure
+ */
+function isValidDIDDocument(value: unknown): value is DIDDocument {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const doc = value as Record<string, unknown>;
+
+  // id is required and must be a string
+  if (typeof doc['id'] !== 'string' || doc['id'].length === 0) {
+    return false;
+  }
+
+  // verificationMethod is optional but if present must be an array
+  if (doc['verificationMethod'] !== undefined) {
+    if (!Array.isArray(doc['verificationMethod'])) {
+      return false;
+    }
+
+    // Each verification method must have required fields
+    for (const vm of doc['verificationMethod']) {
+      if (!isValidVerificationMethod(vm)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Type guard for checking if value is a valid VerificationMethod
+ */
+function isValidVerificationMethod(value: unknown): value is VerificationMethod {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const vm = value as Record<string, unknown>;
+
+  // id, type, and controller are required strings
+  if (typeof vm['id'] !== 'string' || vm['id'].length === 0) {
+    return false;
+  }
+  if (typeof vm['type'] !== 'string' || vm['type'].length === 0) {
+    return false;
+  }
+  if (typeof vm['controller'] !== 'string' || vm['controller'].length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if a DID is a did:web DID
+ *
+ * @param did - The DID to check
+ * @returns true if it's a did:web DID
+ */
+export function isDidWeb(did: string): boolean {
+  return did.startsWith('did:web:');
+}
+
+/**
+ * Parse a did:web DID into its components
+ *
+ * @param did - The did:web DID to parse
+ * @returns Parsed components or null if invalid
+ */
+export function parseDidWeb(did: string): ParsedDidWeb | null {
+  if (!isDidWeb(did)) {
+    return null;
+  }
+
+  // Remove the 'did:web:' prefix
+  const remainder = did.slice(8);
+
+  if (remainder.length === 0) {
+    return null;
+  }
+
+  // Split by ':' to get domain and path components
+  const parts = remainder.split(':');
+
+  // First part is the domain (URL-decoded)
+  const domain = decodeURIComponent(parts[0]!);
+
+  if (domain.length === 0) {
+    return null;
+  }
+
+  // Remaining parts form the path
+  const path = parts.slice(1).map((p) => decodeURIComponent(p));
+
+  return { domain, path };
+}
+
+/**
+ * Convert a did:web DID to its resolution URL
+ *
+ * did:web:example.com → https://example.com/.well-known/did.json
+ * did:web:example.com:path:to:doc → https://example.com/path/to/doc/did.json
+ *
+ * @param did - The did:web DID
+ * @returns The resolution URL or null if invalid
+ */
+export function didWebToUrl(did: string): string | null {
+  const parsed = parseDidWeb(did);
+
+  if (!parsed) {
+    return null;
+  }
+
+  const { domain, path } = parsed;
+
+  // Build the URL
+  // Note: did:web specification requires HTTPS
+  let url = `https://${domain}`;
+
+  if (path.length === 0) {
+    // Root domain: use /.well-known/did.json
+    url += '/.well-known/did.json';
+  } else {
+    // Path-based: use /path/to/resource/did.json
+    url += '/' + path.join('/') + '/did.json';
+  }
+
+  return url;
+}
+
+/**
+ * DID:web resolver implementation
+ */
+export class DidWebResolver implements DIDResolver {
+  private fetchProvider: FetchProvider;
+  private cache: Map<string, { document: DIDDocument; expiresAt: number }>;
+  private cacheTtl: number;
+
+  constructor(fetchProvider: FetchProvider, options?: { cacheTtl?: number }) {
+    this.fetchProvider = fetchProvider;
+    this.cache = new Map();
+    this.cacheTtl = options?.cacheTtl ?? 300_000; // 5 minutes default
+  }
+
+  /**
+   * Resolve a did:web DID to its DID Document
+   *
+   * @param did - The did:web DID to resolve
+   * @returns The DID Document or null if resolution fails
+   */
+  async resolve(did: string): Promise<DIDDocument | null> {
+    // Check if it's a did:web
+    if (!isDidWeb(did)) {
+      return null;
+    }
+
+    // Check cache
+    const cached = this.cache.get(did);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.document;
+    }
+
+    // Convert to URL
+    const url = didWebToUrl(did);
+    if (!url) {
+      logger.warn(`[DidWebResolver] Invalid did:web format: ${did}`);
+      return null;
+    }
+
+    try {
+      // Fetch the DID document
+      const response = await this.fetchProvider.fetch(url);
+
+      if (!response.ok) {
+        logger.warn(`[DidWebResolver] HTTP ${response.status} fetching ${url}`);
+        return null;
+      }
+
+      // Parse JSON
+      let json: unknown;
+      try {
+        json = await response.json();
+      } catch {
+        logger.warn(`[DidWebResolver] Invalid JSON from ${url}`);
+        return null;
+      }
+
+      // Validate structure
+      if (!isValidDIDDocument(json)) {
+        logger.warn(`[DidWebResolver] Invalid DID Document structure from ${url}`);
+        return null;
+      }
+
+      // Verify the id matches the DID
+      if (json.id !== did) {
+        logger.warn(`[DidWebResolver] DID Document id mismatch: expected ${did}, got ${json.id}`);
+        return null;
+      }
+
+      // Cache the result
+      this.cache.set(did, {
+        document: json,
+        expiresAt: Date.now() + this.cacheTtl,
+      });
+
+      return json;
+    } catch (error) {
+      logger.warn(
+        `[DidWebResolver] Error resolving ${did}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Clear the resolution cache
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Clear a specific entry from the cache
+   */
+  clearCacheEntry(did: string): void {
+    this.cache.delete(did);
+  }
+}
+
+/**
+ * Create a did:web resolver with the given fetch provider
+ *
+ * @param fetchProvider - Provider for making HTTP requests
+ * @param options - Optional configuration
+ * @returns DIDResolver implementation for did:web
+ */
+export function createDidWebResolver(
+  fetchProvider: FetchProvider,
+  options?: { cacheTtl?: number }
+): DIDResolver {
+  return new DidWebResolver(fetchProvider, options);
+}

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -21,5 +21,12 @@ export {
   extractPublicKeyFromDidKey,
   publicKeyToJwk,
 } from './did-key-resolver.js';
+export {
+  DidWebResolver,
+  createDidWebResolver,
+  isDidWeb,
+  parseDidWeb,
+  didWebToUrl,
+} from './did-web-resolver.js';
 export { MemoryStatusListStorage } from './storage/memory-statuslist-storage.js';
 export { MemoryDelegationGraphStorage } from './storage/memory-graph-storage.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,14 @@ export {
   publicKeyToJwk,
 } from './delegation/did-key-resolver.js';
 
+export {
+  DidWebResolver,
+  createDidWebResolver,
+  isDidWeb,
+  parseDidWeb,
+  didWebToUrl,
+} from './delegation/did-web-resolver.js';
+
 // Utils
 export {
   base58Encode,

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { createMCPIMiddleware } from '../with-mcpi.js';
 import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
 import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import type { Proof } from '../../types/protocol.js';
+import { base64urlEncodeFromBytes } from '../../utils/base64.js';
 
 async function createTestMiddleware(options?: { autoSession?: boolean }) {
   const crypto = new NodeCryptoProvider();
@@ -111,6 +114,109 @@ describe('createMCPIMiddleware', () => {
       const result = await handler({});
       expect(result.content[0].text).toBe('Hello!');
       expect(result._meta).toBeUndefined();
+    });
+  });
+
+  describe('wrapWithDelegation', () => {
+    async function issueDelegationVC(scopes: string[]) {
+      const crypto = new NodeCryptoProvider();
+      const keyPair = await crypto.generateKeyPair();
+      const did = generateDidKeyFromBase64(keyPair.publicKey);
+      const kid = `${did}#keys-1`;
+
+      const signingFn = async (
+        canonicalVC: string,
+        _issuerDid: string,
+        kidArg: string,
+      ): Promise<Proof> => {
+        const data = new TextEncoder().encode(canonicalVC);
+        const sigBytes = await crypto.sign(data, keyPair.privateKey);
+        const proofValue = base64urlEncodeFromBytes(sigBytes);
+        return {
+          type: 'Ed25519Signature2020',
+          created: new Date().toISOString(),
+          verificationMethod: kidArg,
+          proofPurpose: 'assertionMethod',
+          proofValue,
+        };
+      };
+
+      const issuer = new DelegationCredentialIssuer(
+        {
+          getDid: () => did,
+          getKeyId: () => kid,
+          getPrivateKey: () => keyPair.privateKey,
+        },
+        signingFn,
+      );
+
+      return issuer.createAndIssueDelegation({
+        id: `test-delegation-${Date.now()}`,
+        issuerDid: did,
+        subjectDid: did,
+        constraints: {
+          scopes,
+          notAfter: Math.floor(Date.now() / 1000) + 3600,
+        },
+      });
+    }
+
+    it('should return needs_authorization when no _mcpi_delegation arg is provided', async () => {
+      const mcpi = await createTestMiddleware();
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ name: 'world' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('needs_authorization');
+      expect(parsed.authorizationUrl).toBe('https://example.com/consent');
+      expect(parsed.scopes).toContain('test:scope');
+      expect(typeof parsed.resumeToken).toBe('string');
+      expect(typeof parsed.expiresAt).toBe('number');
+    });
+
+    it('should reject when VC has wrong scope', async () => {
+      const mcpi = await createTestMiddleware();
+      const vc = await issueDelegationVC(['wrong:scope']);
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_scope_missing');
+    });
+
+    it('should accept and call handler when VC has correct scope and valid signature', async () => {
+      const mcpi = await createTestMiddleware();
+      const vc = await issueDelegationVC(['test:scope', 'other:scope']);
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async (args) => ({
+          content: [{ type: 'text', text: `Called: ${JSON.stringify(args)}` }],
+        }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc, name: 'DIF' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text.replace('Called: ', ''));
+      // _mcpi_delegation should be stripped from args
+      expect(parsed['_mcpi_delegation']).toBeUndefined();
+      expect(parsed['name']).toBe('DIF');
     });
   });
 

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -23,6 +23,18 @@ import {
   type ToolResponse,
 } from "../proof/generator.js";
 import { validateHandshakeFormat } from "../session/manager.js";
+import {
+  DelegationCredentialVerifier,
+  type SignatureVerificationFunction,
+} from "../delegation/vc-verifier.js";
+import { createDidKeyResolver } from "../delegation/did-key-resolver.js";
+import {
+  createNeedsAuthorizationError,
+  type DelegationCredential,
+} from "../types/protocol.js";
+import { logger } from "../logging/index.js";
+import { canonicalizeJSON } from "../delegation/utils.js";
+import { base64urlDecodeToBytes, bytesToBase64 } from "../utils/base64.js";
 
 export interface MCPIIdentityConfig {
   did: string;
@@ -105,6 +117,23 @@ export interface MCPIMiddleware {
    * Returns a new handler that appends proof metadata to the response.
    */
   wrapWithProof(toolName: string, handler: MCPIToolHandler): MCPIToolHandler;
+
+  /**
+   * Wrap a tool handler to require a valid W3C Delegation Credential.
+   *
+   * Caller must pass the VC as `_mcpi_delegation` in the tool args.
+   * - If absent: returns a `needs_authorization` response with the consentUrl.
+   * - If present but invalid: returns a structured error with reason.
+   * - If valid with correct scope: strips `_mcpi_delegation` and calls the handler.
+   */
+  wrapWithDelegation(
+    toolName: string,
+    config: {
+      scopeId: string;
+      consentUrl: string;
+    },
+    handler: MCPIToolHandler,
+  ): MCPIToolHandler;
 }
 
 /**
@@ -285,11 +314,156 @@ export function createMCPIMiddleware(
     };
   }
 
+  function wrapWithDelegation(
+    toolName: string,
+    config: { scopeId: string; consentUrl: string },
+    handler: MCPIToolHandler,
+  ): MCPIToolHandler {
+    const didResolver = createDidKeyResolver();
+
+    const signatureVerifier: SignatureVerificationFunction = async (
+      vc: DelegationCredential,
+      publicKeyJwk: unknown,
+    ): Promise<{ valid: boolean; reason?: string }> => {
+      const proof = vc.proof;
+      if (!proof) {
+        return { valid: false, reason: "Missing proof" };
+      }
+
+      const proofValue = proof["proofValue"] as string | undefined;
+      if (!proofValue) {
+        return { valid: false, reason: "Missing proofValue in proof" };
+      }
+
+      // Reconstruct the unsigned VC (without proof) for signature verification
+      const vcRecord = vc as Record<string, unknown>;
+      const vcWithoutProof: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(vcRecord)) {
+        if (k !== "proof") vcWithoutProof[k] = v;
+      }
+      const canonical = canonicalizeJSON(vcWithoutProof);
+      const data = new TextEncoder().encode(canonical);
+
+      // Decode signature from base64url proof value
+      const sigBytes = base64urlDecodeToBytes(proofValue);
+
+      // Get public key from JWK (x is base64url-encoded raw key bytes)
+      const jwk = publicKeyJwk as { x?: string };
+      if (!jwk.x) {
+        return { valid: false, reason: "No x field in publicKeyJwk" };
+      }
+
+      // Convert base64url key to standard base64 for the crypto provider
+      const pubKeyBytes = base64urlDecodeToBytes(jwk.x);
+      const pubKeyBase64 = bytesToBase64(pubKeyBytes);
+
+      const valid = await cryptoProvider.verify(data, sigBytes, pubKeyBase64);
+      return {
+        valid,
+        reason: valid ? undefined : "Signature verification failed",
+      };
+    };
+
+    const verifier = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier,
+    });
+
+    return async (
+      args: Record<string, unknown>,
+      sessionId?: string,
+    ) => {
+      const delegationArg = args["_mcpi_delegation"];
+
+      if (delegationArg === undefined || delegationArg === null) {
+        // No delegation provided — return needs_authorization response
+        const tokenBytes = await cryptoProvider.randomBytes(16);
+        const hex = Array.from(tokenBytes)
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        const resumeToken = [
+          hex.slice(0, 8),
+          hex.slice(8, 12),
+          hex.slice(12, 16),
+          hex.slice(16, 20),
+          hex.slice(20),
+        ].join("-");
+        const expiresAt = Math.floor(Date.now() / 1000) + 300;
+
+        const authError = createNeedsAuthorizationError({
+          message: `Tool "${toolName}" requires delegation with scope: ${config.scopeId}`,
+          authorizationUrl: config.consentUrl,
+          resumeToken,
+          expiresAt,
+          scopes: [config.scopeId],
+        });
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(authError) }],
+        };
+      }
+
+      // Verify the delegation VC
+      const vc = delegationArg as DelegationCredential;
+      const verificationResult = await verifier.verifyDelegationCredential(vc);
+
+      if (!verificationResult.valid) {
+        logger.warn(
+          `[mcpi] Delegation verification failed for "${toolName}": ${verificationResult.reason}`,
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "delegation_invalid",
+                reason: verificationResult.reason,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Check that required scope is present in credentialSubject.delegation.scopes
+      const scopes = vc.credentialSubject.delegation.scopes;
+      if (!scopes || !scopes.includes(config.scopeId)) {
+        logger.warn(
+          `[mcpi] Delegation missing required scope "${config.scopeId}" for "${toolName}"`,
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "delegation_scope_missing",
+                reason: `Required scope "${config.scopeId}" not in delegation scopes`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Strip _mcpi_delegation from args before passing to handler
+      const cleanArgs: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(args)) {
+        if (k !== "_mcpi_delegation") cleanArgs[k] = v;
+      }
+
+      logger.debug(
+        `[mcpi] Delegation verified for "${toolName}", scope "${config.scopeId}"`,
+      );
+      return handler(cleanArgs, sessionId);
+    };
+  }
+
   return {
     sessionManager,
     proofGenerator,
     handshakeTool,
     handleHandshake,
     wrapWithProof,
+    wrapWithDelegation,
   };
 }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -181,7 +181,7 @@ export function wrapDelegationAsVC(
     type: ['VerifiableCredential', 'DelegationCredential'],
     issuer: delegation.issuerDid,
     issuanceDate,
-    expirationDate,
+    ...(expirationDate !== undefined && { expirationDate }),
     credentialSubject: {
       id: delegation.subjectDid,
       delegation: {
@@ -192,15 +192,15 @@ export function wrapDelegationAsVC(
         ...(options?.userIdentifier && { userIdentifier: options.userIdentifier }),
         ...(options?.sessionId && { sessionId: options.sessionId }),
         ...(scopes && scopes.length > 0 && { scopes }),
-        controller: delegation.controller,
-        parentId: delegation.parentId,
+        ...(delegation.controller !== undefined && { controller: delegation.controller }),
+        ...(delegation.parentId !== undefined && { parentId: delegation.parentId }),
         constraints: delegation.constraints,
         status: delegation.status,
-        createdAt: delegation.createdAt,
-        metadata: delegation.metadata,
+        ...(delegation.createdAt !== undefined && { createdAt: delegation.createdAt }),
+        ...(delegation.metadata !== undefined && { metadata: delegation.metadata }),
       },
     },
-    credentialStatus: options?.credentialStatus,
+    ...(options?.credentialStatus !== undefined && { credentialStatus: options.credentialStatus }),
   };
 }
 


### PR DESCRIPTION
## Summary

This PR establishes the `@mcpi/core` package as a complete, standalone MCP-I protocol reference implementation for submission to the DIF Trust and Authorization for AI Agents Working Group (TAAWG).

## What's included

### Protocol specification
- `SPEC.md` — 743-line canonical protocol specification covering: motivation, terminology, session lifecycle, delegation, proof generation, outbound propagation, authorization flow, `/.well-known/mcpi`, and security considerations
- `CONFORMANCE.md` — Three compliance levels (Core Crypto / Full Session / Full Delegation) with explicit test citations for each requirement

### Implementation

**Delegation verification (example server)**
- `examples/node-server/server.ts` — `restricted_greet` now performs real end-to-end delegation VC verification using `DelegationCredentialVerifier`
- `examples/node-server/issue-delegation.ts` — standalone script to issue a real `DelegationCredential` for demo purposes
- `src/middleware/with-mcpi.ts` — added `wrapWithDelegation()` method to middleware

**did:web resolver**
- `src/delegation/did-web-resolver.ts` — resolves `did:web` DIDs per the W3C CCG spec, using the existing `FetchProvider` interface
- Supports both `did:web:example.com` → `/.well-known/did.json` and path-based variants
- Caching with configurable TTL, null-on-failure (no throws)

### Tests
575 passing tests across 25 test files. All new code has corresponding tests.

## Running locally

```bash
npm install
npm test                         # 575 tests
npx tsx examples/node-server/issue-delegation.ts  # issue a delegation VC
npx tsx examples/node-server/server.ts            # start example MCP-I server
```

## DIF TAAWG context

MCP-I adds cryptographic identity, W3C VC-based delegation chains, and non-repudiation proofs to the Model Context Protocol. This reference implementation is being submitted to DIF TAAWG as a candidate protocol standard. See `SPEC.md` §14 (Conformance) and `CONFORMANCE.md` for compliance requirements.

Editors: Dylan Hobbs
License: MIT
DCO: All commits signed off per Linux Foundation requirements