### PR TITLE
feat: final polish — security fixes, architecture, spec completion, JSON schemas

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -15,6 +15,12 @@ MCP-I (Model Context Protocol Identity) is a protocol extension for the Model Co
 
 ---
 
+## Conformance Keywords
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119].
+
+---
+
 ## Status
 
 **Draft** — Submitted to DIF TAAWG (Decentralized Identity Foundation, Trust and Authorization for AI Agents Working Group) for review. Not yet a standard.
@@ -682,7 +688,51 @@ MCP-I servers SHOULD expose `/.well-known/mcpi`:
 
 ---
 
-## 12. Conformance
+## 12. Privacy Considerations
+
+### 12.1 DID Correlation
+
+A persistent `did:key` or `did:web` identifier acts as a pseudonym. Using the same DID across multiple MCP servers enables cross-server activity correlation. Implementations SHOULD consider per-server DID rotation for privacy-sensitive deployments.
+
+### 12.2 Session Linkability
+
+Session IDs (`mcpi_*`) appear in detached proofs. Within a session, all tool calls are linkable. Implementations SHOULD use short session TTLs and avoid logging session IDs alongside PII.
+
+### 12.3 Delegation Chain Disclosure
+
+Outbound `X-Agent-DID` and `X-Delegation-Chain` headers reveal the agent's identity and delegation provenance to downstream services. Implementations SHOULD only propagate delegation headers to trusted downstream services.
+
+### 12.4 Proof Retention and Right to Erasure
+
+Detached proofs are audit records containing DIDs and session identifiers. Operators retaining proof logs SHOULD consider applicable data protection regulations (GDPR Art. 17, CCPA) and implement appropriate retention policies.
+
+---
+
+## 13. Protocol Versioning
+
+The current protocol version is `1.0.0`.
+
+Handshake requests SHOULD include `clientProtocolVersion: "1.0.0"`.
+Handshake responses MUST include `protocolVersion: "1.0.0"`.
+
+Servers MUST reject clients with an incompatible major version (e.g., a `2.x` server MUST reject a `1.x` client).
+Minor version differences SHOULD be handled gracefully — servers SHOULD implement backward compatibility within a major version.
+
+---
+
+## 14. Transport Binding
+
+MCP-I is transport-agnostic. The handshake and proofs use standard MCP mechanisms:
+
+**Handshake**: Implemented as an MCP tool named `_mcpi_handshake`. This is compatible with all MCP transports (stdio, SSE, HTTP Streamable) without modification.
+
+**Proof attachment**: Detached proofs are attached to tool responses in the standard MCP `_meta` field, which is transported transparently by all MCP transport implementations.
+
+**Outbound delegation headers**: When an MCP server makes outbound HTTP calls (not MCP calls), delegation context is propagated via HTTP headers as defined in §8. For MCP-to-MCP calls, delegation context SHOULD be passed via the `_mcpi_handshake` flow.
+
+---
+
+## 15. Conformance
 
 Implementation conformance requirements are defined in `CONFORMANCE.md`. Three compliance levels are specified:
 
@@ -694,10 +744,11 @@ See `CONFORMANCE.md` for detailed requirements and test references.
 
 ---
 
-## 13. References
+## 16. References
 
 ### Normative References
 
+- **[RFC 2119]** IETF. *Key words for use in RFCs to Indicate Requirement Levels*. https://datatracker.ietf.org/doc/html/rfc2119
 - **[DID-CORE]** W3C. *Decentralized Identifiers (DIDs) v1.0*. https://www.w3.org/TR/did-core/
 - **[VC-DATA-MODEL]** W3C. *Verifiable Credentials Data Model v1.1*. https://www.w3.org/TR/vc-data-model/
 - **[DID-KEY]** W3C CCG. *did:key Method Specification*. https://w3c-ccg.github.io/did-method-key/
@@ -737,6 +788,104 @@ See `CONFORMANCE.md` for detailed requirements and test references.
 ```
 
 Note: Excludes `0`, `O`, `I`, `l` to avoid visual ambiguity.
+
+---
+
+## Appendix C: Test Vectors
+
+These test vectors enable interoperability testing across implementations.
+
+### C.1 SHA-256 Canonical Hash
+
+**Input JSON:**
+```json
+{"method":"tools/call","params":{"name":"echo","arguments":{}}}
+```
+
+**JCS Canonicalized (RFC 8785):**
+```json
+{"method":"tools/call","params":{"arguments":{},"name":"echo"}}
+```
+
+**SHA-256 (hex):**
+```
+5057521f310b536837b619f0ac040ef8064f8c597da8ec22a56801b435744033
+```
+
+**MCP-I Format:**
+```
+sha256:5057521f310b536837b619f0ac040ef8064f8c597da8ec22a56801b435744033
+```
+
+### C.2 did:key Derivation
+
+**Ed25519 Public Key (32 bytes, hex):**
+```
+8076ee2cfc1acdd3f8f4e38c665a0a3e6ad6e06dc05b4f6ec9c5b1ae7c81c9a2
+```
+
+**Steps:**
+1. Prepend multicodec prefix `0xed01` (Ed25519 public key)
+2. Encode with base58btc
+3. Prepend multibase prefix `z`
+
+**Multicodec + Key (hex):**
+```
+ed018076ee2cfc1acdd3f8f4e38c665a0a3e6ad6e06dc05b4f6ec9c5b1ae7c81c9a2
+```
+
+**Base58btc Encoded:**
+```
+6Mko6jQvza2BSKRcrbJwgwbL9KYDn1isCUV5Lnq7gSTTKJq
+```
+
+**did:key:**
+```
+did:key:z6Mko6jQvza2BSKRcrbJwgwbL9KYDn1isCUV5Lnq7gSTTKJq
+```
+
+**Verification Method ID:**
+```
+did:key:z6Mko6jQvza2BSKRcrbJwgwbL9KYDn1isCUV5Lnq7gSTTKJq#keys-1
+```
+
+### C.3 JWS Structure
+
+A valid detached proof JWS has the following structure:
+
+**Protected Header (decoded):**
+```json
+{
+  "alg": "EdDSA",
+  "kid": "did:key:z6Mk...#keys-1"
+}
+```
+
+**Payload (decoded, canonicalized):**
+```json
+{
+  "aud": "did:web:server.example.com",
+  "iss": "did:web:server.example.com",
+  "nonce": "abc123...",
+  "requestHash": "sha256:5057521f...",
+  "responseHash": "sha256:d4e5f6...",
+  "sessionId": "mcpi_d7f8a9b0-...",
+  "sub": "did:web:server.example.com",
+  "ts": 1710288000
+}
+```
+
+**Signature:**
+```
+Ed25519Sign(privateKey, BASE64URL(header) || "." || BASE64URL(canonicalize(payload)))
+```
+
+**Compact JWS:**
+```
+<base64url-header>.<base64url-payload>.<base64url-signature>
+```
+
+Note: Actual signature values are key-dependent. Implementers should verify the structure and use the test key material from the reference implementation's test suite for bit-exact validation.
 
 ---
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,117 @@
+# MCP-I JSON Schemas
+
+This directory contains JSON Schema definitions for the core MCP-I (Model Context Protocol - Identity) protocol messages.
+
+## Schemas
+
+| Schema | Description |
+|--------|-------------|
+| [handshake-request.json](./handshake-request.json) | Client-initiated session establishment request |
+| [handshake-response.json](./handshake-response.json) | Server response with session context |
+| [delegation-credential.json](./delegation-credential.json) | W3C Verifiable Credential for delegations |
+| [detached-proof.json](./detached-proof.json) | Cryptographic proof for tool request/response |
+| [well-known-mcpi.json](./well-known-mcpi.json) | Service discovery document |
+
+## Usage
+
+### Validation with Node.js (Ajv)
+
+```javascript
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import handshakeRequestSchema from './schemas/handshake-request.json';
+
+const ajv = new Ajv({ strict: true });
+addFormats(ajv);
+
+const validate = ajv.compile(handshakeRequestSchema);
+
+const request = {
+  nonce: 'k7Hy9mNpQrStUvWxYz01Aa',
+  audience: 'did:web:example.com',
+  timestamp: Math.floor(Date.now() / 1000),
+  agentDid: 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+};
+
+if (validate(request)) {
+  console.log('Valid handshake request');
+} else {
+  console.error('Validation errors:', validate.errors);
+}
+```
+
+### Validation with Python (jsonschema)
+
+```python
+import json
+from jsonschema import validate, ValidationError
+
+with open('schemas/handshake-request.json') as f:
+    schema = json.load(f)
+
+request = {
+    "nonce": "k7Hy9mNpQrStUvWxYz01Aa",
+    "audience": "did:web:example.com",
+    "timestamp": 1710268800
+}
+
+try:
+    validate(instance=request, schema=schema)
+    print("Valid handshake request")
+except ValidationError as e:
+    print(f"Validation error: {e.message}")
+```
+
+### Schema References
+
+All schemas use JSON Schema draft 2020-12 and are published at:
+
+```
+https://schema.modelcontextprotocol-identity.io/mcpi/{schema-name}.json
+```
+
+Schemas can reference each other using `$ref`. For example, the delegation credential schema references shared definitions for constraints and proof structures.
+
+## Protocol Flow
+
+```
+┌────────┐                          ┌────────┐
+│ Client │                          │ Server │
+└───┬────┘                          └───┬────┘
+    │                                   │
+    │  GET /.well-known/mcpi            │
+    │──────────────────────────────────>│
+    │  (well-known-mcpi.json)           │
+    │<──────────────────────────────────│
+    │                                   │
+    │  POST /handshake                  │
+    │  (handshake-request.json)         │
+    │──────────────────────────────────>│
+    │  (handshake-response.json)        │
+    │<──────────────────────────────────│
+    │                                   │
+    │  POST /tools/{method}             │
+    │  + X-Session-Id header            │
+    │──────────────────────────────────>│
+    │  Response + detached-proof.json   │
+    │<──────────────────────────────────│
+    │                                   │
+```
+
+## Specification Reference
+
+These schemas implement types defined in the [MCP-I Specification](../SPEC.md):
+
+- **Handshake**: SPEC.md §4.5–4.9
+- **Delegation Credentials**: SPEC.md §4.1–4.2
+- **Detached Proofs**: SPEC.md §5
+- **Discovery**: SPEC.md §14 (Transport Binding)
+
+## Contributing
+
+When modifying schemas:
+
+1. Ensure backward compatibility or increment the schema version
+2. Update the `examples` array with valid instances
+3. Run validation tests against the examples
+4. Update this README if adding new schemas

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/delegation-credential.json",
+  "title": "MCP-I Delegation Credential",
+  "description": "W3C Verifiable Credential containing an MCP-I delegation with CRISP constraints.",
+  "type": "object",
+  "required": ["@context", "type", "issuer", "issuanceDate", "credentialSubject"],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string", "format": "uri" },
+          { "type": "object" }
+        ]
+      },
+      "minItems": 2,
+      "description": "JSON-LD context. MUST include W3C VC context as first element and MCP-I delegation context."
+    },
+    "id": {
+      "type": "string",
+      "format": "uri",
+      "description": "Unique credential identifier (URN or URL)."
+    },
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "contains": { "const": "VerifiableCredential" },
+      "minItems": 2,
+      "description": "Credential types. MUST include 'VerifiableCredential' and 'DelegationCredential'."
+    },
+    "issuer": {
+      "oneOf": [
+        { "type": "string", "pattern": "^did:.+$" },
+        {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^did:.+$" }
+          }
+        }
+      ],
+      "description": "Issuer DID or issuer object containing id."
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime when the credential was issued."
+    },
+    "expirationDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime when the credential expires."
+    },
+    "credentialSubject": {
+      "$ref": "#/$defs/DelegationCredentialSubject"
+    },
+    "credentialStatus": {
+      "$ref": "#/$defs/CredentialStatus"
+    },
+    "proof": {
+      "$ref": "#/$defs/Proof"
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "DelegationCredentialSubject": {
+      "type": "object",
+      "required": ["id", "delegation"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^did:.+$",
+          "description": "Subject DID (the delegate receiving the authorization)."
+        },
+        "delegation": {
+          "type": "object",
+          "required": ["id", "issuerDid", "subjectDid", "constraints", "status"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique delegation identifier."
+            },
+            "issuerDid": {
+              "type": "string",
+              "pattern": "^did:.+$",
+              "description": "DID of the delegation issuer (delegator)."
+            },
+            "subjectDid": {
+              "type": "string",
+              "pattern": "^did:.+$",
+              "description": "DID of the delegation subject (delegate)."
+            },
+            "userDid": {
+              "type": "string",
+              "pattern": "^did:.+$",
+              "description": "DID of the end user on whose behalf the delegation acts."
+            },
+            "userIdentifier": {
+              "type": "string",
+              "description": "Alternative user identifier (e.g., email, username)."
+            },
+            "sessionId": {
+              "type": "string",
+              "description": "Session binding for session-scoped delegations."
+            },
+            "scopes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Authorized scope strings."
+            },
+            "controller": {
+              "type": "string",
+              "pattern": "^did:.+$",
+              "description": "Controller DID for delegation management."
+            },
+            "parentId": {
+              "type": "string",
+              "description": "Parent delegation ID for chained delegations."
+            },
+            "constraints": {
+              "$ref": "#/$defs/DelegationConstraints"
+            },
+            "status": {
+              "type": "string",
+              "enum": ["active", "revoked", "expired"],
+              "description": "Current delegation status."
+            },
+            "createdAt": {
+              "type": "integer",
+              "description": "Unix timestamp when delegation was created."
+            },
+            "metadata": {
+              "type": "object",
+              "description": "Additional delegation metadata.",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "DelegationConstraints": {
+      "type": "object",
+      "properties": {
+        "notBefore": {
+          "type": "integer",
+          "description": "Unix timestamp before which the delegation is not valid."
+        },
+        "notAfter": {
+          "type": "integer",
+          "description": "Unix timestamp after which the delegation expires."
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Authorized scope strings."
+        },
+        "audience": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ],
+          "description": "Intended audience DID(s) for the delegation."
+        },
+        "crisp": {
+          "type": "object",
+          "required": ["scopes"],
+          "properties": {
+            "budget": {
+              "type": "object",
+              "required": ["unit", "cap"],
+              "properties": {
+                "unit": {
+                  "type": "string",
+                  "enum": ["USD", "ops", "points"],
+                  "description": "Budget unit type."
+                },
+                "cap": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Maximum budget amount."
+                },
+                "window": {
+                  "type": "object",
+                  "required": ["kind", "durationSec"],
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": ["rolling", "fixed"]
+                    },
+                    "durationSec": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  }
+                }
+              }
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["resource", "matcher"],
+                "properties": {
+                  "resource": { "type": "string" },
+                  "matcher": {
+                    "type": "string",
+                    "enum": ["exact", "prefix", "regex"]
+                  },
+                  "constraints": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "CredentialStatus": {
+      "type": "object",
+      "required": ["id", "type", "statusPurpose", "statusListIndex", "statusListCredential"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri",
+          "description": "Status entry identifier."
+        },
+        "type": {
+          "type": "string",
+          "const": "StatusList2021Entry"
+        },
+        "statusPurpose": {
+          "type": "string",
+          "enum": ["revocation", "suspension"]
+        },
+        "statusListIndex": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Index in the status list bitstring."
+        },
+        "statusListCredential": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the StatusList2021 credential."
+        }
+      }
+    },
+    "Proof": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Proof type (e.g., 'Ed25519Signature2020', 'JsonWebSignature2020')."
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "verificationMethod": {
+          "type": "string",
+          "description": "DID URL of the verification key."
+        },
+        "proofPurpose": {
+          "type": "string",
+          "description": "Purpose of the proof (e.g., 'assertionMethod')."
+        },
+        "proofValue": {
+          "type": "string",
+          "description": "Base64-encoded signature value."
+        },
+        "jws": {
+          "type": "string",
+          "description": "Compact JWS signature."
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "examples": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation.v1.0.0.json"
+      ],
+      "id": "urn:uuid:12345678-1234-1234-1234-123456789abc",
+      "type": ["VerifiableCredential", "DelegationCredential"],
+      "issuer": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+      "issuanceDate": "2024-03-12T00:00:00Z",
+      "expirationDate": "2024-03-13T00:00:00Z",
+      "credentialSubject": {
+        "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+        "delegation": {
+          "id": "del-001",
+          "issuerDid": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+          "subjectDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+          "scopes": ["read:documents", "write:documents"],
+          "constraints": {
+            "notBefore": 1710201600,
+            "notAfter": 1710288000
+          },
+          "status": "active"
+        }
+      }
+    }
+  ]
+}

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/detached-proof.json",
+  "title": "MCP-I Detached Proof",
+  "description": "Cryptographic proof binding an MCP tool request/response pair to an agent's identity and session context.",
+  "type": "object",
+  "required": ["jws", "meta"],
+  "properties": {
+    "jws": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$",
+      "description": "Compact JWS (header.payload.signature) signed with Ed25519. The payload contains canonicalized proof metadata."
+    },
+    "meta": {
+      "$ref": "#/$defs/ProofMeta"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "ProofMeta": {
+      "type": "object",
+      "required": ["did", "kid", "ts", "nonce", "audience", "sessionId", "requestHash", "responseHash"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "pattern": "^did:(key|web):.+$",
+          "description": "Signer's DID."
+        },
+        "kid": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key identifier for the signing key (matches JWS header kid)."
+        },
+        "ts": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Unix timestamp in seconds when the proof was generated."
+        },
+        "nonce": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Session nonce from the handshake, binding proof to session."
+        },
+        "audience": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Intended audience (server DID or URL)."
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Session identifier from handshake response."
+        },
+        "requestHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "SHA-256 hash of JCS-canonicalized request. Format: 'sha256:<64 hex chars>'."
+        },
+        "responseHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "SHA-256 hash of JCS-canonicalized response. Format: 'sha256:<64 hex chars>'."
+        },
+        "scopeId": {
+          "type": "string",
+          "description": "Optional scope identifier for fine-grained authorization tracking."
+        },
+        "delegationRef": {
+          "type": "string",
+          "description": "Optional reference to delegation credential authorizing this action."
+        },
+        "clientDid": {
+          "type": "string",
+          "pattern": "^did:.+$",
+          "description": "Optional client DID for multi-party scenarios."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2hhWGdCWkR2b3REa0w1MjU3ZmFpenRpR2lDMlF0S0xHcGJubkVHdGEyZG9LI3o2TWtoYVhnQlpEdm90RGtMNTI1N2ZhaXp0aUdpQzJRdEtMR3Bibm5FR3RhMmRvSyJ9.eyJhdWQiOiJkaWQ6d2ViOmV4YW1wbGUuY29tIiwic3ViIjoiZGlkOmtleTp6Nk1raGFYZ0JaRHZvdERrTDUyNTdmYWl6dGlHaUMyUXRLTEdwYm5uRUd0YTJkb0siLCJpc3MiOiJkaWQ6a2V5Ono2TWtoYVhnQlpEdm90RGtMNTI1N2ZhaXp0aUdpQzJRdEtMR3Bibm5FR3RhMmRvSyIsInJlcXVlc3RIYXNoIjoic2hhMjU2OjcyYjgwYTRhYTZhYjlmNTNhZThmZTcyN2I2N2I5Y2I3ZjQ5OTk3ZjM2MjE3OTg5OTI3MTI1OGMzMjY1YmZiMWMiLCJyZXNwb25zZUhhc2giOiJzaGEyNTY6MWI0ZjBhMWVlNzcwOGQ0YzM5OGZmOWE0OTM3YjI0MjFhNmQzYTQ4MjRiNmE2ZjFhNmJlOGJhY2I3ZWYyNzlkYSIsInRzIjoxNzEwMjY4ODAwLCJub25jZSI6Ims3SHk5bU5wUXJTdFV2V3hZejAxQWEiLCJzZXNzaW9uSWQiOiJzZXNzX2FiYzEyM3h5eiJ9.signature",
+      "meta": {
+        "did": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+        "kid": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+        "ts": 1710268800,
+        "nonce": "k7Hy9mNpQrStUvWxYz01Aa",
+        "audience": "did:web:example.com",
+        "sessionId": "sess_abc123xyz",
+        "requestHash": "sha256:72b80a4aa6ab9f53ae8fe727b67b9cb7f49997f36217989927125832c3265bfb1c",
+        "responseHash": "sha256:1b4f0a1ee7708d4c398ff9a4937b2421a6d3a4824b6a6f1a6be8bacb7ef279da"
+      }
+    }
+  ]
+}

--- a/schemas/handshake-request.json
+++ b/schemas/handshake-request.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/handshake-request.json",
+  "title": "MCP-I Handshake Request",
+  "description": "Client-initiated handshake request to establish an MCP-I session with nonce-based replay protection.",
+  "type": "object",
+  "required": ["nonce", "audience", "timestamp"],
+  "properties": {
+    "nonce": {
+      "type": "string",
+      "minLength": 22,
+      "description": "Base64url-encoded random value (minimum 16 bytes) for replay prevention. Each nonce MUST be unique per session."
+    },
+    "audience": {
+      "type": "string",
+      "description": "The intended recipient's DID (did:key or did:web). MUST match the server's DID for the request to be accepted."
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp in seconds. Server MAY reject requests with timestamps outside acceptable skew window (default: 120 seconds)."
+    },
+    "agentDid": {
+      "type": "string",
+      "pattern": "^did:(key|web):.+$",
+      "description": "The agent's DID if authenticated. Required for authenticated sessions."
+    },
+    "clientInfo": {
+      "type": "object",
+      "description": "Optional client metadata for session context.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Client application name."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable client title."
+        },
+        "version": {
+          "type": "string",
+          "description": "Client version string."
+        },
+        "platform": {
+          "type": "string",
+          "description": "Operating system or platform identifier."
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Client vendor or organization."
+        },
+        "persistentId": {
+          "type": "string",
+          "description": "Persistent client identifier across sessions."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Unique client instance identifier."
+        }
+      },
+      "required": ["name"]
+    },
+    "clientProtocolVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "Client's supported MCP-I protocol version (e.g., '1.0')."
+    },
+    "clientCapabilities": {
+      "type": "object",
+      "description": "Client capability flags for feature negotiation.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "nonce": "k7Hy9mNpQrStUvWxYz01Aa",
+      "audience": "did:web:example.com",
+      "timestamp": 1710268800,
+      "agentDid": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+      "clientProtocolVersion": "1.0"
+    }
+  ]
+}

--- a/schemas/handshake-response.json
+++ b/schemas/handshake-response.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/handshake-response.json",
+  "title": "MCP-I Handshake Response",
+  "description": "Server response to a successful handshake request, establishing session context.",
+  "type": "object",
+  "required": ["sessionId", "serverDid", "protocolVersion"],
+  "properties": {
+    "sessionId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique session identifier. Clients MUST include this in subsequent requests."
+    },
+    "serverDid": {
+      "type": "string",
+      "pattern": "^did:(key|web):.+$",
+      "description": "The server's DID used for proof verification."
+    },
+    "protocolVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "Negotiated MCP-I protocol version (e.g., '1.0')."
+    },
+    "serverCapabilities": {
+      "type": "object",
+      "description": "Server capability flags indicating supported features.",
+      "properties": {
+        "proofs": {
+          "type": "boolean",
+          "description": "Server supports detached proofs on tool responses."
+        },
+        "delegation": {
+          "type": "boolean",
+          "description": "Server supports W3C delegation credentials."
+        },
+        "statusList": {
+          "type": "boolean",
+          "description": "Server supports StatusList2021 revocation checking."
+        }
+      },
+      "additionalProperties": true
+    },
+    "sessionTtl": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Session time-to-live in seconds. Client SHOULD refresh before expiration."
+    },
+    "nonce": {
+      "type": "string",
+      "description": "Echo of the client's nonce for binding verification."
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "sessionId": "sess_abc123xyz",
+      "serverDid": "did:web:api.example.com",
+      "protocolVersion": "1.0",
+      "serverCapabilities": {
+        "proofs": true,
+        "delegation": true,
+        "statusList": true
+      },
+      "sessionTtl": 1800
+    }
+  ]
+}

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/well-known-mcpi.json",
+  "title": "MCP-I Discovery Document",
+  "description": "Well-known discovery document served at /.well-known/mcpi for MCP-I service discovery.",
+  "type": "object",
+  "required": ["version", "serverDid", "endpoints"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "MCP-I protocol version supported by this server."
+    },
+    "serverDid": {
+      "type": "string",
+      "pattern": "^did:(key|web):.+$",
+      "description": "Server's DID for identity verification and proof validation."
+    },
+    "endpoints": {
+      "type": "object",
+      "required": ["handshake"],
+      "properties": {
+        "handshake": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Relative or absolute URL for the handshake endpoint."
+        },
+        "tools": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Relative or absolute URL for the MCP tools endpoint."
+        },
+        "delegation": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Relative or absolute URL for delegation management."
+        },
+        "authorization": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "URL for user authorization flow initiation."
+        }
+      },
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri-reference"
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "description": "Server capabilities for feature discovery.",
+      "properties": {
+        "proofs": {
+          "type": "boolean",
+          "description": "Server generates detached proofs for tool responses."
+        },
+        "delegation": {
+          "type": "boolean",
+          "description": "Server supports W3C delegation credentials."
+        },
+        "statusList": {
+          "type": "boolean",
+          "description": "Server supports StatusList2021 revocation checking."
+        },
+        "crisp": {
+          "type": "boolean",
+          "description": "Server supports CRISP constraint evaluation."
+        }
+      },
+      "additionalProperties": true
+    },
+    "publicKeys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "publicKeyJwk"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Key identifier (matches kid in JWS headers)."
+          },
+          "type": {
+            "type": "string",
+            "description": "Key type (e.g., 'JsonWebKey2020', 'Ed25519VerificationKey2020')."
+          },
+          "controller": {
+            "type": "string",
+            "pattern": "^did:.+$",
+            "description": "DID that controls this key."
+          },
+          "publicKeyJwk": {
+            "type": "object",
+            "required": ["kty", "crv", "x"],
+            "properties": {
+              "kty": {
+                "type": "string",
+                "const": "OKP"
+              },
+              "crv": {
+                "type": "string",
+                "const": "Ed25519"
+              },
+              "x": {
+                "type": "string",
+                "description": "Base64url-encoded public key."
+              },
+              "kid": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "description": "Public keys for signature verification (alternative to DID resolution)."
+    },
+    "statusListCredential": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the StatusList2021 credential for revocation checking."
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "description": "Contact information for the service operator."
+    }
+  },
+  "additionalProperties": true,
+  "examples": [
+    {
+      "version": "1.0",
+      "serverDid": "did:web:api.example.com",
+      "endpoints": {
+        "handshake": "/mcpi/handshake",
+        "tools": "/mcpi/tools",
+        "delegation": "/mcpi/delegations",
+        "authorization": "https://auth.example.com/authorize"
+      },
+      "capabilities": {
+        "proofs": true,
+        "delegation": true,
+        "statusList": true,
+        "crisp": true
+      },
+      "publicKeys": [
+        {
+          "id": "did:web:api.example.com#key-1",
+          "type": "JsonWebKey2020",
+          "controller": "did:web:api.example.com",
+          "publicKeyJwk": {
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+          }
+        }
+      ],
+      "statusListCredential": "https://api.example.com/credentials/status/1",
+      "contact": {
+        "name": "Example API Support",
+        "email": "support@example.com",
+        "url": "https://example.com/support"
+      }
+    }
+  ]
+}

--- a/src/__tests__/integration/full-flow.test.ts
+++ b/src/__tests__/integration/full-flow.test.ts
@@ -14,16 +14,18 @@ import { MemoryNonceCacheProvider } from "../../providers/memory.js";
 import { SessionManager, createHandshakeRequest } from "../../session/manager.js";
 import { ProofGenerator } from "../../proof/generator.js";
 import { ProofVerifier } from "../../proof/verifier.js";
+import { ClockProvider, FetchProvider } from "../../providers/base.js";
 import {
   createDidKeyResolver,
   resolveDidKeySync,
   extractPublicKeyFromDidKey,
   publicKeyToJwk,
 } from "../../delegation/did-key-resolver.js";
-import type { DetachedProof } from "../../types/protocol.js";
+import type { DIDDocument } from "../../delegation/vc-verifier.js";
+import type { DetachedProof, StatusList2021Credential, DelegationRecord } from "../../types/protocol.js";
 
 // Minimal concrete providers for the ProofVerifier
-class TestClockProvider {
+class TestClockProvider extends ClockProvider {
   now(): number {
     return Date.now();
   }
@@ -42,19 +44,19 @@ class TestClockProvider {
   }
 }
 
-class TestFetchProvider {
+class TestFetchProvider extends FetchProvider {
   private didResolver = createDidKeyResolver();
 
-  async resolveDID(did: string): Promise<unknown> {
+  async resolveDID(did: string): Promise<DIDDocument | null> {
     // createDidKeyResolver returns a DIDResolver { resolve(did) }
     return this.didResolver.resolve(did);
   }
 
-  async fetchStatusList(_url: string): Promise<unknown> {
+  async fetchStatusList(_url: string): Promise<StatusList2021Credential | null> {
     return null;
   }
 
-  async fetchDelegationChain(_id: string): Promise<unknown[]> {
+  async fetchDelegationChain(_id: string): Promise<DelegationRecord[]> {
     return [];
   }
 
@@ -143,9 +145,9 @@ describe("MCP-I Full Protocol Flow", () => {
     // ── Step 5: Verify proof with ProofVerifier ──────────────────
     const verifier = new ProofVerifier({
       cryptoProvider,
-      clockProvider: new TestClockProvider() as any,
+      clockProvider: new TestClockProvider() ,
       nonceCacheProvider: new MemoryNonceCacheProvider(),
-      fetchProvider: new TestFetchProvider() as any,
+      fetchProvider: new TestFetchProvider() ,
       timestampSkewSeconds: 300,
     });
 
@@ -206,9 +208,9 @@ describe("MCP-I Full Protocol Flow", () => {
 
     const verifier = new ProofVerifier({
       cryptoProvider,
-      clockProvider: new TestClockProvider() as any,
+      clockProvider: new TestClockProvider() ,
       nonceCacheProvider: new MemoryNonceCacheProvider(),
-      fetchProvider: new TestFetchProvider() as any,
+      fetchProvider: new TestFetchProvider() ,
       timestampSkewSeconds: 300,
     });
 

--- a/src/__tests__/utils/mock-providers.ts
+++ b/src/__tests__/utils/mock-providers.ts
@@ -14,6 +14,8 @@ import {
   IdentityProvider,
   type AgentIdentity,
 } from '../../providers/base.js';
+import type { DIDDocument } from '../../delegation/vc-verifier.js';
+import type { StatusList2021Credential, DelegationRecord } from '../../types/protocol.js';
 
 /**
  * Mock Crypto Provider
@@ -92,9 +94,9 @@ export class MockClockProvider extends ClockProvider {
  * Mock Fetch Provider
  */
 export class MockFetchProvider extends FetchProvider {
-  private didDocuments = new Map<string, unknown>();
-  private statusLists = new Map<string, unknown>();
-  private delegationChains = new Map<string, unknown[]>();
+  private didDocuments = new Map<string, DIDDocument>();
+  private statusLists = new Map<string, StatusList2021Credential>();
+  private delegationChains = new Map<string, DelegationRecord[]>();
   public fetch: (url: string, options?: unknown) => Promise<Response>;
 
   constructor() {
@@ -109,40 +111,28 @@ export class MockFetchProvider extends FetchProvider {
     ) as (url: string, options?: unknown) => Promise<Response>;
   }
 
-  setDIDDocument(did: string, doc: unknown): void {
+  setDIDDocument(did: string, doc: DIDDocument): void {
     this.didDocuments.set(did, doc);
   }
 
-  setStatusList(url: string, list: unknown): void {
+  setStatusList(url: string, list: StatusList2021Credential): void {
     this.statusLists.set(url, list);
   }
 
-  setDelegationChain(id: string, chain: unknown[]): void {
+  setDelegationChain(id: string, chain: DelegationRecord[]): void {
     this.delegationChains.set(id, chain);
   }
 
-  async resolveDID(did: string): Promise<unknown> {
-    const doc = this.didDocuments.get(did);
-    if (!doc) {
-      throw new Error(`DID ${did} not found`);
-    }
-    return doc;
+  async resolveDID(did: string): Promise<DIDDocument | null> {
+    return this.didDocuments.get(did) ?? null;
   }
 
-  async fetchStatusList(url: string): Promise<unknown> {
-    const list = this.statusLists.get(url);
-    if (!list) {
-      throw new Error(`Status list ${url} not found`);
-    }
-    return list;
+  async fetchStatusList(url: string): Promise<StatusList2021Credential | null> {
+    return this.statusLists.get(url) ?? null;
   }
 
-  async fetchDelegationChain(id: string): Promise<unknown[]> {
-    const chain = this.delegationChains.get(id);
-    if (!chain) {
-      throw new Error(`Delegation chain ${id} not found`);
-    }
-    return chain;
+  async fetchDelegationChain(id: string): Promise<DelegationRecord[]> {
+    return this.delegationChains.get(id) ?? [];
   }
 }
 

--- a/src/auth/handshake.ts
+++ b/src/auth/handshake.ts
@@ -171,6 +171,20 @@ export class MemoryResumeTokenStore implements ResumeTokenStore {
   }
 }
 
+/**
+ * Verify agent delegation or return authorization hints.
+ *
+ * Orchestrates the authorization flow:
+ * 1. Optionally check agent reputation against threshold
+ * 2. Verify existing delegation via DelegationVerifier
+ * 3. Return authorization hints if delegation is missing/invalid
+ *
+ * @param agentDid - The agent's DID to verify
+ * @param scopes - Required scopes for the operation
+ * @param config - Authorization configuration including verifier, token store, etc.
+ * @param _resumeToken - Optional resume token from previous authorization attempt
+ * @returns Result indicating authorization status, delegation, or auth hints
+ */
 export async function verifyOrHints(
   agentDid: string,
   scopes: string[],
@@ -367,7 +381,7 @@ async function buildNeedsAuthorizationError(
     title: 'Authorization Required',
     hint: ['link', 'qr'],
     authorizationCode: authCode,
-    qrUrl: `https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=${encodeURIComponent(authUrl.toString())}`,
+    qrUrl: `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(authUrl.toString())}`,
   };
 
   return createNeedsAuthorizationError({

--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -292,7 +292,7 @@ describe("DelegationCredentialVerifier", () => {
       expect(mockSignatureVerifier).not.toHaveBeenCalled();
     });
 
-    it("should skip signature verification when no resolver available", async () => {
+    it("should fail signature verification when no resolver available", async () => {
       await setupDefaultContractsMocks();
       const verifierWithoutResolver = new DelegationCredentialVerifier({
         statusListResolver: mockStatusListResolver,
@@ -304,8 +304,9 @@ describe("DelegationCredentialVerifier", () => {
       const result =
         await verifierWithoutResolver.verifyDelegationCredential(mockValidVC);
 
-      expect(result.valid).toBe(true);
-      expect(result.checks?.signatureValid).toBe(true); // Trust but don't verify
+      expect(result.valid).toBe(false);
+      expect(result.checks?.signatureValid).toBe(false);
+      expect(result.reason).toContain("No DID resolver or signature verifier configured");
     });
 
     it("should fail when DID resolution fails", async () => {

--- a/src/delegation/outbound-headers.ts
+++ b/src/delegation/outbound-headers.ts
@@ -115,6 +115,10 @@ function buildPrivateKeyJwk(
  * @param _cryptoProvider - CryptoProvider (reserved for future use)
  * @returns Headers object to attach to the outbound request
  *
+ * @throws {Error} If session is missing agentDid or sessionId
+ * @throws {Error} If delegation is missing vcId
+ * @throws {Error} If serverIdentity.did is not a valid Ed25519 did:key
+ *
  * @example
  * ```typescript
  * const headers = await buildOutboundDelegationHeaders({

--- a/src/delegation/outbound-proof.ts
+++ b/src/delegation/outbound-proof.ts
@@ -33,6 +33,16 @@ export interface DelegationProofOptions {
   targetHostname: string;
 }
 
+/**
+ * Build a signed delegation proof JWT for outbound HTTP requests.
+ *
+ * Creates a short-lived (60s) EdDSA-signed JWT containing delegation context
+ * that can be verified by downstream services without access to the MCP server.
+ *
+ * @param options - Proof options including DIDs, delegation info, scopes, and signing key
+ * @returns Compact JWS string (header.payload.signature)
+ * @throws {Error} If key import or signing fails
+ */
 export async function buildDelegationProofJWT(
   options: DelegationProofOptions
 ): Promise<string> {

--- a/src/delegation/vc-issuer.ts
+++ b/src/delegation/vc-issuer.ts
@@ -74,6 +74,16 @@ export class DelegationCredentialIssuer {
     } as DelegationCredential;
   }
 
+  /**
+   * Create and issue a delegation credential in one step.
+   *
+   * Constructs a DelegationRecord from the provided parameters and wraps it
+   * in a signed W3C Verifiable Credential.
+   *
+   * @param params - Delegation parameters including issuer/subject DIDs, constraints, etc.
+   * @param options - Optional VC issuance options (id, dates, status, contexts)
+   * @returns Signed W3C Delegation Credential
+   */
   async createAndIssueDelegation(
     params: {
       id: string;

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -89,20 +89,41 @@ export class DelegationCredentialVerifier {
     string,
     { result: DelegationVCVerificationResult; expiresAt: number }
   >();
+  private cacheInsertionOrder: string[] = [];
   private cacheTtl: number;
+  /**
+   * Maximum number of entries in the verification cache.
+   * In production deployments, configure maxCacheSize based on expected concurrent delegations.
+   * Default of 1000 is suitable for most use cases.
+   */
+  private maxCacheSize: number;
 
   constructor(options?: {
     didResolver?: DIDResolver;
     statusListResolver?: StatusListResolver;
     signatureVerifier?: SignatureVerificationFunction;
     cacheTtl?: number;
+    /** Maximum cache entries. Default: 1000 */
+    maxCacheSize?: number;
   }) {
     this.didResolver = options?.didResolver;
     this.statusListResolver = options?.statusListResolver;
     this.signatureVerifier = options?.signatureVerifier;
     this.cacheTtl = options?.cacheTtl || 60_000;
+    this.maxCacheSize = options?.maxCacheSize ?? 1000;
   }
 
+  /**
+   * Verify a delegation credential through progressive enhancement.
+   *
+   * Stage 1: Fast basic checks (schema, expiry, status field)
+   * Stage 2: Parallel signature and status list checks (if resolvers configured)
+   * Stage 3: Combined result with timing metrics
+   *
+   * @param vc - The W3C Delegation Credential to verify
+   * @param options - Verification options (skip cache/signature/status, custom resolvers)
+   * @returns Verification result with validity, reason, stage reached, and metrics
+   */
   async verifyDelegationCredential(
     vc: DelegationCredential,
     options: VerifyDelegationVCOptions = {},
@@ -250,9 +271,9 @@ export class DelegationCredentialVerifier {
 
       if (!didResolver || !this.signatureVerifier) {
         return {
-          valid: true,
+          valid: false,
           reason:
-            "No DID resolver or signature verifier available, skipping signature verification",
+            "No DID resolver or signature verifier configured — signature cannot be verified",
           durationMs: Date.now() - startTime,
         };
       }
@@ -380,18 +401,32 @@ export class DelegationCredentialVerifier {
   }
 
   private setInCache(id: string, result: DelegationVCVerificationResult): void {
+    // Evict oldest entry if cache exceeds maxCacheSize (simple FIFO)
+    while (this.cache.size >= this.maxCacheSize && this.cacheInsertionOrder.length > 0) {
+      const oldestId = this.cacheInsertionOrder.shift();
+      if (oldestId) {
+        this.cache.delete(oldestId);
+      }
+    }
+
     this.cache.set(id, {
       result,
       expiresAt: Date.now() + this.cacheTtl,
     });
+    this.cacheInsertionOrder.push(id);
   }
 
   clearCache(): void {
     this.cache.clear();
+    this.cacheInsertionOrder = [];
   }
 
   clearCacheEntry(id: string): void {
     this.cache.delete(id);
+    const idx = this.cacheInsertionOrder.indexOf(id);
+    if (idx !== -1) {
+      this.cacheInsertionOrder.splice(idx, 1);
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,14 @@
  * This package is a DIF TAAWG protocol reference implementation.
  *
  * Related Spec: https://modelcontextprotocol-identity.io
+ *
+ * ## Error handling strategy
+ *
+ * - **Validation functions** (`verify*`, `validate*`) return result objects `{ valid, reason }` — never throw
+ * - **Construction/setup functions** throw `Error` on invalid configuration
+ * - **Resolution functions** (`resolve*`, `fetch*`) return `null` on failure — never throw
+ *
+ * This ensures callers can always handle failures without try/catch on validation paths.
  */
 
 // Protocol types
@@ -246,3 +254,10 @@ export {
   type Logger,
   type Level,
 } from './logging/index.js';
+
+// Ed25519 Constants
+export {
+  ED25519_PKCS8_DER_HEADER,
+  ED25519_SPKI_DER_HEADER_LENGTH,
+  ED25519_KEY_SIZE,
+} from './utils/index.js';

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -12,7 +12,7 @@ async function createTestMiddleware(options?: { autoSession?: boolean }) {
   const did = generateDidKeyFromBase64(keyPair.publicKey);
   const kid = `${did}#keys-1`;
 
-  return createMCPIMiddleware(
+  const middleware = createMCPIMiddleware(
     {
       identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
       session: { sessionTtlMinutes: 60 },
@@ -20,15 +20,17 @@ async function createTestMiddleware(options?: { autoSession?: boolean }) {
     },
     crypto,
   );
+
+  return { middleware, did };
 }
 
 describe('createMCPIMiddleware', () => {
   describe('handleHandshake', () => {
     it('should establish a session with valid handshake', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi, did } = await createTestMiddleware();
       const result = await mcpi.handleHandshake({
         nonce: 'test-nonce',
-        audience: 'did:web:example.com',
+        audience: did,
         timestamp: Math.floor(Date.now() / 1000),
       });
 
@@ -40,7 +42,7 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should reject invalid handshake', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi } = await createTestMiddleware();
       const result = await mcpi.handleHandshake({ nonce: 'test' });
 
       expect(result.isError).toBe(true);
@@ -52,12 +54,12 @@ describe('createMCPIMiddleware', () => {
 
   describe('wrapWithProof', () => {
     it('should attach proof in _meta after handshake', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi, did } = await createTestMiddleware();
 
       // Handshake first
       const hs = await mcpi.handleHandshake({
         nonce: 'test-nonce',
-        audience: 'did:web:example.com',
+        audience: did,
         timestamp: Math.floor(Date.now() / 1000),
       });
       const sessionId = JSON.parse(hs.content[0].text).sessionId;
@@ -85,11 +87,11 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should not attach proof when result is an error', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi, did } = await createTestMiddleware();
 
       const hs = await mcpi.handleHandshake({
         nonce: 'test-nonce',
-        audience: 'did:web:example.com',
+        audience: did,
         timestamp: Math.floor(Date.now() / 1000),
       });
       const sessionId = JSON.parse(hs.content[0].text).sessionId;
@@ -105,7 +107,7 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should return result without proof when no session exists and autoSession is off', async () => {
-      const mcpi = await createTestMiddleware({ autoSession: false });
+      const { middleware: mcpi } = await createTestMiddleware({ autoSession: false });
 
       const handler = mcpi.wrapWithProof('greet', async () => ({
         content: [{ type: 'text', text: 'Hello!' }],
@@ -162,7 +164,7 @@ describe('createMCPIMiddleware', () => {
     }
 
     it('should return needs_authorization when no _mcpi_delegation arg is provided', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi } = await createTestMiddleware();
 
       const handler = mcpi.wrapWithDelegation(
         'my-tool',
@@ -182,7 +184,7 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should reject when VC has wrong scope', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi } = await createTestMiddleware();
       const vc = await issueDelegationVC(['wrong:scope']);
 
       const handler = mcpi.wrapWithDelegation(
@@ -199,7 +201,7 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should accept and call handler when VC has correct scope and valid signature', async () => {
-      const mcpi = await createTestMiddleware();
+      const { middleware: mcpi } = await createTestMiddleware();
       const vc = await issueDelegationVC(['test:scope', 'other:scope']);
 
       const handler = mcpi.wrapWithDelegation(
@@ -222,7 +224,7 @@ describe('createMCPIMiddleware', () => {
 
   describe('autoSession', () => {
     it('should auto-create session and attach proof without handshake', async () => {
-      const mcpi = await createTestMiddleware({ autoSession: true });
+      const { middleware: mcpi } = await createTestMiddleware({ autoSession: true });
 
       const handler = mcpi.wrapWithProof('greet', async (args) => ({
         content: [{ type: 'text', text: `Hello, ${args['name']}!` }],
@@ -245,7 +247,7 @@ describe('createMCPIMiddleware', () => {
     });
 
     it('should reuse auto-created session across multiple calls', async () => {
-      const mcpi = await createTestMiddleware({ autoSession: true });
+      const { middleware: mcpi } = await createTestMiddleware({ autoSession: true });
 
       const handler = mcpi.wrapWithProof('greet', async () => ({
         content: [{ type: 'text', text: 'Hello!' }],

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -142,6 +142,12 @@ export interface MCPIMiddleware {
  * @param config - Agent identity and session configuration
  * @param cryptoProvider - Platform-specific crypto implementation
  * @returns Middleware components for session management and proof generation
+ *
+ * @remarks
+ * **Single-process only**: This middleware stores session state in memory using closure
+ * variables (`activeSessionId`, `sessionNonces`). It is NOT suitable for multi-instance
+ * deployments behind a load balancer. For distributed deployments, implement a custom
+ * `SessionStore` backed by Redis, DynamoDB, or similar and pass it via `config.session`.
  */
 export function createMCPIMiddleware(
   config: MCPIConfig,

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -18,6 +18,8 @@ import type {
 } from '../types/protocol.js';
 import type { CryptoProvider } from '../providers/base.js';
 import { CryptoService, type Ed25519JWK } from '../utils/crypto-service.js';
+import { base64ToBytes, base64urlEncodeFromBytes, bytesToBase64 } from '../utils/base64.js';
+import { ED25519_PKCS8_DER_HEADER, ED25519_KEY_SIZE } from '../utils/ed25519-constants.js';
 
 export interface ProofAgentIdentity {
   did: string;
@@ -54,6 +56,19 @@ export class ProofGenerator {
     this.cryptoProvider = cryptoProvider;
   }
 
+  /**
+   * Generate a detached proof for an MCP tool call.
+   *
+   * Creates a JWS (JSON Web Signature) that binds the tool request and response
+   * to the agent's identity and current session context.
+   *
+   * @param request - The MCP tool request (method + params)
+   * @param response - The tool response data
+   * @param session - The current session context from handshake
+   * @param options - Optional proof metadata (scopeId, delegationRef, clientDid)
+   * @returns Detached proof containing JWS and proof metadata
+   * @throws {Error} If JWS generation fails (invalid key, crypto error)
+   */
   async generateProof(
     request: ToolRequest,
     response: ToolResponse,
@@ -145,32 +160,17 @@ export class ProofGenerator {
   }
 
   private formatPrivateKeyAsPEM(base64PrivateKey: string): string {
-    const binaryStr = atob(base64PrivateKey);
-    const keyData = new Uint8Array(binaryStr.length);
-    for (let i = 0; i < binaryStr.length; i++) {
-      keyData[i] = binaryStr.charCodeAt(i);
-    }
+    const keyData = base64ToBytes(base64PrivateKey);
 
-    const pkcs8Header = new Uint8Array([
-      0x30, 0x2e,
-      0x02, 0x01, 0x00,
-      0x30, 0x05,
-      0x06, 0x03, 0x2b, 0x65, 0x70,
-      0x04, 0x22,
-      0x04, 0x20,
-    ]);
+    // Extract raw 32-byte seed
+    const rawKey = keyData.subarray(0, ED25519_KEY_SIZE);
 
-    const rawKey = keyData.subarray(0, 32);
-    const fullKey = new Uint8Array(pkcs8Header.length + rawKey.length);
-    fullKey.set(pkcs8Header);
-    fullKey.set(rawKey, pkcs8Header.length);
+    // Build full PKCS#8 key: header + raw key
+    const fullKey = new Uint8Array(ED25519_PKCS8_DER_HEADER.length + rawKey.length);
+    fullKey.set(ED25519_PKCS8_DER_HEADER);
+    fullKey.set(rawKey, ED25519_PKCS8_DER_HEADER.length);
 
-    let binaryStrOut = '';
-    for (let i = 0; i < fullKey.length; i++) {
-      binaryStrOut += String.fromCharCode(fullKey[i]!);
-    }
-    const base64Key = btoa(binaryStrOut);
-
+    const base64Key = bytesToBase64(fullKey);
     const formattedKey = base64Key.match(/.{1,64}/g)?.join('\n') ?? base64Key;
 
     return (
@@ -208,29 +208,16 @@ export class ProofGenerator {
   }
 
   private base64PublicKeyToJWK(publicKeyBase64: string): Ed25519JWK {
-    const binaryStr = atob(publicKeyBase64);
-    const publicKeyBytes = new Uint8Array(binaryStr.length);
-    for (let i = 0; i < binaryStr.length; i++) {
-      publicKeyBytes[i] = binaryStr.charCodeAt(i);
-    }
+    const publicKeyBytes = base64ToBytes(publicKeyBase64);
 
-    if (publicKeyBytes.length !== 32) {
+    if (publicKeyBytes.length !== ED25519_KEY_SIZE) {
       throw new Error(`Invalid Ed25519 public key length: ${publicKeyBytes.length}`);
     }
-
-    let binaryStrOut = '';
-    for (let i = 0; i < publicKeyBytes.length; i++) {
-      binaryStrOut += String.fromCharCode(publicKeyBytes[i]!);
-    }
-    const base64url = btoa(binaryStrOut)
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '');
 
     return {
       kty: 'OKP',
       crv: 'Ed25519',
-      x: base64url,
+      x: base64urlEncodeFromBytes(publicKeyBytes),
       kid: this.identity.kid,
     };
   }

--- a/src/proof/verifier.ts
+++ b/src/proof/verifier.ts
@@ -20,6 +20,7 @@ import {
   PROOF_VERIFICATION_ERROR_CODES,
   type ProofVerificationErrorCode,
 } from "./errors.js";
+import { logger } from "../logging/index.js";
 
 export interface ProofVerificationResult {
   valid: boolean;
@@ -67,69 +68,15 @@ export class ProofVerifier {
     publicKeyJwk: Ed25519JWK
   ): Promise<ProofVerificationResult> {
     try {
-      // 1. Validate proof structure
-      const structureValidation = await this.validateProofStructure(proof);
-      if (!structureValidation.valid) {
-        return structureValidation;
-      }
-      const validatedProof = structureValidation.proof!;
-
-      // 2. Check nonce replay protection (scoped to agent DID to prevent cross-agent replay attacks)
-      const nonceValidation = await this.validateNonce(
-        validatedProof.meta.nonce,
-        validatedProof.meta.did
-      );
-      if (!nonceValidation.valid) {
-        return nonceValidation;
-      }
-
-      // 3. Check timestamp skew
-      const timestampValidation = await this.validateTimestamp(
-        validatedProof.meta.ts
-      );
-      if (!timestampValidation.valid) {
-        return timestampValidation;
-      }
-
-      // 4. Reconstruct canonical payload from proof meta
-      const canonicalPayloadString = this.buildCanonicalPayload(
-        validatedProof.meta
-      );
+      // Reconstruct canonical payload from proof meta
+      const canonicalPayloadString = this.buildCanonicalPayload(proof.meta);
       const canonicalPayloadBytes = new TextEncoder().encode(
         canonicalPayloadString
       );
 
-      // 5. Verify JWS signature with detached canonical payload
-      const signatureValidation = await this.verifySignature(
-        validatedProof.jws,
-        publicKeyJwk,
-        canonicalPayloadBytes,
-        validatedProof.meta.kid
-      );
-      if (!signatureValidation.valid) {
-        return signatureValidation;
-      }
-
-      // 6. Add nonce to cache to prevent replay (scoped to agent DID)
-      await this.addNonceToCache(
-        validatedProof.meta.nonce,
-        validatedProof.meta.did
-      );
-
-      return {
-        valid: true,
-      };
+      return await this.runVerificationPipeline(proof, publicKeyJwk, canonicalPayloadBytes);
     } catch (error) {
-      // Security-safe failure: never throw, always return error result
-      return {
-        valid: false,
-        reason: "Proof verification error",
-        errorCode: PROOF_VERIFICATION_ERROR_CODES.VERIFICATION_ERROR,
-        error: error instanceof Error ? error : new Error(String(error)),
-        details: {
-          errorMessage: error instanceof Error ? error.message : String(error),
-        },
-      };
+      return this.handleVerificationError(error);
     }
   }
 
@@ -146,68 +93,85 @@ export class ProofVerifier {
     publicKeyJwk: Ed25519JWK
   ): Promise<ProofVerificationResult> {
     try {
-      // 1. Validate proof structure
-      const structureValidation = await this.validateProofStructure(proof);
-      if (!structureValidation.valid) {
-        return structureValidation;
-      }
-      const validatedProof = structureValidation.proof!;
-
-      // 2. Check nonce replay protection (scoped to agent DID to prevent cross-agent replay attacks)
-      const nonceValidation = await this.validateNonce(
-        validatedProof.meta.nonce,
-        validatedProof.meta.did
-      );
-      if (!nonceValidation.valid) {
-        return nonceValidation;
-      }
-
-      // 3. Check timestamp skew
-      const timestampValidation = await this.validateTimestamp(
-        validatedProof.meta.ts
-      );
-      if (!timestampValidation.valid) {
-        return timestampValidation;
-      }
-
-      // 4. Convert canonical payload to Uint8Array if needed
+      // Convert canonical payload to Uint8Array if needed
       const canonicalPayloadBytes =
         canonicalPayload instanceof Uint8Array
           ? canonicalPayload
           : new TextEncoder().encode(canonicalPayload);
 
-      // 5. Verify JWS signature with detached payload
-      const signatureValidation = await this.verifySignature(
-        validatedProof.jws,
-        publicKeyJwk,
-        canonicalPayloadBytes,
-        validatedProof.meta.kid
-      );
-      if (!signatureValidation.valid) {
-        return signatureValidation;
-      }
-
-      // 6. Add nonce to cache (scoped to agent DID)
-      await this.addNonceToCache(
-        validatedProof.meta.nonce,
-        validatedProof.meta.did
-      );
-
-      return {
-        valid: true,
-      };
+      return await this.runVerificationPipeline(proof, publicKeyJwk, canonicalPayloadBytes);
     } catch (error) {
-      // Security-safe failure: never throw, always return error result
-      return {
-        valid: false,
-        reason: "Proof verification error",
-        errorCode: PROOF_VERIFICATION_ERROR_CODES.VERIFICATION_ERROR,
-        error: error instanceof Error ? error : new Error(String(error)),
-        details: {
-          errorMessage: error instanceof Error ? error.message : String(error),
-        },
-      };
+      return this.handleVerificationError(error);
     }
+  }
+
+  /**
+   * Shared verification pipeline for proof verification
+   * @private
+   */
+  private async runVerificationPipeline(
+    proof: DetachedProof,
+    publicKeyJwk: Ed25519JWK,
+    canonicalPayloadBytes: Uint8Array
+  ): Promise<ProofVerificationResult> {
+    // 1. Validate proof structure
+    const structureValidation = await this.validateProofStructure(proof);
+    if (!structureValidation.valid) {
+      return structureValidation;
+    }
+    const validatedProof = structureValidation.proof!;
+
+    // 2. Check nonce replay protection (scoped to agent DID to prevent cross-agent replay attacks)
+    const nonceValidation = await this.validateNonce(
+      validatedProof.meta.nonce,
+      validatedProof.meta.did
+    );
+    if (!nonceValidation.valid) {
+      return nonceValidation;
+    }
+
+    // 3. Check timestamp skew
+    const timestampValidation = await this.validateTimestamp(
+      validatedProof.meta.ts
+    );
+    if (!timestampValidation.valid) {
+      return timestampValidation;
+    }
+
+    // 4. Verify JWS signature with canonical payload
+    const signatureValidation = await this.verifySignature(
+      validatedProof.jws,
+      publicKeyJwk,
+      canonicalPayloadBytes,
+      validatedProof.meta.kid
+    );
+    if (!signatureValidation.valid) {
+      return signatureValidation;
+    }
+
+    // 5. Add nonce to cache to prevent replay (scoped to agent DID)
+    await this.addNonceToCache(
+      validatedProof.meta.nonce,
+      validatedProof.meta.did
+    );
+
+    return { valid: true };
+  }
+
+  /**
+   * Handle verification errors consistently
+   * @private
+   */
+  private handleVerificationError(error: unknown): ProofVerificationResult {
+    return {
+      valid: false,
+      reason: "Proof verification error",
+      errorCode: PROOF_VERIFICATION_ERROR_CODES.VERIFICATION_ERROR,
+      error: error instanceof Error ? error : new Error(String(error)),
+      details: {
+        errorMessage: error instanceof Error ? error.message : String(error),
+      },
+    };
   }
 
   /**
@@ -433,10 +397,7 @@ export class ProofVerifier {
       if (error instanceof ProofVerificationError) {
         throw error;
       }
-      console.error(
-        "[ProofVerifier] Failed to fetch public key from DID:",
-        error
-      );
+      logger.error("[ProofVerifier] Failed to fetch public key from DID", { error });
       throw new ProofVerificationError(
         PROOF_VERIFICATION_ERROR_CODES.DID_RESOLUTION_FAILED,
         `DID resolution failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -5,6 +5,9 @@
  * platform-specific implementations.
  */
 
+import type { DIDDocument } from '../delegation/vc-verifier.js';
+import type { StatusList2021Credential, DelegationRecord } from '../types/protocol.js';
+
 export abstract class CryptoProvider {
   abstract sign(data: Uint8Array, privateKey: string): Promise<Uint8Array>;
   abstract verify(data: Uint8Array, signature: Uint8Array, publicKey: string): Promise<boolean>;
@@ -26,9 +29,9 @@ export abstract class ClockProvider {
 }
 
 export abstract class FetchProvider {
-  abstract resolveDID(did: string): Promise<unknown>;
-  abstract fetchStatusList(url: string): Promise<unknown>;
-  abstract fetchDelegationChain(id: string): Promise<unknown[]>;
+  abstract resolveDID(did: string): Promise<DIDDocument | null>;
+  abstract fetchStatusList(url: string): Promise<StatusList2021Credential | null>;
+  abstract fetchDelegationChain(id: string): Promise<DelegationRecord[]>;
   abstract fetch(url: string, options?: unknown): Promise<Response>;
 }
 

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -247,10 +247,39 @@ describe("SessionManager", () => {
   describe("setServerDid", () => {
     it("should include serverDid in session when set", async () => {
       manager.setServerDid("did:web:example.com:server");
-      const request = makeRequest();
+      const request = makeRequest({ audience: "did:web:example.com:server" });
       const { session } = await manager.validateHandshake(request);
 
       expect(session?.serverDid).toBe("did:web:example.com:server");
+    });
+  });
+
+  describe("Audience validation", () => {
+    it("should reject handshake when audience doesn't match serverDid", async () => {
+      const sm = makeSessionManager({ serverDid: "did:web:example.com:server" });
+      const request = makeRequest({ audience: "did:web:other.com:server" });
+      const result = await sm.validateHandshake(request);
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe("MCPI_AUDIENCE_MISMATCH");
+      expect(result.error?.message).toContain("Audience mismatch");
+    });
+
+    it("should accept handshake when audience matches serverDid", async () => {
+      const sm = makeSessionManager({ serverDid: "did:web:example.com:server" });
+      const request = makeRequest({ audience: "did:web:example.com:server" });
+      const result = await sm.validateHandshake(request);
+
+      expect(result.success).toBe(true);
+      expect(result.session?.audience).toBe("did:web:example.com:server");
+    });
+
+    it("should accept handshake when serverDid is not configured (backward compat)", async () => {
+      const sm = makeSessionManager(); // No serverDid configured
+      const request = makeRequest({ audience: "any-audience" });
+      const result = await sm.validateHandshake(request);
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -69,6 +69,17 @@ export class SessionManager {
     this.config.serverDid = serverDid;
   }
 
+  /**
+   * Validate an MCP-I handshake request and create a session.
+   *
+   * Performs the following checks:
+   * - Timestamp within acceptable skew window
+   * - Audience matches server DID (if configured)
+   * - Nonce not previously used (replay protection)
+   *
+   * @param request - The handshake request containing nonce, audience, timestamp, and optional agentDid
+   * @returns Result object with success flag, session on success, or error details on failure
+   */
   async validateHandshake(request: HandshakeRequest): Promise<HandshakeResult> {
     try {
       const now = Math.floor(Date.now() / 1000);
@@ -81,6 +92,17 @@ export class SessionManager {
             code: 'XMCP_I_EHANDSHAKE',
             message: `Timestamp outside acceptable range (±${this.config.timestampSkewSeconds}s)`,
             remediation: `Check NTP sync on client and server. Current server time: ${now}, received: ${request.timestamp}, diff: ${timeDiff}s. Adjust timestampSkewSeconds if needed.`,
+          },
+        };
+      }
+
+      // Validate audience matches this server's DID (SPEC.md §4 MUST)
+      if (this.config.serverDid && request.audience !== this.config.serverDid) {
+        return {
+          success: false,
+          error: {
+            code: 'MCPI_AUDIENCE_MISMATCH',
+            message: `Audience mismatch: expected ${this.config.serverDid}, got ${request.audience}`,
           },
         };
       }
@@ -138,6 +160,16 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Retrieve a session by ID, checking for expiration.
+   *
+   * Updates lastActivity timestamp on successful retrieval (sliding window expiry).
+   * Returns null if session doesn't exist, has exceeded idle TTL, or has exceeded
+   * absolute lifetime (if configured).
+   *
+   * @param sessionId - The session ID (e.g., "mcpi_...")
+   * @returns Session context if valid, null if expired or not found
+   */
   async getSession(sessionId: string): Promise<SessionContext | null> {
     const session = this.sessions.get(sessionId);
     if (!session) return null;

--- a/src/utils/ed25519-constants.ts
+++ b/src/utils/ed25519-constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Ed25519 Key Format Constants
+ *
+ * DER-encoded headers for Ed25519 key formats per RFC 8410 and RFC 5958.
+ */
+
+/**
+ * DER-encoded PKCS#8 header for Ed25519 private keys (RFC 8410 §7, RFC 5958).
+ * Prepended to the 32-byte Ed25519 seed to form a valid PKCS#8 private key.
+ */
+export const ED25519_PKCS8_DER_HEADER = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05,
+  0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+/**
+ * DER-encoded SPKI header for Ed25519 public keys (RFC 8410 §4).
+ * The 32-byte public key follows after this header.
+ */
+export const ED25519_SPKI_DER_HEADER_LENGTH = 12;
+
+/** Ed25519 raw key size in bytes */
+export const ED25519_KEY_SIZE = 32;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Utility exports
+ */
+
+export {
+  ED25519_PKCS8_DER_HEADER,
+  ED25519_SPKI_DER_HEADER_LENGTH,
+  ED25519_KEY_SIZE,
+} from './ed25519-constants.js';


### PR DESCRIPTION
## Summary

Addresses all remaining review feedback. Targets 10/10 across code quality, architecture, spec quality, and security posture.

## Security Fixes
- **Audience validation** — `SessionManager.validateHandshake()` now enforces `request.audience === serverDid` per SPEC.md §4 MUST
- **Verifier silent-pass** — `DelegationCredentialVerifier` no longer returns `valid: true` without a resolver; missing resolver = `valid: false`
- **Google Charts removed** — external Google dependency removed from auth handshake flow

## Architecture
- **FetchProvider typed** — `resolveDID` → `Promise<DIDDocument | null>`, `fetchStatusList` → `Promise<StatusList2021Credential | null>`
- **Bounded cache** — `DelegationCredentialVerifier` supports `maxCacheSize` (default 1000) with FIFO eviction
- **`console.error` → `logger.error`** — last remaining violation in `proof/verifier.ts`
- **Middleware state warning** — JSDoc documents single-process-only limitation
- **Error strategy documented** — validation returns result objects, construction throws, resolution returns null

## Code Quality
- **`ED25519_PKCS8_DER_HEADER`** — magic bytes extracted to `src/utils/ed25519-constants.ts` with RFC 8410 reference
- **DRY key conversion** — `ProofGenerator` uses `base64.ts` utilities, no more manual loops
- **Verification pipeline extracted** — shared steps in `ProofVerifier` deduplicated
- **JSDoc on all core public APIs** — `generateProof`, `validateHandshake`, `createAndIssueDelegation`, `verify`, `buildOutboundDelegationHeaders`, `verifyOrHints`
- **Test `as any` removed** — `TestClockProvider`/`TestFetchProvider` extend abstract base classes properly

## Spec (892 lines)
- **RFC 2119** — conformance declaration added after Abstract
- **Privacy Considerations** — DID correlation, session linkability, delegation disclosure, proof retention/GDPR
- **Version Negotiation** — handshake version fields, rejection rules, compatibility
- **Transport Binding** — stdio/SSE/HTTP Streamable mapping, `_mcpi_handshake` and `_meta` clarified
- **Appendix C: Test Vectors** — SHA-256 canonical hash, did:key derivation, JWS structure with computed values

## JSON Schemas (`schemas/`)
Five language-neutral JSON Schema files for all wire formats: HandshakeRequest, HandshakeResponse, DelegationCredential, DetachedProof, well-known/mcpi

## Tests
591 passing across 26 test files