### PR TITLE
fix: harden delegation middleware verification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,7 @@ export {
 export {
   createMCPIMiddleware,
   type MCPIConfig,
+  type MCPIDelegationConfig,
   type MCPIIdentityConfig,
   type MCPIMiddleware,
   type MCPIToolDefinition,

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -1,12 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { createMCPIMiddleware } from '../with-mcpi.js';
+import {
+  createMCPIMiddleware,
+  type MCPIDelegationConfig,
+} from '../with-mcpi.js';
 import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+import { MockFetchProvider } from '../../__tests__/utils/mock-providers.js';
 import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
 import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
-import type { Proof } from '../../types/protocol.js';
-import { base64urlEncodeFromBytes } from '../../utils/base64.js';
+import type {
+  CredentialStatus,
+  DelegationCredential,
+  Proof,
+} from '../../types/protocol.js';
+import {
+  base64ToBytes,
+  base64urlEncodeFromBytes,
+} from '../../utils/base64.js';
 
-async function createTestMiddleware(options?: { autoSession?: boolean }) {
+async function createTestMiddleware(options?: {
+  autoSession?: boolean;
+  delegation?: MCPIDelegationConfig;
+}) {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
@@ -16,12 +30,76 @@ async function createTestMiddleware(options?: { autoSession?: boolean }) {
     {
       identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
       session: { sessionTtlMinutes: 60 },
+      delegation: options?.delegation,
       autoSession: options?.autoSession,
     },
     crypto,
   );
 
   return { middleware, did };
+}
+
+async function createDelegationIssuer(options?: { did?: string; kid?: string }) {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = options?.did ?? generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = options?.kid ?? `${did}#keys-1`;
+
+  const signingFn = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kidArg: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, keyPair.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kidArg,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => did,
+      getKeyId: () => kid,
+      getPrivateKey: () => keyPair.privateKey,
+    },
+    signingFn,
+  );
+
+  return { crypto, keyPair, did, kid, issuer };
+}
+
+async function issueDelegationVC(options?: {
+  issuer?: Awaited<ReturnType<typeof createDelegationIssuer>>;
+  scopes?: string[];
+  audience?: string | string[];
+  parentId?: string;
+  credentialStatus?: CredentialStatus;
+  subjectDid?: string;
+}): Promise<DelegationCredential> {
+  const issuerIdentity = options?.issuer ?? await createDelegationIssuer();
+
+  return issuerIdentity.issuer.createAndIssueDelegation(
+    {
+      id: `test-delegation-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      issuerDid: issuerIdentity.did,
+      subjectDid: options?.subjectDid ?? issuerIdentity.did,
+      parentId: options?.parentId,
+      constraints: {
+        scopes: options?.scopes ?? [],
+        ...(options?.audience !== undefined && { audience: options.audience }),
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+    },
+    ...(options?.credentialStatus
+      ? [{ credentialStatus: options.credentialStatus }]
+      : []),
+  );
 }
 
 describe('createMCPIMiddleware', () => {
@@ -120,49 +198,6 @@ describe('createMCPIMiddleware', () => {
   });
 
   describe('wrapWithDelegation', () => {
-    async function issueDelegationVC(scopes: string[]) {
-      const crypto = new NodeCryptoProvider();
-      const keyPair = await crypto.generateKeyPair();
-      const did = generateDidKeyFromBase64(keyPair.publicKey);
-      const kid = `${did}#keys-1`;
-
-      const signingFn = async (
-        canonicalVC: string,
-        _issuerDid: string,
-        kidArg: string,
-      ): Promise<Proof> => {
-        const data = new TextEncoder().encode(canonicalVC);
-        const sigBytes = await crypto.sign(data, keyPair.privateKey);
-        const proofValue = base64urlEncodeFromBytes(sigBytes);
-        return {
-          type: 'Ed25519Signature2020',
-          created: new Date().toISOString(),
-          verificationMethod: kidArg,
-          proofPurpose: 'assertionMethod',
-          proofValue,
-        };
-      };
-
-      const issuer = new DelegationCredentialIssuer(
-        {
-          getDid: () => did,
-          getKeyId: () => kid,
-          getPrivateKey: () => keyPair.privateKey,
-        },
-        signingFn,
-      );
-
-      return issuer.createAndIssueDelegation({
-        id: `test-delegation-${Date.now()}`,
-        issuerDid: did,
-        subjectDid: did,
-        constraints: {
-          scopes,
-          notAfter: Math.floor(Date.now() / 1000) + 3600,
-        },
-      });
-    }
-
     it('should return needs_authorization when no _mcpi_delegation arg is provided', async () => {
       const { middleware: mcpi } = await createTestMiddleware();
 
@@ -185,7 +220,7 @@ describe('createMCPIMiddleware', () => {
 
     it('should reject when VC has wrong scope', async () => {
       const { middleware: mcpi } = await createTestMiddleware();
-      const vc = await issueDelegationVC(['wrong:scope']);
+      const vc = await issueDelegationVC({ scopes: ['wrong:scope'] });
 
       const handler = mcpi.wrapWithDelegation(
         'my-tool',
@@ -202,7 +237,7 @@ describe('createMCPIMiddleware', () => {
 
     it('should accept and call handler when VC has correct scope and valid signature', async () => {
       const { middleware: mcpi } = await createTestMiddleware();
-      const vc = await issueDelegationVC(['test:scope', 'other:scope']);
+      const vc = await issueDelegationVC({ scopes: ['test:scope', 'other:scope'] });
 
       const handler = mcpi.wrapWithDelegation(
         'my-tool',
@@ -218,6 +253,164 @@ describe('createMCPIMiddleware', () => {
       const parsed = JSON.parse(result.content[0].text.replace('Called: ', ''));
       // _mcpi_delegation should be stripped from args
       expect(parsed['_mcpi_delegation']).toBeUndefined();
+      expect(parsed['name']).toBe('DIF');
+    });
+
+    it('should reject credentials with credentialStatus when no status list resolver is configured', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const vc = await issueDelegationVC({
+        scopes: ['test:scope'],
+        credentialStatus: {
+          id: 'https://status.example.com/revocation/v1#0',
+          type: 'StatusList2021Entry',
+          statusPurpose: 'revocation',
+          statusListIndex: '0',
+          statusListCredential: 'https://status.example.com/revocation/v1',
+        },
+      });
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('statusListResolver');
+    });
+
+    it('should reject delegations whose audience does not include the server DID', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const vc = await issueDelegationVC({
+        scopes: ['test:scope'],
+        audience: 'did:web:other.example.com',
+      });
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('audience does not include server DID');
+    });
+
+    it('should reject parent delegations when no chain resolver is configured', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const vc = await issueDelegationVC({
+        scopes: ['test:scope'],
+        parentId: 'parent-delegation',
+      });
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('resolveDelegationChain');
+    });
+
+    it('should reject delegation chains that widen parent scopes', async () => {
+      const parentIssuer = await createDelegationIssuer();
+      const childIssuer = await createDelegationIssuer();
+      const leafSubject = (await createDelegationIssuer()).did;
+      const parentVc = await issueDelegationVC({
+        issuer: parentIssuer,
+        scopes: ['test:scope'],
+        subjectDid: childIssuer.did,
+      });
+      const childVc = await issueDelegationVC({
+        issuer: childIssuer,
+        scopes: ['test:scope', 'admin:scope'],
+        parentId: parentVc.credentialSubject.delegation.id,
+        subjectDid: leafSubject,
+      });
+
+      const { middleware: mcpi } = await createTestMiddleware({
+        delegation: {
+          resolveDelegationChain: async () => [parentVc],
+        },
+      });
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: childVc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('widens scopes');
+    });
+
+    it('should accept did:web issuers when a fetch-backed resolver is available', async () => {
+      const did = 'did:web:issuer.example.com';
+      const kid = `${did}#key-1`;
+      const issuer = await createDelegationIssuer({ did, kid });
+      const vc = await issueDelegationVC({
+        issuer,
+        scopes: ['test:scope'],
+      });
+      const fetchProvider = new MockFetchProvider();
+      fetchProvider.fetch = async () =>
+        new Response(
+          JSON.stringify({
+            id: did,
+            verificationMethod: [
+              {
+                id: kid,
+                type: 'Ed25519VerificationKey2020',
+                controller: did,
+                publicKeyJwk: {
+                  kty: 'OKP',
+                  crv: 'Ed25519',
+                  x: base64urlEncodeFromBytes(base64ToBytes(issuer.keyPair.publicKey)),
+                },
+              },
+            ],
+            authentication: [kid],
+            assertionMethod: [kid],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+
+      const { middleware: mcpi } = await createTestMiddleware({
+        delegation: { fetchProvider },
+      });
+
+      const handler = mcpi.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async (args) => ({
+          content: [{ type: 'text', text: `Called: ${JSON.stringify(args)}` }],
+        }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc, name: 'DIF' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text.replace('Called: ', ''));
       expect(parsed['name']).toBe('DIF');
     });
   });

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -7,6 +7,7 @@
 export {
   createMCPIMiddleware,
   type MCPIConfig,
+  type MCPIDelegationConfig,
   type MCPIIdentityConfig,
   type MCPIMiddleware,
   type MCPIToolDefinition,

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -10,7 +10,10 @@
  *   registerToolWithProof(server, myToolDef, myHandler);
  */
 
-import type { CryptoProvider } from "../providers/base.js";
+import {
+  type CryptoProvider,
+  FetchProvider,
+} from "../providers/base.js";
 import {
   SessionManager,
   type SessionConfig,
@@ -25,12 +28,18 @@ import {
 import { validateHandshakeFormat } from "../session/manager.js";
 import {
   DelegationCredentialVerifier,
+  type DIDResolver,
   type SignatureVerificationFunction,
+  type StatusListResolver,
 } from "../delegation/vc-verifier.js";
 import { createDidKeyResolver } from "../delegation/did-key-resolver.js";
+import { createDidWebResolver } from "../delegation/did-web-resolver.js";
+import { verifyDelegationAudience } from "../delegation/audience-validator.js";
 import {
   createNeedsAuthorizationError,
+  extractDelegationFromVC,
   type DelegationCredential,
+  type DelegationRecord,
 } from "../types/protocol.js";
 import { logger } from "../logging/index.js";
 import { canonicalizeJSON } from "../delegation/utils.js";
@@ -43,11 +52,38 @@ export interface MCPIIdentityConfig {
   publicKey: string;
 }
 
+export interface MCPIDelegationConfig {
+  /**
+   * Optional custom DID resolver. If it returns null, middleware falls back to
+   * built-in did:key resolution and fetch-backed did:web resolution.
+   */
+  didResolver?: DIDResolver;
+  /**
+   * Optional fetch provider used for did:web resolution.
+   * If omitted, middleware falls back to the runtime global fetch when available.
+   */
+  fetchProvider?: FetchProvider;
+  /**
+   * Resolver for StatusList2021 checks. Credentials with credentialStatus are
+   * rejected when no resolver is configured.
+   */
+  statusListResolver?: StatusListResolver;
+  /**
+   * Resolve ancestor credentials for a delegated chain. The returned array may
+   * contain only ancestors (root -> parent) or the full chain (root -> leaf).
+   */
+  resolveDelegationChain?: (
+    leafCredential: DelegationCredential,
+  ) => Promise<DelegationCredential[]>;
+}
+
 export interface MCPIConfig {
-  /** Agent identity (did:key + key material) */
+  /** Agent identity (DID + key material) */
   identity: MCPIIdentityConfig;
   /** Session configuration overrides */
   session?: Omit<SessionConfig, "nonceCache">;
+  /** Delegation verification overrides */
+  delegation?: MCPIDelegationConfig;
   /**
    * When true, automatically creates a session on the first tool call
    * if no session exists. Useful for demos and development where
@@ -136,6 +172,73 @@ export interface MCPIMiddleware {
   ): MCPIToolHandler;
 }
 
+class RuntimeFetchProvider extends FetchProvider {
+  async resolveDID(): Promise<null> {
+    return null;
+  }
+
+  async fetchStatusList(): Promise<null> {
+    return null;
+  }
+
+  async fetchDelegationChain(): Promise<DelegationRecord[]> {
+    return [];
+  }
+
+  async fetch(url: string, options?: unknown): Promise<Response> {
+    if (typeof globalThis.fetch !== "function") {
+      throw new Error("Global fetch is not available in this runtime");
+    }
+
+    return globalThis.fetch(url, options as RequestInit);
+  }
+}
+
+function getDelegationScopes(credential: DelegationCredential): string[] {
+  const scopes = new Set<string>();
+
+  for (const scope of credential.credentialSubject.delegation.scopes ?? []) {
+    scopes.add(scope);
+  }
+
+  for (const scope of credential.credentialSubject.delegation.constraints.scopes ?? []) {
+    scopes.add(scope);
+  }
+
+  return Array.from(scopes);
+}
+
+function validateScopeAttenuation(
+  parentCredential: DelegationCredential,
+  childCredential: DelegationCredential,
+): { valid: boolean; reason?: string } {
+  const parentScopes = getDelegationScopes(parentCredential);
+  const childScopes = getDelegationScopes(childCredential);
+  const childDelegation = childCredential.credentialSubject.delegation;
+
+  if (parentScopes.length === 0) {
+    return { valid: true };
+  }
+
+  if (childScopes.length === 0) {
+    return {
+      valid: false,
+      reason: `Delegation ${childDelegation.id} omits scopes required to prove attenuation from parent ${parentCredential.credentialSubject.delegation.id}`,
+    };
+  }
+
+  const parentScopeSet = new Set(parentScopes);
+  const widenedScopes = childScopes.filter((scope) => !parentScopeSet.has(scope));
+  if (widenedScopes.length > 0) {
+    return {
+      valid: false,
+      reason: `Delegation ${childDelegation.id} widens scopes beyond parent ${parentCredential.credentialSubject.delegation.id}: ${widenedScopes.join(", ")}`,
+    };
+  }
+
+  return { valid: true };
+}
+
 /**
  * Create MCP-I middleware for a standard MCP SDK Server.
  *
@@ -166,6 +269,7 @@ export function createMCPIMiddleware(
   });
 
   const proofGenerator = new ProofGenerator(identity, cryptoProvider);
+  const delegationConfig = config.delegation;
 
   // Session map: sessionId → last nonce (for proof generation)
   const sessionNonces = new Map<string, string>();
@@ -326,7 +430,36 @@ export function createMCPIMiddleware(
     config: { scopeId: string; consentUrl: string },
     handler: MCPIToolHandler,
   ): MCPIToolHandler {
-    const didResolver = createDidKeyResolver();
+    const didKeyResolver = createDidKeyResolver();
+    const fetchProvider =
+      delegationConfig?.fetchProvider ??
+      (typeof globalThis.fetch === "function"
+        ? new RuntimeFetchProvider()
+        : undefined);
+    const didWebResolver = fetchProvider
+      ? createDidWebResolver(fetchProvider)
+      : undefined;
+    const didResolver: DIDResolver = {
+      async resolve(did: string) {
+        const customResolver = delegationConfig?.didResolver;
+        if (customResolver) {
+          const resolved = await customResolver.resolve(did);
+          if (resolved) {
+            return resolved;
+          }
+        }
+
+        if (did.startsWith("did:key:")) {
+          return didKeyResolver.resolve(did);
+        }
+
+        if (did.startsWith("did:web:")) {
+          return didWebResolver?.resolve(did) ?? null;
+        }
+
+        return null;
+      },
+    };
 
     const signatureVerifier: SignatureVerificationFunction = async (
       vc: DelegationCredential,
@@ -374,7 +507,157 @@ export function createMCPIMiddleware(
     const verifier = new DelegationCredentialVerifier({
       didResolver,
       signatureVerifier,
+      statusListResolver: delegationConfig?.statusListResolver,
     });
+
+    const buildDelegationErrorResponse = (
+      error: string,
+      reason: string,
+    ): Awaited<ReturnType<MCPIToolHandler>> => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ error, reason }),
+        },
+      ],
+      isError: true,
+    });
+
+    const validateDelegationChain = async (
+      leafCredential: DelegationCredential,
+    ): Promise<{ valid: boolean; reason?: string }> => {
+      const leafDelegation = extractDelegationFromVC(leafCredential);
+      let chain: DelegationCredential[] = [leafCredential];
+
+      if (leafDelegation.parentId) {
+        if (!delegationConfig?.resolveDelegationChain) {
+          return {
+            valid: false,
+            reason: `Delegation ${leafDelegation.id} references parent ${leafDelegation.parentId} but no resolveDelegationChain handler is configured`,
+          };
+        }
+
+        let resolvedChain: DelegationCredential[];
+        try {
+          resolvedChain =
+            await delegationConfig.resolveDelegationChain(leafCredential);
+        } catch (error) {
+          return {
+            valid: false,
+            reason: `Failed to resolve delegation chain: ${error instanceof Error ? error.message : "Unknown error"}`,
+          };
+        }
+
+        if (resolvedChain.length === 0) {
+          return {
+            valid: false,
+            reason: `Delegation ${leafDelegation.id} references parent ${leafDelegation.parentId} but the resolved chain is empty`,
+          };
+        }
+
+        const leafIndex = resolvedChain.findIndex(
+          (credential) =>
+            credential.credentialSubject.delegation.id === leafDelegation.id,
+        );
+        if (leafIndex !== -1 && leafIndex !== resolvedChain.length - 1) {
+          return {
+            valid: false,
+            reason: `Resolved delegation chain for ${leafDelegation.id} must end with the leaf credential`,
+          };
+        }
+
+        chain =
+          leafIndex === -1 ? [...resolvedChain, leafCredential] : resolvedChain;
+      }
+
+      const seenIds = new Set<string>();
+      let previousDelegation: DelegationRecord | undefined;
+      let previousCredential: DelegationCredential | undefined;
+
+      for (const credential of chain) {
+        const delegation = extractDelegationFromVC(credential);
+
+        if (seenIds.has(delegation.id)) {
+          return {
+            valid: false,
+            reason: `Delegation chain contains a circular reference at ${delegation.id}`,
+          };
+        }
+        seenIds.add(delegation.id);
+
+        if (credential.credentialStatus && !delegationConfig?.statusListResolver) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} has credentialStatus but no statusListResolver is configured`,
+          };
+        }
+
+        const credentialVerification = await verifier.verifyDelegationCredential(
+          credential,
+        );
+        if (!credentialVerification.valid) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} invalid: ${credentialVerification.reason}`,
+          };
+        }
+
+        if (!verifyDelegationAudience(delegation, identity.did)) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} audience does not include server DID ${identity.did}`,
+          };
+        }
+
+        if (!previousDelegation || !previousCredential) {
+          if (delegation.parentId) {
+            return {
+              valid: false,
+              reason: `Resolved delegation chain is incomplete: root delegation ${delegation.id} still references parent ${delegation.parentId}`,
+            };
+          }
+
+          previousDelegation = delegation;
+          previousCredential = credential;
+          continue;
+        }
+
+        if (delegation.parentId !== previousDelegation.id) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} references parent ${delegation.parentId} but expected ${previousDelegation.id}`,
+          };
+        }
+
+        if (delegation.issuerDid !== previousDelegation.subjectDid) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} issued by ${delegation.issuerDid} but parent subject is ${previousDelegation.subjectDid}`,
+          };
+        }
+
+        const scopeValidation = validateScopeAttenuation(
+          previousCredential,
+          credential,
+        );
+        if (!scopeValidation.valid) {
+          return scopeValidation;
+        }
+
+        previousDelegation = delegation;
+        previousCredential = credential;
+      }
+
+      const finalDelegation = extractDelegationFromVC(chain[chain.length - 1]!);
+      if (finalDelegation.id !== leafDelegation.id) {
+        return {
+          valid: false,
+          reason: `Resolved delegation chain ended at ${finalDelegation.id} instead of leaf ${leafDelegation.id}`,
+        };
+      }
+
+      return { valid: true };
+    };
 
     return async (
       args: Record<string, unknown>,
@@ -410,46 +693,28 @@ export function createMCPIMiddleware(
         };
       }
 
-      // Verify the delegation VC
       const vc = delegationArg as DelegationCredential;
-      const verificationResult = await verifier.verifyDelegationCredential(vc);
+      const verificationResult = await validateDelegationChain(vc);
 
       if (!verificationResult.valid) {
         logger.warn(
           `[mcpi] Delegation verification failed for "${toolName}": ${verificationResult.reason}`,
         );
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                error: "delegation_invalid",
-                reason: verificationResult.reason,
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return buildDelegationErrorResponse(
+          "delegation_invalid",
+          verificationResult.reason ?? "Unknown delegation validation error",
+        );
       }
 
-      // Check that required scope is present in credentialSubject.delegation.scopes
-      const scopes = vc.credentialSubject.delegation.scopes;
-      if (!scopes || !scopes.includes(config.scopeId)) {
+      const scopes = getDelegationScopes(vc);
+      if (!scopes.includes(config.scopeId)) {
         logger.warn(
           `[mcpi] Delegation missing required scope "${config.scopeId}" for "${toolName}"`,
         );
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                error: "delegation_scope_missing",
-                reason: `Required scope "${config.scopeId}" not in delegation scopes`,
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return buildDelegationErrorResponse(
+          "delegation_scope_missing",
+          `Required scope "${config.scopeId}" not in delegation scopes`,
+        );
       }
 
       // Strip _mcpi_delegation from args before passing to handler


### PR DESCRIPTION
Reject unchecked status-list and parent-chain credentials while enforcing audience validation and did:web verification in the default middleware path.


## Description


## Spec Impact

<!-- Which sections of SPEC.md are affected, if any? -->


## Checklist

- [x] Tests pass (`npm test`)
- [ ] DCO signed (`git commit -s`)
- [ ] Spec impact noted
- [x] CHANGELOG.md updated if applicable
