### PR TITLE
fix: update CoC contact and correct schema $id URLs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **dylan.hobbs@vouched.id**. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -67,7 +67,7 @@ except ValidationError as e:
 All schemas use JSON Schema draft 2020-12 and are published at:
 
 ```
-https://schema.modelcontextprotocol-identity.io/mcpi/{schema-name}.json
+https://schema.modelcontextprotocol-identity.io/xmcp-i/{category}/{schema-name}.v1.0.0.json
 ```
 
 Schemas can reference each other using `$ref`. For example, the delegation credential schema references shared definitions for constraints and proof structures.

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/delegation-credential.json",
+  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation-credential.v1.0.0.json",
   "title": "MCP-I Delegation Credential",
   "description": "W3C Verifiable Credential containing an MCP-I delegation with CRISP constraints.",
   "type": "object",

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/detached-proof.json",
+  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/proof/detached-proof.v1.0.0.json",
   "title": "MCP-I Detached Proof",
   "description": "Cryptographic proof binding an MCP tool request/response pair to an agent's identity and session context.",
   "type": "object",

--- a/schemas/handshake-request.json
+++ b/schemas/handshake-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/handshake-request.json",
+  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/handshake/handshake-request.v1.0.0.json",
   "title": "MCP-I Handshake Request",
   "description": "Client-initiated handshake request to establish an MCP-I session with nonce-based replay protection.",
   "type": "object",

--- a/schemas/handshake-response.json
+++ b/schemas/handshake-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/handshake-response.json",
+  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/handshake/handshake-response.v1.0.0.json",
   "title": "MCP-I Handshake Response",
   "description": "Server response to a successful handshake request, establishing session context.",
   "type": "object",

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/mcpi/well-known-mcpi.json",
+  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/discovery/well-known-mcpi.v1.0.0.json",
   "title": "MCP-I Discovery Document",
   "description": "Well-known discovery document served at /.well-known/mcpi for MCP-I service discovery.",
   "type": "object",


### PR DESCRIPTION
- Replace [INSERT CONTACT METHOD] placeholder in CODE_OF_CONDUCT.md with dylan.hobbs@vouched.id
- Update all schema $id URLs from /mcpi/{name}.json to the correct /xmcp-i/{category}/{name}.v1.0.0.json pattern that resolves on schema.modelcontextprotocol-identity.io

## Description


## Spec Impact

<!-- Which sections of SPEC.md are affected, if any? -->


## Checklist

- [ ] Tests pass (`npm test`)
- [ ] DCO signed (`git commit -s`)
- [ ] Spec impact noted
- [ ] CHANGELOG.md updated if applicable
