### PR TITLE
feat: withMCPI() — 2-line McpServer integration + NodeCryptoProvider

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in @mcpi/core
+about: Report a bug in @mcp-i/core
 labels: bug
 ---
 
@@ -13,7 +13,7 @@ labels: bug
 **Expected behavior**
 
 
-**Environment** (Node version, OS, @mcpi/core version)
+**Environment** (Node version, OS, @mcp-i/core version)
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/conformance_submission.md
+++ b/.github/ISSUE_TEMPLATE/conformance_submission.md
@@ -1,6 +1,6 @@
 ---
 name: Conformance Submission
-about: Submit conformance test results for a @mcpi/core implementation
+about: Submit conformance test results for a @mcp-i/core implementation
 labels: conformance
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to @mcpi/core will be documented here.
+All notable changes to @mcp-i/core will be documented here.
 
 Format: https://keepachangelog.com/en/1.0.0/
 Versioning: https://semver.org/spec/v2.0.0.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to @mcpi/core
+# Contributing to @mcp-i/core
 
-Thank you for your interest in contributing to `@mcpi/core` — the MCP-I protocol reference implementation submitted to the [DIF Trust and Authorization for AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/agent-and-authorization.html).
+Thank you for your interest in contributing to `@mcp-i/core` — the MCP-I protocol reference implementation submitted to the [DIF Trust and Authorization for AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/agent-and-authorization.html).
 
 All contributions are welcome: bug fixes, protocol clarifications, new examples, test improvements, and documentation.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spec: [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.i
 | **proof** | Platform-agnostic proof generation (`ProofGenerator`) and server-side verification (`ProofVerifier`) — JCS canonicalization, SHA-256 hashing, Ed25519 JWS signing/verification |
 | **session** | Handshake validation and session management (`SessionManager`) with nonce replay prevention |
 | **auth** | Authorization handshake orchestration (`verifyOrHints`) — checks delegation and returns authorization hints |
-| **middleware** | MCP SDK integration (`createMCPIMiddleware`) — adds identity, sessions, and proof generation to a standard `@modelcontextprotocol/sdk` Server |
+| **middleware** | MCP SDK integration — `withMCPI(server, { crypto })` adds identity, sessions, and auto-proof to any `McpServer` in one call. Lower-level `createMCPIMiddleware` available for the `Server` API. |
 | **providers** | Abstract base classes (`CryptoProvider`, `StorageProvider`, etc.) and in-memory implementations for testing |
 | **types** | Pure TypeScript interfaces for all protocol types — zero runtime dependencies |
 
@@ -55,7 +55,7 @@ npm install @mcpi/core
 
 ## Delegation Hardening Compatibility
 
-`createMCPIMiddleware` now enforces strict delegation-chain and status-list checks by default.
+MCP-I now enforces strict delegation-chain and status-list checks by default.
 
 - Credentials with `parentId` require `delegation.resolveDelegationChain`.
 - Credentials with `credentialStatus` require `delegation.statusListResolver`.
@@ -63,15 +63,12 @@ npm install @mcpi/core
 For temporary migration support in legacy integrations, you can opt in to compatibility mode:
 
 ```typescript
-const mcpi = createMCPIMiddleware(
-  {
-    identity,
-    delegation: {
-      allowLegacyUnsafeDelegation: true, // temporary compatibility escape hatch
-    },
+await withMCPI(server, {
+  crypto: new NodeCryptoProvider(),
+  delegation: {
+    allowLegacyUnsafeDelegation: true, // temporary compatibility escape hatch
   },
-  cryptoProvider
-);
+});
 ```
 
 Compatibility mode weakens security guarantees and should only be used during migration.
@@ -316,23 +313,47 @@ console.log('Agent DID:', proof.meta.did);
 
 ---
 
-## Example 4 — MCP Server with Middleware
+## Example 4 — MCP Server with Middleware (`withMCPI`)
+
+The recommended way to add MCP-I to any `McpServer`-based server:
 
 ```typescript
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { createMCPIMiddleware, CryptoProvider } from '@mcpi/core';
+import { withMCPI, CryptoProvider } from '@mcpi/core';
+import { z } from 'zod';
 
 // ... (NodeCryptoProvider as above)
 
-const crypto = new NodeCryptoProvider();
-const keys = await crypto.generateKeyPair();
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
 
-const mcpi = createMCPIMiddleware({
-  identity: { did: 'did:key:z...', kid: 'did:key:z...#key-1', ...keys },
-  session: { sessionTtlMinutes: 60 },
-}, crypto);
+// One call: auto-generates identity, registers handshake, auto-proofs all tools
+await withMCPI(server, { crypto: new NodeCryptoProvider() });
+
+// Register tools normally — proofs are attached automatically
+server.registerTool(
+  'echo',
+  { description: 'Echo a message', inputSchema: { message: z.string() } },
+  async ({ message }) => ({ content: [{ type: 'text' as const, text: `Echo: ${message}` }] }),
+);
+
+await server.connect(new StdioServerTransport());
+```
+
+<details>
+<summary>Low-level Server API (advanced)</summary>
+
+For the low-level `Server` API with manual request handlers, use `createMCPIMiddleware` directly:
+
+```typescript
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { createMCPIMiddleware, generateIdentity } from '@mcpi/core';
+
+const crypto = new NodeCryptoProvider();
+const identity = await generateIdentity(crypto);
+
+const mcpi = createMCPIMiddleware({ identity, session: { sessionTtlMinutes: 60 } }, crypto);
 
 const echo = mcpi.wrapWithProof('echo', async (args) => ({
   content: [{ type: 'text', text: `Echo: ${args['message']}` }],
@@ -346,12 +367,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (req.params.name === '_mcpi_handshake') return mcpi.handleHandshake(req.params.arguments ?? {});
-  if (req.params.name === 'echo') return echo(req.params.arguments ?? {}, req.params.arguments?.['sessionId']);
+  if (req.params.name === 'echo') return echo(req.params.arguments ?? {});
   return { content: [{ type: 'text', text: 'Unknown tool' }], isError: true };
 });
 
 await server.connect(new StdioServerTransport());
 ```
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @mcpi/core
+# @mcp-i/core
 
 **MCP-I protocol reference implementation** — delegation, proof, and session for the Model Context Protocol Identity (MCP-I) standard.
 
@@ -48,7 +48,7 @@ For outbound delegation propagation (forwarding delegation context to downstream
 ## Installation
 
 ```bash
-npm install @mcpi/core
+npm install @mcp-i/core
 ```
 
 ---
@@ -97,7 +97,7 @@ import {
   DelegationCredentialIssuer,
   type DelegationIdentityProvider,
   type VCSigningFunction,
-} from '@mcpi/core';
+} from '@mcp-i/core';
 
 // Minimal Node.js CryptoProvider backed by node:crypto
 class NodeCryptoProvider extends CryptoProvider {
@@ -188,7 +188,7 @@ import {
   SessionManager,
   MemoryNonceCacheProvider,
   createHandshakeRequest,
-} from '@mcpi/core';
+} from '@mcp-i/core';
 
 // SessionManager only needs randomBytes() for session ID generation
 class NodeCryptoProvider extends CryptoProvider {
@@ -245,7 +245,7 @@ import {
   MemoryIdentityProvider,
   ProofGenerator,
   SessionManager,
-} from '@mcpi/core';
+} from '@mcp-i/core';
 
 class NodeCryptoProvider extends CryptoProvider {
   async generateKeyPair() {
@@ -320,7 +320,7 @@ The recommended way to add MCP-I to any `McpServer`-based server:
 ```typescript
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { withMCPI, CryptoProvider } from '@mcpi/core';
+import { withMCPI, CryptoProvider } from '@mcp-i/core';
 import { z } from 'zod';
 
 // ... (NodeCryptoProvider as above)
@@ -348,7 +348,7 @@ For the low-level `Server` API with manual request handlers, use `createMCPIMidd
 ```typescript
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { createMCPIMiddleware, generateIdentity } from '@mcpi/core';
+import { createMCPIMiddleware, generateIdentity } from '@mcp-i/core';
 
 const crypto = new NodeCryptoProvider();
 const identity = await generateIdentity(crypto);
@@ -381,7 +381,7 @@ await server.connect(new StdioServerTransport());
 ## Example 5 — Verify a Proof with DID:key Resolution
 
 ```typescript
-import { ProofVerifier, createDidKeyResolver, CryptoProvider } from '@mcpi/core';
+import { ProofVerifier, createDidKeyResolver, CryptoProvider } from '@mcp-i/core';
 
 // ... (NodeCryptoProvider with verify + hash)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ Reporters will be credited in release notes unless they prefer to remain anonymo
 
 ## Scope
 
-This policy covers the `@mcpi/core` npm package and this repository. It includes:
+This policy covers the `@mcp-i/core` npm package and this repository. It includes:
 - Cryptographic implementation errors (Ed25519, JWS, SHA-256)
 - Delegation verification bypasses
 - Session replay vulnerabilities

--- a/examples/brave-search-mcp-server/.gitignore
+++ b/examples/brave-search-mcp-server/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+.env
+.smithery

--- a/examples/brave-search-mcp-server/.prettierignore
+++ b/examples/brave-search-mcp-server/.prettierignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+*.d.ts
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Editor directories and files
+.vscode/
+.idea/
+
+# Package files
+package-lock.json
+yarn.lock

--- a/examples/brave-search-mcp-server/.prettierrc
+++ b/examples/brave-search-mcp-server/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/examples/brave-search-mcp-server/Dockerfile
+++ b/examples/brave-search-mcp-server/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:alpine@sha256:636c5bc8fa6a7a542bc99f25367777b0b3dd0db7d1ca3959d14137a1ac80bde2 AS builder
+
+RUN apk add --no-cache openssl=3.5.5-r0
+
+WORKDIR /app
+
+COPY ./package.json ./package.json
+COPY ./package-lock.json ./package-lock.json
+
+RUN npm ci --ignore-scripts
+
+COPY ./src ./src
+COPY ./tsconfig.json ./tsconfig.json
+
+RUN npm run build
+
+FROM node:alpine@sha256:636c5bc8fa6a7a542bc99f25367777b0b3dd0db7d1ca3959d14137a1ac80bde2 AS release
+
+RUN apk add --no-cache openssl=3.5.5-r0
+
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+RUN npm ci --ignore-scripts --omit-dev
+
+USER node
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/examples/brave-search-mcp-server/LICENSE
+++ b/examples/brave-search-mcp-server/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Anthropic, PBC
+Copyright (c) 2025 Brave Software, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/brave-search-mcp-server/README.md
+++ b/examples/brave-search-mcp-server/README.md
@@ -1,0 +1,345 @@
+# Brave Search MCP Server
+
+An MCP server implementation that integrates the Brave Search API, providing comprehensive search capabilities including web search, local business search, image search, video search, news search, and AI-powered summarization. This project supports both STDIO and HTTP transports, with STDIO as the default mode.
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/brave/brave-search-mcp-server)
+
+## Migration
+
+### 1.x to 2.x
+
+#### Default transport now STDIO
+
+To follow established MCP conventions, the server now defaults to STDIO. If you would like to continue using HTTP, you will need to set the `BRAVE_MCP_TRANSPORT` environment variable to `http`, or provide the runtime argument `--transport http` when launching the server.
+
+#### Response structure of `brave_image_search`
+
+Version 1.x of the MCP server would return base64-encoded image data along with image URLs. This dramatically slowed down the response, as well as consumed unnecessarily context in the session. Version 2.x removes the base64-encoded data, and returns a response object that more closely reflects the original Brave Search API response. The updated output schema is defined in [`src/tools/images/schemas/output.ts`](https://github.com/brave/brave-search-mcp-server/blob/main/src/tools/images/schemas/output.ts).
+
+## Tools
+
+### Web Search (`brave_web_search`)
+Performs comprehensive web searches with rich result types and advanced filtering options.
+
+**Parameters:**
+- `query` (string, required): Search terms (max 400 chars, 50 words)
+- `country` (string, optional): Country code (default: "US")
+- `search_lang` (string, optional): Search language (default: "en")
+- `ui_lang` (string, optional): UI language (default: "en-US")
+- `count` (number, optional): Results per page (1-20, default: 10)
+- `offset` (number, optional): Pagination offset (max 9, default: 0)
+- `safesearch` (string, optional): Content filtering ("off", "moderate", "strict", default: "moderate")
+- `freshness` (string, optional): Time filter ("pd", "pw", "pm", "py", or date range)
+- `text_decorations` (boolean, optional): Include highlighting markers (default: true)
+- `spellcheck` (boolean, optional): Enable spell checking (default: true)
+- `result_filter` (array, optional): Filter result types (default: ["web", "query"])
+- `goggles` (array, optional): Custom re-ranking definitions
+- `units` (string, optional): Measurement units ("metric" or "imperial")
+- `extra_snippets` (boolean, optional): Get additional excerpts (Pro plans only)
+- `summary` (boolean, optional): Enable summary key generation for AI summarization
+
+### Local Search (`brave_local_search`)
+Searches for local businesses and places with detailed information including ratings, hours, and AI-generated descriptions.
+
+**Parameters:**
+- Same as `brave_web_search` with automatic location filtering
+- Automatically includes "web" and "locations" in result_filter
+
+**Note:** Requires Pro plan for full local search capabilities. Falls back to web search otherwise.
+
+### Video Search (`brave_video_search`)
+Searches for videos with comprehensive metadata and thumbnail information.
+
+**Parameters:**
+- `query` (string, required): Search terms (max 400 chars, 50 words)
+- `country` (string, optional): Country code (default: "US")
+- `search_lang` (string, optional): Search language (default: "en")
+- `ui_lang` (string, optional): UI language (default: "en-US")
+- `count` (number, optional): Results per page (1-50, default: 20)
+- `offset` (number, optional): Pagination offset (max 9, default: 0)
+- `spellcheck` (boolean, optional): Enable spell checking (default: true)
+- `safesearch` (string, optional): Content filtering ("off", "moderate", "strict", default: "moderate")
+- `freshness` (string, optional): Time filter ("pd", "pw", "pm", "py", or date range)
+
+### Image Search (`brave_image_search`)
+Searches for images with automatic fetching and base64 encoding for direct display.
+
+**Parameters:**
+- `query` (string, required): Search terms (max 400 chars, 50 words)
+- `country` (string, optional): Country code (default: "US")
+- `search_lang` (string, optional): Search language (default: "en")
+- `count` (number, optional): Results per page (1-200, default: 50)
+- `safesearch` (string, optional): Content filtering ("off", "strict", default: "strict")
+- `spellcheck` (boolean, optional): Enable spell checking (default: true)
+
+### News Search (`brave_news_search`)
+Searches for current news articles with freshness controls and breaking news indicators.
+
+**Parameters:**
+- `query` (string, required): Search terms (max 400 chars, 50 words)
+- `country` (string, optional): Country code (default: "US")
+- `search_lang` (string, optional): Search language (default: "en")
+- `ui_lang` (string, optional): UI language (default: "en-US")
+- `count` (number, optional): Results per page (1-50, default: 20)
+- `offset` (number, optional): Pagination offset (max 9, default: 0)
+- `spellcheck` (boolean, optional): Enable spell checking (default: true)
+- `safesearch` (string, optional): Content filtering ("off", "moderate", "strict", default: "moderate")
+- `freshness` (string, optional): Time filter (default: "pd" for last 24 hours)
+- `extra_snippets` (boolean, optional): Get additional excerpts (Pro plans only)
+- `goggles` (array, optional): Custom re-ranking definitions
+
+### Summarizer Search (`brave_summarizer`)
+Generates AI-powered summaries from web search results using Brave's summarization API.
+
+**Parameters:**
+- `key` (string, required): Summary key from web search results (use `summary: true` in web search)
+- `entity_info` (boolean, optional): Include entity information (default: false)
+- `inline_references` (boolean, optional): Add source URL references (default: false)
+
+**Usage:** First perform a web search with `summary: true`, then use the returned summary key with this tool.
+
+## Configuration
+
+### Getting an API Key
+
+1. Sign up for a [Brave Search API account](https://brave.com/search/api/)
+2. Choose a plan:
+   - **Free**: 2,000 queries/month, basic web search
+   - **Pro**: Enhanced features including local search, AI summaries, extra snippets
+3. Generate your API key from the [developer dashboard](https://api-dashboard.search.brave.com/app/keys)
+
+### Environment Variables
+
+The server supports the following environment variables:
+
+- `BRAVE_API_KEY`: Your Brave Search API key (required)
+- `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "stdio")
+- `BRAVE_MCP_PORT`: HTTP server port (default: 8000)
+- `BRAVE_MCP_HOST`: HTTP server host (default: "0.0.0.0")
+- `BRAVE_MCP_LOG_LEVEL`: Desired logging level("debug", "info", "notice", "warning", "error", "critical", "alert", or "emergency", default: "info")
+- `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a whitelist for supported tools
+- `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a blacklist for supported tools
+- `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "true").  When running on Amazon Bedrock Agentcore, set to "true".
+
+### Command Line Options
+
+```bash
+node dist/index.js [options]
+
+Options:
+  --brave-api-key <string>    Brave API key
+  --transport <stdio|http>    Transport type (default: stdio)
+  --port <number>             HTTP server port (default: 8080)
+  --host <string>             HTTP server host (default: 0.0.0.0)
+  --logging-level <string>    Desired logging level (one of _debug_, _info_, _notice_, _warning_, _error_, _critical_, _alert_, or _emergency_)
+  --enabled-tools             Tools whitelist (only the specified tools will be enabled)
+  --disabled-tools            Tools blacklist (included tools will be disabled)
+  --stateless  <boolean>      HTTP Stateless flag
+```
+
+## Installation
+
+### Installing via Smithery
+
+To install Brave Search automatically via [Smithery](https://smithery.ai/server/brave):
+
+```bash
+npx -y @smithery/cli install brave
+```
+
+### Usage with Claude Desktop
+
+Add this to your `claude_desktop_config.json`:
+
+#### Docker
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "docker.io/mcp/brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+#### NPX
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "http"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+### Usage with VS Code
+
+For quick installation, use the one-click installation buttons below:
+
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-NPM-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=brave-search&inputs=%5B%7B%22password%22%3Atrue%2C%22id%22%3A%22brave-api-key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Brave+Search+API+Key%22%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40brave%2Fbrave-search-mcp-server%22%2C%22--transport%22%2C%22stdio%22%5D%2C%22env%22%3A%7B%22BRAVE_API_KEY%22%3A%22%24%7Binput%3Abrave-api-key%7D%22%7D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-NPM-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=brave-search&inputs=%5B%7B%22password%22%3Atrue%2C%22id%22%3A%22brave-api-key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Brave+Search+API+Key%22%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40brave%2Fbrave-search-mcp-server%22%2C%22--transport%22%2C%22stdio%22%5D%2C%22env%22%3A%7B%22BRAVE_API_KEY%22%3A%22%24%7Binput%3Abrave-api-key%7D%22%7D%7D&quality=insiders)  
+[![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Docker-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=brave-search&inputs=%5B%7B%22password%22%3Atrue%2C%22id%22%3A%22brave-api-key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Brave+Search+API+Key%22%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22BRAVE_API_KEY%22%2C%22mcp%2Fbrave-search%22%5D%2C%22env%22%3A%7B%22BRAVE_API_KEY%22%3A%22%24%7Binput%3Abrave-api-key%7D%22%7D%7D) [![Install with Docker in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Docker-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=brave-search&inputs=%5B%7B%22password%22%3Atrue%2C%22id%22%3A%22brave-api-key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Brave+Search+API+Key%22%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22BRAVE_API_KEY%22%2C%22mcp%2Fbrave-search%22%5D%2C%22env%22%3A%7B%22BRAVE_API_KEY%22%3A%22%24%7Binput%3Abrave-api-key%7D%22%7D%7D&quality=insiders)
+
+For manual installation, add the following to your User Settings (JSON) or `.vscode/mcp.json`:
+
+#### Docker
+
+```json
+{
+  "inputs": [
+    {
+      "password": true,
+      "id": "brave-api-key",
+      "type": "promptString",
+      "description": "Brave Search API Key",
+    }
+  ],
+  "servers": {
+    "brave-search": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "mcp/brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "${input:brave-api-key}"
+      }
+    }
+  }
+}
+```
+
+#### NPX
+
+```json
+{
+  "inputs": [
+    {
+      "password": true,
+      "id": "brave-api-key",
+      "type": "promptString",
+      "description": "Brave Search API Key",
+    }
+  ],
+  "servers": {
+    "brave-search-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": "${input:brave-api-key}"
+      }
+    }
+  }
+}
+```
+
+## Build
+
+### Docker
+
+```bash
+docker build -t mcp/brave-search:latest .
+```
+
+### Local Build
+
+```bash
+npm install
+npm run build
+```
+
+## Development
+
+### Prerequisites
+
+- Node.js 22.x or higher
+- npm
+- Brave Search API key
+
+### Setup
+
+1. Clone the repository:
+```bash
+git clone https://github.com/brave/brave-search-mcp-server.git
+cd brave-search-mcp-server
+```
+
+2. Install dependencies:
+```bash
+npm install
+```
+
+3. Build the project:
+```bash
+npm run build
+```
+
+### Testing via Claude Desktop
+
+Add a reference to your local build in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "brave-search-dev": {
+      "command": "node",
+      "args": ["C:\\GitHub\\brave-search-mcp-server\\dist\\index.js"], // Verify your path
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+### Testing via MCP Inspector
+
+1. Build and start the server:
+```bash
+npm run build
+node dist/index.js
+```
+
+2. In another terminal, start the MCP Inspector:
+```bash
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+STDIO is the default mode. For HTTP mode testing, add `--transport http` to the arguments in the Inspector UI.
+
+### Testing via Smithery.AI
+
+1. Establish and acquire a smithery.ai account and API key
+2. Run `npm run install`, `npm run smithery:build`, and lastly `npm run smithery:dev` to begin testing
+
+### Available Scripts
+
+- `npm run build`: Build the TypeScript project
+- `npm run watch`: Watch for changes and rebuild
+- `npm run format`: Format code with Prettier
+- `npm run format:check`: Check code formatting
+- `npm run prepare`: Format and build (runs automatically on npm install)
+
+- `npm run inspector`: Launch an instance of MCP Inspector
+- `npm run inspector:stdio`: Launch a instance of MCP Inspector, configured for STDIO
+- `npm run smithery:build`: Build the project for smithery.ai
+- `npm run smithery:dev`: Launch the development environment for smithery.ai
+
+### Docker Compose
+
+For local development with Docker:
+
+```bash
+docker-compose up --build
+```
+
+## License
+
+This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/examples/brave-search-mcp-server/docker-compose.yml
+++ b/examples/brave-search-mcp-server/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mcp-server:
+    build: .
+    cap_drop:
+      - all
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 5s
+    environment:
+      - BRAVE_API_KEY
+      - BRAVE_MCP_TRANSPORT=http
+      - BRAVE_MCP_PORT=8080
+      - BRAVE_MCP_STATELESS
+      - BRAVE_MCP_HOST=0.0.0.0
+      - BRAVE_MCP_LOG_LEVEL=info
+      - BRAVE_MCP_ENABLED_TOOLS
+      - BRAVE_MCP_DISABLED_TOOLS
+    init: true
+    ports:
+      - 8080:8080
+    security_opt:
+      - no-new-privileges:true

--- a/examples/brave-search-mcp-server/glama.json
+++ b/examples/brave-search-mcp-server/glama.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://glama.ai/mcp/schemas/server.json",
+    "maintainers": [
+        "jonathansampson"
+    ]
+}

--- a/examples/brave-search-mcp-server/marketplace-revision-release.json
+++ b/examples/brave-search-mcp-server/marketplace-revision-release.json
@@ -1,0 +1,114 @@
+{
+    "Catalog": "AWSMarketplace",
+    "ChangeSet": [
+        {
+            "ChangeType": "AddDeliveryOptions",
+            "Entity": {
+                "Type": "ContainerProduct@1.0",
+                "Identifier": "prod-ixigokshzjrpw"
+            },
+            "DetailsDocument": {
+               "Version": {
+                  "ReleaseNotes": "",
+                  "VersionTitle": ""
+               },
+               "DeliveryOptions": [
+                    {
+                        "DeliveryOptionTitle": "Brave Search MCP Server",
+                        "Details": {
+                            "EcrDeliveryOptionDetails": {
+                                "UsageInstructions": "The Brave Search MCP Server provides a powerful REST API proxy to access Brave Search capabilities through a standardized interface. This container allows you to integrate Brave's comprehensive search services into your AI applications, with features ranging from web search to image search and summarization.\n\n\n\n## Key Features\n- Brave LLM Context API delivers pre-extracted, relevance-scored web content optimized for grounding LLM responses in real-time search results.\n- Web search with comprehensive results and metadata\n- Local business and location search\n- Image and video search capabilities\n- News search for current events and trending stories\n- AI-optimized results with extra snippets\n- Content summarization across search results\n\n\n\n## Usage and limits\n- Cost: $5 CPM (cost per thousand) / $0.005 per request\n- Rate: Maximum of 50 requests per second\n- Volume: Unlimited requests\n\n\n\n## Getting started\n\n### Prerequisites\n1. **Brave Search API Key**: Create an AWS Marketplace Subscription for  [Brave Search API](https://aws.amazon.com/marketplace/pp/prodview-qjlabherxghtq)  \n2. **Container Configuration**: Configure your MCP Server with the required environment variables \n\n#### Container Configuration\n\n##### Environment Variables\n```json\n\"environmentVariables\": { \"BRAVE_API_KEY\": \"<YOUR_BRAVE_API_KEY>\", \"BRAVE_MCP_TRANSPORT\": \"http\", , \"BRAVE_MCP_STATELESS\": \"true\", \"BRAVE_MCP_PORT\": \"8000\", \"BRAVE_MCP_HOST\": \"0.0.0.0\" }}'\n```\n\n##### Network Configuration \n```json\n\"networkConfiguration\": { \"networkMode\": \"PUBLIC\" }\n```\n\n##### Protocol Configuration\n```json\n\"protocolConfiguration\": { \"serverProtocol\": \"MCP\" }\n```\n\n\n\n## Example\n\n### [`brave_web_search`](https://api.search.brave.com/res/v1/web/search)\n\nPerforms general web searches with rich metadata. Best for general information queries, research, and finding diverse content types.\n\n#### Example\n\n```json\n{\n  \"query\": \"climate change solutions\",\n  \"count\": 10,\n  \"extra_snippets\": true\n}\n```\n\n\n\n\nReference documentation for additional endpoints:\n\n- [`brave_local_search`](https://api-dashboard.search.brave.com/documentation/services/place-search)\n- [`brave_image_search`](https://api-dashboard.search.brave.com/documentation/services/image-search)\n- [`brave_video_search`](https://api-dashboard.search.brave.com/documentation/services/video-search)\n- [`brave_news_search`](https://api-dashboard.search.brave.com/documentation/services/news-search)\n- [`brave_summarizer`](https://api-dashboard.search.brave.com/documentation/services/summarizer)\n\n\n\n## Best Practices\n1. Use specific queries to get more relevant results\n2. Leverage `extra_snippets` for AI applications that need more context\n3. Use appropriate `result_filter` values to focus on specific content types\n4. Consider `safesearch` settings based on your application's audience\n5. Utilize the summarizer for efficient information extraction\n\n## Support\nFor detailed API documentation, visit the [Brave Search API Documentation](https://api-dashboard.search.brave.com/app/documentation/web-search/get-started).  For all general inquiries and support, please contact us at searchapi-support@brave.com.",
+                                "AgenticType": [
+                                    "MCP_SERVER"
+                                ],
+                                "CompatibleServices": [
+                                    "Bedrock-AgentCore"
+                                ],
+                                "Description": "",
+                                "DeploymentResources": [
+                                    {
+                                        "Url": "https://brave-marketplace-artifacts-prod.s3.us-west-2.amazonaws.com/brave-search-mcp-server/MCP_Server_Usage_Instructions_md.md",
+                                        "Name": "Brave Search MCP Usage Instructions"
+                                    }
+                                ],
+                                "ContainerImages": "",
+                                "EnvironmentVariables": [
+                                    {
+                                        "Name": "BRAVE_API_KEY",
+                                        "Description": "*Required* Brave Search API Key.  Obtain Brave Search API Key through AWS Marketplace Product (https://aws.amazon.com/marketplace/pp/prodview-qjlabherxghtq)"
+                                    },
+                                    {
+                                        "DefaultValue": "http",
+                                        "Name": "BRAVE_MCP_TRANSPORT",
+                                        "Description": "MCP protocol transport mode.  Supported values are \"http\" or \"stdio\", however Bedrock Agentcore only supports \"http\" (reference https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-runtime.html#agentcore-container-requirements)."
+                                    },
+                                    {
+                                        "DefaultValue": "8000",
+                                        "Name": "BRAVE_MCP_PORT",
+                                        "Description": "HTTP server port (default: 8000).  Mandatory port for Bedrock Agentcore is 8000 (reference https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-runtime.html#agentcore-container-requirements)."
+                                    },
+                                    {
+                                        "DefaultValue": "0.0.0.0",
+                                        "Name": "BRAVE_MCP_HOST",
+                                        "Description": "HTTP server host (default: 0.0.0.0).  Mandatory host value is 0.0.0.0 for Bedrock Agentcore (reference https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-runtime.html#agentcore-container-requirements)."
+                                    },
+                                    {
+                                        "DefaultValue": "info",
+                                        "Name": "BRAVE_MCP_LOG_LEVEL",
+                                        "Description": "MCP supported logging level (reference https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#log-levels)"
+                                    },
+                                    {
+                                        "Name": "BRAVE_MCP_ENABLED_TOOLS",
+                                        "Description": "*Optional* When used, specifies a whitelist for supported tools"
+                                    },
+                                    {
+                                        "Name": "BRAVE_MCP_DISABLED_TOOLS",
+                                        "Description": "*Optional* When used, specifies a blacklist for supported tools"
+                                    },
+                                    {
+                                        "DefaultValue": "true",
+                                        "Name": "BRAVE_MCP_STATELESS",
+                                        "Description": "Sets HTTP Stateless mode (default: true). When deploying on Bedrock Agentcore, this should be set to true."
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "DeliveryOptionTitle": "Docker Image",
+                        "Details": {
+                            "EcrDeliveryOptionDetails": {
+                                "UsageInstructions": "",
+                                "CompatibleServices": [
+                                    "ECS",
+                                    "ECS-Anywhere",
+                                    "EKS",
+                                    "EKS-Anywhere"
+                                ],
+                                "Description": "",
+                                "DeploymentResources": [],
+                                "ContainerImages": ""
+                            }
+                        }
+                    }
+               ]
+            }
+        }
+    ],
+    "ChangeSetName": "",
+    "ClientRequestToken": "",
+    "ChangeSetTags": [
+        {
+            "Key": "Release",
+            "Value": ""
+        },
+        {
+            "Key": "CostEntity",
+            "Value": "SEZC"
+        },
+        {
+            "Key": "IPGroup",
+            "Value": "KY BAT Ledger Service"
+        }
+    ]
+}

--- a/examples/brave-search-mcp-server/package-lock.json
+++ b/examples/brave-search-mcp-server/package-lock.json
@@ -1,0 +1,4967 @@
+{
+  "name": "@brave/brave-search-mcp-server",
+  "version": "2.0.75",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@brave/brave-search-mcp-server",
+      "version": "2.0.75",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.27.1",
+        "commander": "14.0.3",
+        "dotenv": "17.3.1",
+        "express": "5.2.1",
+        "zod": "4.3.6"
+      },
+      "bin": {
+        "brave-search-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@smithery/cli": "2.2.1",
+        "@types/express": "5.0.6",
+        "@types/node": "24.10.13",
+        "prettier": "3.8.1",
+        "shx": "0.4.0",
+        "tsx": "4.21.0",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-1.1.1.tgz",
+      "integrity": "sha512-a8R5pQcPPwUfuswR2of4tHDd/NJHv1L6mKJ97hfqE/gZq/xaqL12mDUtQVcyl3g1BV8csi9JOpyf15jLvfIXvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.1",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
+      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
+      "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
+      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@ngrok/ngrok": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.5.2.tgz",
+      "integrity": "sha512-gN7KKdLTKer+wBSk9s9eDx53MUFdcnXNHsXxiC5sJLLD5HY9JRMSn6UzcCqnk7IgeIgCgw5h1k6YDqhjx6lmtg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ngrok/ngrok-android-arm64": "1.5.2",
+        "@ngrok/ngrok-darwin-arm64": "1.5.2",
+        "@ngrok/ngrok-darwin-universal": "1.5.2",
+        "@ngrok/ngrok-darwin-x64": "1.5.2",
+        "@ngrok/ngrok-freebsd-x64": "1.5.2",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.5.2",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.5.2",
+        "@ngrok/ngrok-linux-arm64-musl": "1.5.2",
+        "@ngrok/ngrok-linux-x64-gnu": "1.5.2",
+        "@ngrok/ngrok-linux-x64-musl": "1.5.2",
+        "@ngrok/ngrok-win32-arm64-msvc": "1.5.2",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.5.2",
+        "@ngrok/ngrok-win32-x64-msvc": "1.5.2"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.5.2.tgz",
+      "integrity": "sha512-v81VbxxAgg2W7jbjhEcn8K9R2aUf0h1AuTx+8tDlw3L4H1YEmbmllIpBAGgMjHRBxLZKOo5GBi0k7oS+VRM5TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-8CVzS9AveYpNhWbydm7cJ6XqmVg29/VRKF15l4kJ2djlNoJxuGSibgM9A627dWRdnJyj5uhmU3VzsgeU8t+/3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-universal": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.5.2.tgz",
+      "integrity": "sha512-mEMH1OxN6RxnqRSWb4xY9RqbtdlCpv+WlRKxq4lVy8JVsxEyFNnzVQ0jn+iuiy981jCXjokctzJeGMvECuSQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-rGdcADw4NtMSU7SHUTly7uvMVYX6eMeMCppKyL5g3CSlEQntKf3AWs/89ah2TBWJA2WVl0UgGLkXp4xs1tg9eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-WgY54qUekaUGa5+lFvzYUMjlzf22IEXuZHhxnzJM2/gMqa7gjU8N5W4U8XNDjVW/oz6DekrzIjuoAEPO+2icDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.5.2.tgz",
+      "integrity": "sha512-azMxr/TGEeFU4JAUbSu5MO2aZEvdq+TzcxiLw6d+yhdEtNAjDW9TOyCczTrIZPOG5fP8G3lcCd8TP7mVIWdOnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.5.2.tgz",
+      "integrity": "sha512-79eFCxio4rM0ICRBXx/CVvbXDeWk1Jxr7szkezEYWtHaL+gXivrtS1QjtMnJpGY1GJlLTQL+49w2lGydqPOJQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.5.2.tgz",
+      "integrity": "sha512-ou9Z7iPQJIQ0RX5bdBhb3y7GwYRt+X0G9tenyRzKLXXvs0XfUUcg/23aBP61hmdRvBq7xpliV1PnvEVBgUIYMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.5.2.tgz",
+      "integrity": "sha512-VI1mmtl3Ie5uXTVAR9thPiMNMsCWeqkjBUbHAyk2vZ2OXR4Vs2DGjOPXK+wTl/hjF29FXoxunjhMy6caF9ht0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.5.2.tgz",
+      "integrity": "sha512-F4j9EyC/0R3IgYSd+OER4bC8bxuBubvj33e24GvQnRF/IQaKhpybkvQbz54fnvsL7y0j2BB42NAIm2CFtk7tCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-arm64-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.5.2.tgz",
+      "integrity": "sha512-0OMXNjWElM1MQX7lMBnpRtafS9+3ybauqGD4m2dZcIm6hFvexsJFwNgx0mCa5aKxe2mQ4zNarEUd+SqG2Aa4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.5.2.tgz",
+      "integrity": "sha512-hdvhnr7Br4XhUblpW67v5XP6FyoQwJ2xSbwas4KW4hZ3F4cw0m6sqXpssRfmqg3/5HJony1H5B2jLi0x4J7uOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.5.2.tgz",
+      "integrity": "sha512-aHuMiRti9Taow9DlYLGVmu9CXtXD/v4CBQWpZlmt7VGuK1KsTWWLaGIBFVp6UXnyW87b0A+KC69Kn/Xjylw+sg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@smithery/cli": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithery/cli/-/cli-2.2.1.tgz",
+      "integrity": "sha512-qSkEMnJq1bY5RxbjUnOuw/9xNdx2sQf1ujRYtymZF0gY4lh7ydhhscymeZytt8tKHxoaxyCnvux7RjL6ylG+AA==",
+      "dev": true,
+      "dependencies": {
+        "@anthropic-ai/mcpb": "^1.1.1",
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "@ngrok/ngrok": "^1.5.1",
+        "@smithery/registry": "^0.4.2",
+        "boxen": "^8.0.1",
+        "chalk": "^4.1.2",
+        "commander": "^14.0.0",
+        "cors": "^2.8.5",
+        "cross-fetch": "^4.1.0",
+        "esbuild": "^0.25.10",
+        "express": "^5.1.0",
+        "inquirer": "^8.2.4",
+        "inquirer-autocomplete-prompt": "^2.0.0",
+        "keytar": "^7.9.0",
+        "lodash": "^4.17.21",
+        "ora": "^8.2.0",
+        "shx": "^0.4.0",
+        "uuid": "^11.1.0",
+        "uuidv7": "^1.0.2",
+        "yaml": "^2.3.4"
+      },
+      "bin": {
+        "smithery": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@smithery/sdk": "^3.0.1",
+        "zod": "^4"
+      }
+    },
+    "node_modules/@smithery/registry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@smithery/registry/-/registry-0.4.3.tgz",
+      "integrity": "sha512-gzVe2a1aGLxoYkRzBhhFsLffhRrtkbzy32JAv/JL3U02PyE0oa/CHsiaZRtX5Kkx8HNYKziGunB5uLW/LZLl4Q==",
+      "dev": true,
+      "dependencies": {
+        "zod": "^3.20.0"
+      }
+    },
+    "node_modules/@smithery/registry/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
+      "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer-autocomplete-prompt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-2.0.1.tgz",
+      "integrity": "sha512-jUHrH0btO7j5r8DTQgANf2CBkTZChoVySD8zF/wp5fZCOLIuUbleXhf4ZY5jNBOc1owA3gdfWtfZuppfYBhcUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-escapes": "^4.3.2",
+        "figures": "^3.2.0",
+        "picocolors": "^1.0.0",
+        "run-async": "^2.4.1",
+        "rxjs": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "inquirer": "^8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
+      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.9.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/uuidv7": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.0.2.tgz",
+      "integrity": "sha512-8JQkH4ooXnm1JCIhqTMbtmdnYEn6oKukBxHn1Ic9878jMkL7daTI7anTExfY18VRCX7tcdn5quzvCb6EWrR8PA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/examples/brave-search-mcp-server/package.json
+++ b/examples/brave-search-mcp-server/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@brave/brave-search-mcp-server",
+  "mcpName": "io.github.brave/brave-search-mcp-server",
+  "version": "2.0.75",
+  "description": "Brave Search MCP Server: web results, images, videos, rich results, AI summaries, and more.",
+  "keywords": [
+    "api",
+    "brave",
+    "mcp",
+    "search"
+  ],
+  "license": "MIT",
+  "author": "Brave Software, Inc. (https://brave.com)",
+  "homepage": "https://github.com/brave/brave-search-mcp-server",
+  "bugs": "https://github.com/brave/brave-search-mcp-server/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brave/brave-search-mcp-server.git"
+  },
+  "type": "module",
+  "module": "dist/server.js",
+  "bin": {
+    "brave-search-mcp-server": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "prepare": "npm run format && npm run typecheck",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "inspector": "npx @modelcontextprotocol/inspector",
+    "inspector:http": "npx @modelcontextprotocol/inspector --transport http"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.27.1",
+    "commander": "14.0.3",
+    "dotenv": "17.3.1",
+    "express": "5.2.1",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/express": "5.0.6",
+    "@smithery/cli": "2.2.1",
+    "@types/node": "24.10.13",
+    "prettier": "3.8.1",
+    "shx": "0.4.0",
+    "tsx": "4.21.0",
+    "typescript": "5.9.3"
+  },
+  "overrides": {
+    "formdata-node": "6.0.3",
+    "tmp": "0.2.5"
+  }
+}

--- a/examples/brave-search-mcp-server/server.json
+++ b/examples/brave-search-mcp-server/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.brave/brave-search-mcp-server",
+  "description": "Brave Search MCP Server: web results, images, videos, rich results, AI summaries, and more.",
+  "version": "2.0.75",
+  "repository": {
+    "url": "https://github.com/brave/brave-search-mcp-server",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@brave/brave-search-mcp-server",
+      "version": "2.0.75",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "BRAVE_API_KEY",
+          "description": "Your API key for the service",
+          "format": "string",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/examples/brave-search-mcp-server/smithery.yaml
+++ b/examples/brave-search-mcp-server/smithery.yaml
@@ -1,0 +1,1 @@
+runtime: "typescript"

--- a/examples/brave-search-mcp-server/src/BraveAPI/index.ts
+++ b/examples/brave-search-mcp-server/src/BraveAPI/index.ts
@@ -1,0 +1,119 @@
+import type { Endpoints } from './types.js';
+import config from '../config.js';
+import { stringify } from '../utils.js';
+
+const typeToPathMap: Record<keyof Endpoints, string> = {
+  images: '/res/v1/images/search',
+  localPois: '/res/v1/local/pois',
+  localDescriptions: '/res/v1/local/descriptions',
+  news: '/res/v1/news/search',
+  videos: '/res/v1/videos/search',
+  web: '/res/v1/web/search',
+  summarizer: '/res/v1/summarizer/search',
+};
+
+const getDefaultRequestHeaders = (): Record<string, string> => {
+  return {
+    Accept: 'application/json',
+    'Accept-Encoding': 'gzip',
+    'X-Subscription-Token': config.braveApiKey,
+  };
+};
+
+const isValidGoggleURL = (url: string) => {
+  try {
+    // Only allow HTTPS URLs
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+async function issueRequest<T extends keyof Endpoints>(
+  endpoint: T,
+  parameters: Endpoints[T]['params'],
+  // TODO (Sampson): Implement support for custom request headers (helpful for POIs, etc.)
+  requestHeaders: Endpoints[T]['requestHeaders'] = {} as Endpoints[T]['requestHeaders']
+): Promise<Endpoints[T]['response']> {
+  // TODO (Sampson): Improve rate-limit logic to support self-throttling and n-keys
+  // checkRateLimit();
+
+  // Determine URL, and setup parameters
+  const url = new URL(`https://api.search.brave.com${typeToPathMap[endpoint]}`);
+  const queryParams = new URLSearchParams();
+
+  // TODO (Sampson): Move param-construction/validation to modules
+  for (const [key, value] of Object.entries(parameters)) {
+    // The 'ids' parameter is expected to appear multiple times for multiple IDs
+    if (['localPois', 'localDescriptions'].includes(endpoint)) {
+      if (key === 'ids') {
+        if (Array.isArray(value) && value.length > 0) {
+          value.forEach((id) => queryParams.append(key, id));
+        } else if (typeof value === 'string') {
+          queryParams.set(key, value);
+        }
+
+        continue;
+      }
+    }
+
+    // Handle `result_filter` parameter
+    if (key === 'result_filter') {
+      // Handle special behavior of 'summary' parameter:
+      // Requires `result_filter` to be empty, or only contain 'summarizer'
+      // see: https://bravesoftware.slack.com/archives/C01NNFM9XMM/p1751654841090929
+      if ('summary' in parameters && parameters.summary === true) {
+        queryParams.set(key, 'summarizer');
+      } else if (Array.isArray(value) && value.length > 0) {
+        queryParams.set(key, value.join(','));
+      }
+
+      continue;
+    }
+
+    // Handle `goggles` parameter(s)
+    if (key === 'goggles') {
+      if (typeof value === 'string') {
+        queryParams.set(key, value);
+      } else if (Array.isArray(value)) {
+        for (const url of value.filter(isValidGoggleURL)) {
+          queryParams.append(key, url);
+        }
+      }
+      continue;
+    }
+
+    if (value !== undefined) {
+      queryParams.set(key === 'query' ? 'q' : key, value.toString());
+    }
+  }
+
+  // Issue Request
+  const urlWithParams = url.toString() + '?' + queryParams.toString();
+  const headers = { ...getDefaultRequestHeaders(), ...requestHeaders } as Headers;
+  const response = await fetch(urlWithParams, { headers });
+
+  // Handle Error
+  if (!response.ok) {
+    let errorMessage = `${response.status} ${response.statusText}`;
+
+    try {
+      const responseBody = await response.json();
+      errorMessage += `\n${stringify(responseBody, true)}`;
+    } catch (error) {
+      errorMessage += `\n${await response.text()}`;
+    }
+
+    // TODO (Sampson): Setup proper error handling, updating state, etc.
+    throw new Error(errorMessage);
+  }
+
+  // Return Response
+  const responseBody = await response.json();
+
+  return responseBody as Endpoints[T]['response'];
+}
+
+export default {
+  issueRequest,
+};

--- a/examples/brave-search-mcp-server/src/BraveAPI/types.ts
+++ b/examples/brave-search-mcp-server/src/BraveAPI/types.ts
@@ -1,0 +1,72 @@
+import type { QueryParams as WebQueryParams } from '../tools/web/params.js';
+import type { QueryParams as ImageQueryParams } from '../tools/images/schemas/input.js';
+import type { QueryParams as VideoQueryParams } from '../tools/videos/params.js';
+import type { QueryParams as NewsQueryParams } from '../tools/news/params.js';
+import type { LocalPoisParams, LocalDescriptionsParams } from '../tools/local/params.js';
+import type { SummarizerQueryParams } from '../tools/summarizer/params.js';
+import type { WebSearchApiResponse } from '../tools/web/types.js';
+import type { SummarizerSearchApiResponse } from '../tools/summarizer/types.js';
+import type { ImageSearchApiResponse } from '../tools/images/types.js';
+import type { VideoSearchApiResponse } from '../tools/videos/types.js';
+import type { NewsSearchApiResponse } from '../tools/news/types.js';
+import type {
+  LocalPoiSearchApiResponse,
+  LocalDescriptionsSearchApiResponse,
+} from '../tools/local/types.js';
+
+export interface RateLimitErrorResponse {
+  type: 'ErrorResponse';
+  error: {
+    id: string;
+    status: number;
+    code: 'RATE_LIMITED';
+    detail: string;
+    meta: {
+      plan: string;
+      rate_limit: number;
+      rate_current: number;
+      quota_limit: number;
+      quota_current: number;
+      component: 'rate_limiter';
+    };
+  };
+  time: number;
+}
+
+export type Endpoints = {
+  web: {
+    params: WebQueryParams;
+    response: WebSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  images: {
+    params: ImageQueryParams;
+    response: ImageSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  videos: {
+    params: VideoQueryParams;
+    response: VideoSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  news: {
+    params: NewsQueryParams;
+    response: NewsSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  localPois: {
+    params: LocalPoisParams;
+    response: LocalPoiSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  localDescriptions: {
+    params: LocalDescriptionsParams;
+    response: LocalDescriptionsSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  summarizer: {
+    params: SummarizerQueryParams;
+    response: SummarizerSearchApiResponse;
+    requestHeaders: Headers;
+  };
+};

--- a/examples/brave-search-mcp-server/src/config.ts
+++ b/examples/brave-search-mcp-server/src/config.ts
@@ -1,0 +1,190 @@
+import { LoggingLevel, LoggingLevelSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Command } from 'commander';
+import dotenv from 'dotenv';
+import { z } from 'zod';
+import tools from './tools/index.js';
+
+dotenv.config({ debug: false, quiet: true });
+
+// Config schema for Smithery.ai
+export const configSchema = z.object({
+  braveApiKey: z
+    .string()
+    .describe('Your API key')
+    .default(process.env.BRAVE_API_KEY ?? ''),
+  enabledTools: z
+    .array(z.string())
+    .describe('Enforces a tool whitelist (cannot be used with disabledTools)')
+    .optional(),
+  disabledTools: z
+    .array(z.string())
+    .describe('Enforces a tool blacklist (cannot be used with enabledTools)')
+    .optional(),
+  loggingLevel: z
+    .enum([
+      'debug',
+      'error',
+      'info',
+      'notice',
+      'warning',
+      'critical',
+      'alert',
+      'emergency',
+    ] as const)
+    .default('info')
+    .describe('Desired logging level')
+    .optional(),
+  stateless: z
+    .boolean()
+    .default(false)
+    .describe('Whether the server should be stateless')
+    .optional(),
+});
+
+export type SmitheryConfig = z.infer<typeof configSchema>;
+
+type Configuration = {
+  transport: 'stdio' | 'http';
+  port: number;
+  host: string;
+  braveApiKey: string;
+  loggingLevel: LoggingLevel;
+  enabledTools: string[];
+  disabledTools: string[];
+  stateless: boolean;
+};
+
+const state: Configuration & { ready: boolean } = {
+  transport: 'stdio',
+  port: 8080,
+  host: '0.0.0.0',
+  braveApiKey: process.env.BRAVE_API_KEY ?? '',
+  loggingLevel: 'info',
+  ready: false,
+  enabledTools: [],
+  disabledTools: [],
+  stateless: false,
+};
+
+export function isToolPermittedByUser(toolName: string): boolean {
+  return state.enabledTools.length > 0
+    ? state.enabledTools.includes(toolName)
+    : state.disabledTools.includes(toolName) === false;
+}
+
+export function getOptions(): Configuration | false {
+  const program = new Command()
+    .option('--brave-api-key <string>', 'Brave API key', process.env.BRAVE_API_KEY ?? '')
+    .option('--logging-level <string>', 'Logging level', process.env.BRAVE_MCP_LOG_LEVEL ?? 'info')
+    .option(
+      '--transport <stdio|http>',
+      'transport type',
+      process.env.BRAVE_MCP_TRANSPORT ?? 'stdio'
+    )
+    .option(
+      '--enabled-tools <names...>',
+      'tools to enable',
+      process.env.BRAVE_MCP_ENABLED_TOOLS?.trim().split(' ') ?? []
+    )
+    .option(
+      '--disabled-tools <names...>',
+      'tools to disable',
+      process.env.BRAVE_MCP_DISABLED_TOOLS?.trim().split(' ') ?? []
+    )
+    .option(
+      '--port <number>',
+      'desired port for HTTP transport',
+      process.env.BRAVE_MCP_PORT ?? '8080'
+    )
+    .option(
+      '--host <string>',
+      'desired host for HTTP transport',
+      process.env.BRAVE_MCP_HOST ?? '0.0.0.0'
+    )
+    .option(
+      '--stateless <boolean>',
+      'whether the server should be stateless',
+      process.env.BRAVE_MCP_STATELESS === 'true' ? true : false
+    )
+    .allowUnknownOption()
+    .parse(process.argv);
+
+  const options = program.opts();
+  const toolNames = Object.values(tools).map((tool) => tool.name);
+
+  // Validate tool inclusion configuration
+  const enabledTools = options.enabledTools.filter((t: string) => t.trim().length > 0);
+  const disabledTools = options.disabledTools.filter((t: string) => t.trim().length > 0);
+
+  if (enabledTools.length > 0 && disabledTools.length > 0) {
+    console.error('Error: --enabled-tools and --disabled-tools cannot be used together');
+    return false;
+  }
+
+  if (
+    [...enabledTools, ...disabledTools].some(
+      (t) => t.trim().length > 0 && !toolNames.includes(t.trim())
+    )
+  ) {
+    console.error(`Invalid tool name used. Must be one of: ${toolNames.join(', ')}`);
+    return false;
+  }
+
+  // Validate all other options
+  if (!['stdio', 'http'].includes(options.transport)) {
+    console.error(
+      `Invalid --transport value: '${options.transport}'. Must be one of: stdio, http.`
+    );
+    return false;
+  }
+
+  if (!LoggingLevelSchema.options.includes(options.loggingLevel)) {
+    console.error(
+      `Invalid --logging-level value: '${options.loggingLevel}'. Must be one of: ${LoggingLevelSchema.options.join(', ')}`
+    );
+    return false;
+  }
+
+  if (!options.braveApiKey) {
+    console.error(
+      'Error: --brave-api-key is required. You can get one at https://brave.com/search/api/.'
+    );
+    return false;
+  }
+
+  if (options.transport === 'http') {
+    if (options.port < 1 || options.port > 65535) {
+      console.error(
+        `Invalid --port value: '${options.port}'. Must be a valid port number between 1 and 65535.`
+      );
+      return false;
+    }
+
+    if (!options.host) {
+      console.error('Error: --host is required');
+      return false;
+    }
+  }
+
+  // Normalize stateless to boolean (CLI passes it as string)
+  options.stateless = options.stateless === true || options.stateless === 'true';
+
+  // Update state
+  state.braveApiKey = options.braveApiKey;
+  state.transport = options.transport;
+  state.port = options.port;
+  state.host = options.host;
+  state.loggingLevel = options.loggingLevel;
+  state.enabledTools = options.enabledTools;
+  state.disabledTools = options.disabledTools;
+  state.stateless = options.stateless;
+  state.ready = true;
+
+  return options as Configuration;
+}
+
+export function setOptions(options: SmitheryConfig) {
+  return Object.assign(state, options);
+}
+
+export default state;

--- a/examples/brave-search-mcp-server/src/constants.ts
+++ b/examples/brave-search-mcp-server/src/constants.ts
@@ -1,0 +1,4 @@
+export const RATE_LIMIT = {
+  perSecond: 1,
+  perMonth: 15000,
+} as const;

--- a/examples/brave-search-mcp-server/src/helpers.ts
+++ b/examples/brave-search-mcp-server/src/helpers.ts
@@ -1,0 +1,16 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+export function registerSigIntHandler(
+  transports: Map<string, StdioServerTransport | StreamableHTTPServerTransport>
+) {
+  process.on('SIGINT', async () => {
+    for (const sessionID of transports.keys()) {
+      await transports.get(sessionID)?.close();
+      transports.delete(sessionID);
+    }
+
+    console.error('Server shut down.');
+    process.exit(0);
+  });
+}

--- a/examples/brave-search-mcp-server/src/index.ts
+++ b/examples/brave-search-mcp-server/src/index.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { getOptions } from './config.js';
+import { stdioServer, httpServer } from './protocols/index.js';
+
+async function main() {
+  const options = getOptions();
+
+  if (!options) {
+    console.error('Invalid configuration');
+    process.exit(1);
+  }
+
+  // default to stdio server unless http is explicitly requested
+  if (options.transport === 'http') {
+    httpServer.start();
+    return;
+  }
+
+  await stdioServer.start();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/brave-search-mcp-server/src/protocols/http.ts
+++ b/examples/brave-search-mcp-server/src/protocols/http.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from 'node:crypto';
+import express, { type Request, type Response } from 'express';
+import config from '../config.js';
+import createMcpServer from '../server.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const yieldGenericServerError = (res: Response) => {
+  res.status(500).json({
+    id: null,
+    jsonrpc: '2.0',
+    error: { code: -32603, message: 'Internal server error' },
+  });
+};
+
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+const isListToolsRequest = (value: unknown): value is ListToolsRequest =>
+  ListToolsRequestSchema.safeParse(value).success;
+
+const getTransport = async (request: Request): Promise<StreamableHTTPServerTransport> => {
+  // Check for an existing session
+  const sessionId = request.headers['mcp-session-id'] as string;
+
+  if (sessionId && transports.has(sessionId)) {
+    return transports.get(sessionId)!;
+  }
+
+  // We have a special case where we'll permit ListToolsRequest w/o a session ID
+  if (!sessionId && isListToolsRequest(request.body)) {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    const mcpServer = await createMcpServer();
+    await mcpServer.connect(transport);
+    return transport;
+  }
+
+  let transport: StreamableHTTPServerTransport;
+
+  if (config.stateless) {
+    // Some contexts (e.g. AgentCore) may prefer or require a stateless transport
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+  } else {
+    // Otherwise, start a new transport/session
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        transports.set(sessionId, transport);
+      },
+    });
+  }
+
+  const mcpServer = await createMcpServer();
+  await mcpServer.connect(transport);
+  return transport;
+};
+
+const createApp = () => {
+  const app = express();
+
+  app.use(express.json());
+
+  app.all('/mcp', async (req: Request, res: Response) => {
+    try {
+      const transport = await getTransport(req);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      console.error(error);
+      if (!res.headersSent) {
+        yieldGenericServerError(res);
+      }
+    }
+  });
+
+  app.all('/ping', (req: Request, res: Response) => {
+    res.status(200).json({ message: 'pong' });
+  });
+
+  return app;
+};
+
+const start = () => {
+  if (!config.ready) {
+    console.error('Invalid configuration');
+    process.exit(1);
+  }
+
+  const app = createApp();
+
+  app.listen(config.port, config.host, () => {
+    console.log(`Server is running on http://${config.host}:${config.port}/mcp`);
+  });
+};
+
+export default { start, createApp };

--- a/examples/brave-search-mcp-server/src/protocols/index.ts
+++ b/examples/brave-search-mcp-server/src/protocols/index.ts
@@ -1,0 +1,2 @@
+export { default as stdioServer } from './stdio.js';
+export { default as httpServer } from './http.js';

--- a/examples/brave-search-mcp-server/src/protocols/stdio.ts
+++ b/examples/brave-search-mcp-server/src/protocols/stdio.ts
@@ -1,0 +1,14 @@
+import newMcpServer from '../server.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const createTransport = (): StdioServerTransport => {
+  return new StdioServerTransport();
+};
+
+const start = async (): Promise<void> => {
+  const transport = createTransport();
+  const mcpServer = await newMcpServer();
+  await mcpServer.connect(transport);
+};
+
+export default { start, createTransport };

--- a/examples/brave-search-mcp-server/src/server.ts
+++ b/examples/brave-search-mcp-server/src/server.ts
@@ -1,0 +1,55 @@
+import tools from './tools/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import pkg from '../package.json' with { type: 'json' };
+import { isToolPermittedByUser } from './config.js';
+import { type SmitheryConfig, setOptions } from './config.js';
+import { withMCPI, generateIdentity } from '../../../src/middleware/index.js';
+import type { MCPIIdentityConfig } from '../../../src/middleware/index.js';
+import { NodeCryptoProvider } from '../../node-server/node-crypto.js';
+export { configSchema } from './config.js';
+
+// Shared crypto + identity — generated once, reused across all McpServer instances
+const crypto = new NodeCryptoProvider();
+let sharedIdentity: MCPIIdentityConfig | undefined;
+
+type CreateMcpServerOptions = {
+  config: SmitheryConfig;
+};
+
+export default async function createMcpServer(
+  options?: CreateMcpServerOptions
+): Promise<McpServer> {
+  if (options?.config) setOptions(options.config);
+
+  // Generate identity once on first call
+  if (!sharedIdentity) {
+    sharedIdentity = await generateIdentity(crypto);
+    console.error(`[mcpi] Server DID: ${sharedIdentity.did}`);
+  }
+
+  const mcpServer = new McpServer(
+    {
+      version: pkg.version,
+      name: 'brave-search-mcp-server',
+      title: 'Brave Search MCP Server',
+    },
+    {
+      capabilities: {
+        logging: {},
+        tools: { listChanged: false },
+      },
+      instructions: `Use this server to search the Web for various types of data via the Brave Search API.`,
+    }
+  );
+
+  // MCP-I: auto-register handshake + auto-proof all tools (reuses shared identity)
+  await withMCPI(mcpServer, { crypto, identity: sharedIdentity });
+
+  for (const tool of Object.values(tools)) {
+    // The user may have enabled/disabled this tool at runtime
+    if (!isToolPermittedByUser(tool.name)) continue;
+    tool.register(mcpServer);
+  }
+
+  return mcpServer;
+}

--- a/examples/brave-search-mcp-server/src/tools/images/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/images/index.ts
@@ -1,0 +1,82 @@
+import type { TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import params, { type QueryParams } from './schemas/input.js';
+import API from '../../BraveAPI/index.js';
+import type { ImageResult } from './types.js';
+import OutputSchema, { SimplifiedImageResultSchema } from './schemas/output.js';
+import { z } from 'zod';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_image_search';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave Image Search',
+  openWorldHint: true,
+};
+
+export const description = `
+    Performs an image search using the Brave Search API. Helpful for when you need pictures of people, places, things, graphic design ideas, art inspiration, and more. When relaying results in a markdown environment, it may be helpful to include images in the results (e.g., ![image.title](image.properties.url)).
+`;
+
+export const execute = async (params: QueryParams) => {
+  const response = await API.issueRequest<'images'>('images', params);
+  const items = response.results.map(simplifySchemaForLLM).filter((o) => o !== null);
+
+  const structuredContent = OutputSchema.safeParse({
+    type: 'object',
+    items,
+    count: items.length,
+    might_be_offensive: response.extra.might_be_offensive,
+  });
+
+  const payload = structuredContent.success
+    ? structuredContent.data
+    : structuredContent.error.flatten();
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) } as TextContent],
+    isError: !structuredContent.success,
+    structuredContent: payload,
+  };
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: params.shape,
+      outputSchema: OutputSchema.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+function simplifySchemaForLLM(
+  result: ImageResult
+): z.infer<typeof SimplifiedImageResultSchema> | null {
+  const parsed = SimplifiedImageResultSchema.safeParse({
+    title: result.title,
+    url: result.url,
+    page_fetched: result.page_fetched,
+    confidence: result.confidence,
+    properties: {
+      url: result.properties?.url,
+      width: result.properties?.width,
+      height: result.properties?.height,
+    },
+  });
+
+  return parsed.success ? parsed.data : null;
+}
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: params.shape,
+  outputSchema: OutputSchema.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/images/schemas/input.ts
+++ b/examples/brave-search-mcp-server/src/tools/images/schemas/input.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const params = z.object({
+  query: z
+    .string()
+    .min(1)
+    .max(400)
+    .refine((str) => str.split(/\s+/).length <= 50, 'Query cannot exceed 50 words')
+    .describe(
+      "The user's search query. Query cannot be empty. Limited to 400 characters and 50 words."
+    ),
+  country: z
+    .string()
+    .default('US')
+    .describe(
+      'Search query country, where the results come from. The country string is limited to 2 character country codes of supported countries.'
+    )
+    .optional(),
+  search_lang: z
+    .string()
+    .default('en')
+    .describe(
+      'Search language preference. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  count: z
+    .int()
+    .min(1)
+    .max(200)
+    .default(50)
+    .describe(
+      'Number of results (1-200, default 50). Combine this parameter with `offset` to paginate search results.'
+    )
+    .optional(),
+  safesearch: z
+    .union([z.literal('off'), z.literal('strict')])
+    .default('strict')
+    .describe(
+      "Filters search results for adult content. The following values are supported: 'off' - No filtering. 'strict' - Drops all adult content from search results."
+    )
+    .optional(),
+  spellcheck: z
+    .boolean()
+    .default(true)
+    .describe('Whether to spellcheck provided query.')
+    .optional(),
+});
+
+export type QueryParams = z.infer<typeof params>;
+
+export default params;

--- a/examples/brave-search-mcp-server/src/tools/images/schemas/output.ts
+++ b/examples/brave-search-mcp-server/src/tools/images/schemas/output.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { ConfidenceSchema, ExtraSchema } from './response.js';
+
+export const SimplifiedImageResultSchema = z.object({
+  title: z.string(),
+  url: z.url(),
+  page_fetched: z.iso.datetime(),
+  confidence: ConfidenceSchema,
+  properties: z.object({
+    url: z.url(),
+    width: z.int().positive(),
+    height: z.int().positive(),
+  }),
+});
+
+const OutputSchema = z.object({
+  type: z.literal('object'),
+  items: z.array(SimplifiedImageResultSchema),
+  count: z.int().nonnegative(),
+  might_be_offensive: ExtraSchema.shape.might_be_offensive,
+});
+
+export default OutputSchema;

--- a/examples/brave-search-mcp-server/src/tools/images/schemas/response.ts
+++ b/examples/brave-search-mcp-server/src/tools/images/schemas/response.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+/**
+ * https://api-dashboard.search.brave.com/app/documentation/image-search/responses
+ */
+
+const QuerySchema = z.object({
+  original: z.string().describe('The original query string.'),
+  altered: z.string().optional().describe('The altered query string.'),
+  spellcheck_off: z.boolean().optional().describe('Whether spellcheck was disabled.'),
+  show_strict_warning: z
+    .boolean()
+    .optional()
+    .describe('When true, some results were blocked by safesearch.'),
+});
+
+const ThumbnailSchema = z.object({
+  src: z.url().optional().describe('The URL of the thumbnail.'),
+  width: z.int().positive().optional().describe('The width of the thumbnail.'),
+  height: z.int().positive().optional().describe('The height of the thumbnail.'),
+});
+
+const PropertiesSchema = z.object({
+  url: z.url().optional().describe('The URL of the image.'),
+  placeholder: z.url().optional().describe('The lower resolution placeholder image.'),
+  width: z.int().positive().optional().describe('The width of the image.'),
+  height: z.int().positive().optional().describe('The height of the image.'),
+});
+
+const MetaUrlSchema = z.object({
+  scheme: z.enum(['https', 'http']).optional().describe('The scheme of the URL.'),
+  netloc: z.string().optional().describe('The network location of the URL.'),
+  hostname: z.string().optional().describe('The lowercased hostname of the URL.'),
+  favicon: z.url().optional().describe('The URL of the favicon of the URL.'),
+  path: z.string().optional().describe('The path of the URL (useful as a display string).'),
+});
+
+export const ConfidenceSchema = z
+  .enum(['low', 'medium', 'high'])
+  .describe('The confidence level of the result.');
+
+const ImageResultSchema = z.object({
+  type: z.literal('image_result').describe('The type of result.'),
+  title: z.string().optional().describe('The title of the image.'),
+  url: z.url().optional().describe('The URL of the image.'),
+  source: z.url().optional().describe('The source URL of the image.'),
+  page_fetched: z.iso.datetime().optional().describe('The date and time the page was fetched.'),
+  thumbnail: ThumbnailSchema.optional().describe('The thumbnail of the image.'),
+  properties: PropertiesSchema.optional().describe('The metadata for the image.'),
+  meta_url: MetaUrlSchema.optional().describe(
+    'Information about the URL associated with the image.'
+  ),
+  confidence: ConfidenceSchema.optional(),
+});
+
+export const ExtraSchema = z.object({
+  might_be_offensive: z.boolean().describe('Whether the image might be offensive.'),
+});
+
+export const ImageSearchApiResponseSchema = z.object({
+  type: z.literal('images').describe('The type of API response.'),
+  query: QuerySchema.describe('The query used to generate the results.'),
+  results: z.array(ImageResultSchema).describe('The results of the image search.'),
+  extra: ExtraSchema.describe('Extra information about the search.'),
+});

--- a/examples/brave-search-mcp-server/src/tools/images/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/images/types.ts
@@ -1,0 +1,80 @@
+export interface ImageSearchApiResponse {
+  /** The type of search API result. The value is always images. */
+  type: 'images';
+  /** Image search query string. */
+  query: Query;
+  /** The list of image results for the given query. */
+  results: ImageResult[];
+  /** Additional information about the image search results. */
+  extra: Extra;
+}
+
+interface Query {
+  /** The original query that was requested. */
+  original: string;
+  /** The altered query by the spellchecker. This is the query that is used to search. */
+  altered?: string;
+  /** Whether the spellchecker is enabled or disabled. */
+  spellcheck_off?: boolean;
+  /** The value is true if the lack of results is due to a strict safesearch setting. Adult content relevant to the query was found, but was blocked by safesearch. */
+  show_strict_warning?: string;
+}
+
+export interface ImageResult {
+  /** The type of image search API result. The value is always image_result. */
+  type: 'image_result';
+  /** The title of the image. */
+  title?: string;
+  /** The original page URL where the image was found. */
+  url?: string;
+  /** The source domain where the image was found. */
+  source?: string;
+  /** The ISO date time when the page was last fetched. The format is YYYY-MM-DDTHH:MM:SSZ. */
+  page_fetched?: string;
+  /** The thumbnail for the image. */
+  thumbnail?: Thumbnail;
+  /** Metadata for the image. */
+  properties?: Properties;
+  /** Aggregated information on the URL associated with the image search result. */
+  meta_url?: MetaUrl;
+  /** The confidence level for the image result. */
+  confidence?: 'low' | 'medium' | 'high';
+}
+
+interface Thumbnail {
+  /** The served URL of the image. */
+  src?: string;
+  /** The width of the thumbnail. */
+  width?: number;
+  /** The height of the thumbnail. */
+  height?: number;
+}
+
+export interface Properties {
+  /** The image URL. */
+  url?: string;
+  /** The lower resolution placeholder image URL. */
+  placeholder?: string;
+  /** The width of the image. */
+  width?: number;
+  /** The height of the image. */
+  height?: number;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme?: string;
+  /** The network location part extracted from the URL. */
+  netloc?: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon?: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path?: string;
+}
+
+interface Extra {
+  /** Indicates whether the image search results might contain offensive content. */
+  might_be_offensive: boolean;
+}

--- a/examples/brave-search-mcp-server/src/tools/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/index.ts
@@ -1,0 +1,15 @@
+import WebSearchTool from './web/index.js';
+import LocalSearchTool from './local/index.js';
+import VideoSearchTool from './videos/index.js';
+import ImageSearchTool from './images/index.js';
+import NewsSearchTool from './news/index.js';
+import SummarizerTool from './summarizer/index.js';
+
+export default {
+  WebSearchTool,
+  LocalSearchTool,
+  VideoSearchTool,
+  ImageSearchTool,
+  NewsSearchTool,
+  SummarizerTool,
+};

--- a/examples/brave-search-mcp-server/src/tools/local/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/local/index.ts
@@ -1,0 +1,182 @@
+import type {
+  LocationResult,
+  LocationDescription,
+  OpeningHours,
+  DayOpeningHours,
+} from './types.js';
+import webParams, { type QueryParams as WebQueryParams } from '../web/params.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import API from '../../BraveAPI/index.js';
+import { formatWebResults } from '../web/index.js';
+import { stringify } from '../../utils.js';
+import { type WebSearchApiResponse } from '../web/types.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_local_search';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave Local Search',
+  openWorldHint: true,
+};
+
+export const description = `
+    Brave Local Search API provides enrichments for location search results. Access to this API is available only through the Brave Search API Pro plans; confirm the user's plan before using this tool (if the user does not have a Pro plan, use the brave_web_search tool). Searches for local businesses and places using Brave's Local Search API. Best for queries related to physical locations, businesses, restaurants, services, etc.
+    
+    Returns detailed information including:
+        - Business names and addresses
+        - Ratings and review counts
+        - Phone numbers and opening hours
+
+    Use this when the query implies 'near me', 'in my area', or mentions specific locations (e.g., 'in San Francisco'). This tool automatically falls back to brave_web_search if no local results are found.
+`;
+
+// Access to Local API is available through the Pro plans.
+export const execute = async (params: WebQueryParams) => {
+  // Make sure both 'web' and 'locations' are in the result_filter
+  params = { ...params, result_filter: [...(params.result_filter || []), 'web', 'locations'] };
+
+  // Starts with a web search to retrieve potential location IDs
+  const { locations, web: web_fallback } = await API.issueRequest<'web'>('web', params);
+
+  // We can send up to 20 location IDs at a time to the Local API
+  // TODO (Sampson): Add support for multiple requests
+  const locationIDs = (locations?.results || []).map((poi) => poi.id as string).slice(0, 20);
+
+  // No locations were found - user's plan may not include access to the Local API
+  if (!locations || locationIDs.length === 0) {
+    // If we have web results, but no locations, we'll fall back to the web results
+    if (web_fallback && web_fallback.results.length > 0) {
+      return buildFallbackWebResponse(web_fallback);
+    }
+
+    // If we have no web results, we'll send a message to the user
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: "No location data was returned. User's plan does not support local search, or the query may be unclear.",
+        },
+      ],
+    };
+  }
+
+  // Fetch AI-generated descriptions
+  const descriptions = await API.issueRequest<'localDescriptions'>('localDescriptions', {
+    ids: locationIDs,
+  });
+
+  return {
+    content: formatLocalResults(locations.results, descriptions.results).map((formattedPOI) => ({
+      type: 'text' as const,
+      text: formattedPOI,
+    })),
+  };
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: webParams.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+const buildFallbackWebResponse = (web_fallback: WebSearchApiResponse['web']): CallToolResult => {
+  if (!web_fallback || web_fallback.results.length === 0) throw new Error('No web results found');
+
+  const fallback = {
+    content: [
+      {
+        type: 'text' as const,
+        text: "No location data was returned. Either the user's plan does not support local search, or the API was unable to find locations for the provided query. Falling back to general web search.",
+      },
+    ],
+  };
+
+  for (const web_result of formatWebResults(web_fallback)) {
+    fallback.content.push({
+      type: 'text' as const,
+      text: stringify(web_result),
+    });
+  }
+
+  return fallback;
+};
+
+const formatLocalResults = (
+  poisData: LocationResult[],
+  descData: LocationDescription[] = []
+): string[] => {
+  return poisData.map((poi) => {
+    return stringify({
+      name: poi.title,
+      price_range: poi.price_range,
+      phone: poi.contact?.telephone,
+      rating: poi.rating?.ratingValue,
+      hours: formatOpeningHours(poi.opening_hours),
+      rating_count: poi.rating?.reviewCount,
+      description: descData.find(({ id }) => id === poi.id)?.description,
+      address: poi.postal_address?.displayAddress,
+    });
+  });
+};
+
+const formatOpeningHours = (openingHours?: OpeningHours): Record<string, string> | undefined => {
+  if (!openingHours) return undefined;
+  /**
+   * Response will be something like {
+   *     'sunday': '10:00-18:00',
+   *     'monday': '10:00-18:00',
+   *     'tuesday': '10:00-18:00',
+   *     'wednesday': '10:00-18:00, 19:00-22:00',
+   *     'thursday': '10:00-18:00',
+   *     'friday': '10:00-18:00',
+   *     'saturday': '12:00-18:00',
+   * }
+   */
+  const today: DayOpeningHours[] = openingHours.current_day || [];
+  const response = {} as Record<string, string>;
+
+  const dayHours: [string, string[]][] = [
+    [
+      `today (${today[0].full_name.toLowerCase()})`,
+      today.map(({ opens, closes }) => `${opens}-${closes}`),
+    ],
+  ];
+
+  // Add the rest of the days to the response
+  for (let parts of openingHours.days || []) {
+    // Not all days have arrays of hours, so normalize to an array
+    if (!Array.isArray(parts)) parts = [parts];
+
+    // Add the hours for each day to the response
+    for (const { full_name, opens, closes } of parts) {
+      const dayName = full_name.toLowerCase();
+      const existingEntry = dayHours.find(([name]) => name === dayName);
+
+      existingEntry
+        ? existingEntry[1].push(`${opens}-${closes}`)
+        : dayHours.push([dayName, [`${opens}-${closes}`]]);
+    }
+  }
+
+  for (const [name, hours] of dayHours) {
+    response[name] = hours.join(', ');
+  }
+
+  return response;
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: webParams.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/local/params.ts
+++ b/examples/brave-search-mcp-server/src/tools/local/params.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const LocalPoisParams = z.object({
+  ids: z.array(z.string()).describe('List of location IDs for which to fetch POIs'),
+});
+
+export const LocalDescriptionsParams = z.object({
+  ids: z.array(z.string()).describe('List of location IDs for which to fetch descriptions'),
+});
+
+export type LocalPoisParams = z.infer<typeof LocalPoisParams>;
+export type LocalDescriptionsParams = z.infer<typeof LocalDescriptionsParams>;

--- a/examples/brave-search-mcp-server/src/tools/local/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/local/types.ts
@@ -1,0 +1,259 @@
+export interface LocalPoiSearchApiResponse {
+  /** The type of local POI search API result. The value is always local_pois. */
+  type: 'local_pois';
+  /** Location results matching the ids in the request. */
+  results?: LocationResult[];
+}
+
+export interface LocalDescriptionsSearchApiResponse {
+  /** The type of local description search API result. The value is always local_descriptions. */
+  type: 'local_descriptions';
+  /** Location descriptions matching the ids in the request. */
+  results?: LocationDescription[];
+}
+
+export interface LocationDescription {
+  /** The type of a location description. The value is always local_description. */
+  type: 'local_description';
+  /** A Temporary id of the location with this description. */
+  id: string;
+  /** AI generated description of the location with the given id. */
+  description?: string;
+}
+
+interface Result {
+  /** The title of the web page. */
+  title: string;
+  /** The URL where the page is served. */
+  url: string;
+  is_source_local: boolean;
+  is_source_both: boolean;
+  /** A description for the web page. */
+  description?: string;
+  /** A date representing the age of the web page. */
+  page_age?: string;
+  /** A date representing when the web page was last fetched. */
+  page_fetched?: string;
+  /** A profile associated with the web page. */
+  profile?: Profile;
+  /** A language classification for the web page. */
+  language?: string;
+  /** Whether the web page is family friendly. */
+  family_friendly: boolean;
+}
+
+interface Profile {
+  /** The name of the profile. */
+  name: string;
+  /** The long name of the profile. */
+  long_name: string;
+  /** The original URL where the profile is available. */
+  url?: string;
+  /** The served image URL representing the profile. */
+  img?: string;
+}
+
+export interface LocationResult extends Result {
+  /** Location result type identifier. The value is always location_result. */
+  type: 'location_result';
+  /** A Temporary id associated with this result, which can be used to retrieve extra information about the location. It remains valid for 8 hours… */
+  id?: string;
+  /** The complete URL of the provider. */
+  provider_url: string;
+  /** A list of coordinates associated with the location. This is a lat long represented as a floating point. */
+  coordinates?: number[];
+  /** The zoom level on the map. */
+  zoom_level: number;
+  /** The thumbnail associated with the location. */
+  thumbnail?: Thumbnail;
+  /** The postal address associated with the location. */
+  postal_address?: PostalAddress;
+  /** The opening hours, if it is a business, associated with the location . */
+  opening_hours?: OpeningHours;
+  /** The contact of the business associated with the location. */
+  contact?: Contact;
+  /** A display string used to show the price classification for the business. */
+  price_range?: string;
+  /** The ratings of the business. */
+  rating?: Rating;
+  /** The distance of the location from the client. */
+  distance?: Unit;
+  /** Profiles associated with the business. */
+  profiles?: DataProvider[];
+  /** Aggregated reviews from various sources relevant to the business. */
+  reviews?: Reviews;
+  /** A bunch of pictures associated with the business. */
+  pictures?: PictureResults;
+  /** An action to be taken. */
+  action?: Action;
+  /** A list of cuisine categories served. */
+  serves_cuisine?: string[];
+  /** A list of categories. */
+  categories?: string[];
+  /** An icon category. */
+  icon_category?: string;
+  /** Web results related to this location. */
+  results?: LocationWebResult;
+  /** IANA timezone identifier. */
+  timezone?: string;
+  /** The utc offset of the timezone. */
+  timezone_offset?: string;
+}
+
+interface Thumbnail {
+  /** The served URL of the picture thumbnail. */
+  src: string;
+  /** The original URL of the image. */
+  original?: string;
+}
+
+interface PostalAddress {
+  /** The type identifying a postal address. The value is always PostalAddress. */
+  type: 'PostalAddress';
+  /** The country associated with the location. */
+  country?: string;
+  /** The postal code associated with the location. */
+  postalCode?: string;
+  /** The street address associated with the location. */
+  streetAddress?: string;
+  /** The region associated with the location. This is usually a state. */
+  addressRegion?: string;
+  /** The address locality or subregion associated with the location. */
+  addressLocality?: string;
+  /** The displayed address string. */
+  displayAddress: string;
+}
+
+export interface OpeningHours {
+  /** The current day opening hours. Can have two sets of opening hours. */
+  current_day?: DayOpeningHours[];
+  /** The opening hours for the whole week. */
+  days?: DayOpeningHours[] | [DayOpeningHours][];
+}
+
+interface Contact {
+  /** The email address. */
+  email?: string;
+  /** The telephone number. */
+  telephone?: string;
+}
+
+interface Rating {
+  /** The current value of the rating. */
+  ratingValue: number;
+  /** Best rating received. */
+  bestRating: number;
+  /** The number of reviews associated with the rating. */
+  reviewCount?: number;
+  /** The profile associated with the rating. */
+  profile?: Profile;
+  /** Whether the rating is coming from Tripadvisor. */
+  is_tripadvisor: boolean;
+}
+
+interface Unit {
+  /** The quantity of the unit. */
+  value: number;
+  /** The name of the unit associated with the quantity. */
+  units: string;
+}
+
+interface DataProvider {
+  /** The type representing the source of data. This is usually external. */
+  type: 'external';
+  /** The name of the data provider. This can be a domain. */
+  name: string;
+  /** The URL where the information is coming from. */
+  url: string;
+  /** The long name for the data provider. */
+  long_name?: string;
+  /** The served URL for the image data. */
+  img?: string;
+}
+
+interface Reviews {
+  /** A list of trip advisor reviews for the entity. */
+  results: TripAdvisorReview[];
+  /** A URL to a web page where more information on the result can be seen. */
+  viewMoreUrl: string;
+  /** Any reviews available in a foreign language. */
+  reviews_in_foreign_language: boolean;
+}
+
+interface PictureResults {
+  /** A URL to view more pictures. */
+  viewMoreUrl?: string;
+  /** A list of thumbnail results. */
+  results: Thumbnail[];
+}
+
+interface Action {
+  /** The type representing the action. */
+  type: string;
+  /** A URL representing the action to be taken. */
+  url: string;
+}
+
+interface LocationWebResult extends Result {
+  /** Aggregated information about the URL. */
+  meta_url: MetaUrl;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme: string;
+  /** The network location part extracted from the URL. */
+  netloc: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path: string;
+}
+
+export interface DayOpeningHours {
+  /** A short string representing the day of the week. */
+  abbr_name: string;
+  /** A full string representing the day of the week. */
+  full_name: string;
+  /** A 24 hr clock time string for the opening time of the business on a particular day. */
+  opens: string;
+  /** A 24 hr clock time string for the closing time of the business on a particular day. */
+  closes: string;
+}
+
+interface TripAdvisorReview {
+  /** The title of the review. */
+  title: string;
+  /** A description seen in the review. */
+  description: string;
+  /** The date when the review was published. */
+  date: string;
+  /** A rating given by the reviewer. */
+  rating: Rating;
+  /** The author of the review. */
+  author: Person;
+  /** A URL link to the page where the review can be found. */
+  review_url: string;
+  /** The language of the review. */
+  language: string;
+}
+
+interface Person extends Omit<Thing, 'type'> {
+  /** A type identifying a person. The value is always person. */
+  type: 'person';
+  /** Email address of the person. */
+  email?: string;
+}
+
+interface Thing {
+  /** A type identifying a thing. The value is always thing. */
+  type: 'thing';
+  /** The name of the thing. */
+  name: string;
+  /** A URL for the thing. */
+  url?: string;
+  /** Thumbnail associated with the thing. */
+  thumbnail?: Thumbnail;
+}

--- a/examples/brave-search-mcp-server/src/tools/news/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/news/index.ts
@@ -1,0 +1,75 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import params, { type QueryParams } from './params.js';
+import API from '../../BraveAPI/index.js';
+import { stringify } from '../../utils.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_news_search';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave News Search',
+  openWorldHint: true,
+};
+
+export const description = `
+    This tool searches for news articles using Brave's News Search API based on the user's query. Use it when you need current news information, breaking news updates, or articles about specific topics, events, or entities.
+    
+    When to use:
+        - Finding recent news articles on specific topics
+        - Getting breaking news updates
+        - Researching current events or trending stories
+        - Gathering news sources and headlines for analysis
+
+    Returns a JSON list of news-related results with title, url, and description. Some results may contain snippets of text from the article.
+    
+    When relaying results in markdown-supporting environments, always cite sources with hyperlinks.
+    
+    Examples:
+        - "According to [Reuters](https://www.reuters.com/technology/china-bans/), China bans uncertified and recalled power banks on planes".
+        - "The [New York Times](https://www.nytimes.com/2025/06/27/us/technology/ev-sales.html) reports that Tesla's EV sales have increased by 20%".
+        - "According to [BBC News](https://www.bbc.com/news/world-europe-65910000), the UK government has announced a new policy to support renewable energy".
+`;
+
+export const execute = async (params: QueryParams) => {
+  const response = await API.issueRequest<'news'>('news', params);
+
+  return {
+    content: response.results.map((newsResult) => {
+      return {
+        type: 'text' as const,
+        text: stringify({
+          url: newsResult.url,
+          title: newsResult.title,
+          age: newsResult.age,
+          page_age: newsResult.page_age,
+          breaking: newsResult.breaking ?? false,
+          description: newsResult.description,
+          extra_snippets: newsResult.extra_snippets,
+          thumbnail: newsResult.thumbnail?.src,
+        }),
+      };
+    }),
+  };
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: params.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: params.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/news/params.ts
+++ b/examples/brave-search-mcp-server/src/tools/news/params.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const params = z.object({
+  query: z
+    .string()
+    .max(400)
+    .refine((str) => str.split(/\s+/).length <= 50, 'Query cannot exceed 50 words')
+    .describe('Search query (max 400 chars, 50 words)'),
+  country: z
+    .string()
+    .default('US')
+    .describe(
+      'Search query country, where the results come from. The country string is limited to 2 character country codes of supported countries.'
+    )
+    .optional(),
+  search_lang: z
+    .string()
+    .default('en')
+    .describe(
+      'Search language preference. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  ui_lang: z
+    .string()
+    .default('en-US')
+    .describe(
+      'User interface language preferred in response. Usually of the format <language_code>-<country_code>. For more, see RFC 9110.'
+    )
+    .optional(),
+  count: z
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Number of results (1-50, default 20)')
+    .optional(),
+  offset: z
+    .int()
+    .min(0)
+    .max(9)
+    .default(0)
+    .describe('Pagination offset (max 9, default 0)')
+    .optional(),
+  spellcheck: z
+    .boolean()
+    .default(true)
+    .describe('Whether to spellcheck provided query.')
+    .optional(),
+  safesearch: z
+    .union([z.literal('off'), z.literal('moderate'), z.literal('strict')])
+    .default('moderate')
+    .describe(
+      "Filters search results for adult content. The following values are supported: 'off' - No filtering. 'moderate' - Filter out explicit content. 'strict' - Filter out explicit and suggestive content. The default value is 'moderate'."
+    )
+    .optional(),
+  freshness: z
+    .union([z.literal('pd'), z.literal('pw'), z.literal('pm'), z.literal('py'), z.string()])
+    .default('pd')
+    .describe(
+      "Filters search results by when they were discovered. The following values are supported: 'pd' - Discovered within the last 24 hours. 'pw' - Discovered within the last 7 Days. 'pm' - Discovered within the last 31 Days. 'py' - Discovered within the last 365 Days. 'YYYY-MM-DDtoYYYY-MM-DD' - Timeframe is also supported by specifying the date range e.g. 2022-04-01to2022-07-30."
+    )
+    .optional(),
+  extra_snippets: z
+    .boolean()
+    .default(false)
+    .describe(
+      'A snippet is an excerpt from a page you get as a result of the query, and extra_snippets allow you to get up to 5 additional, alternative excerpts. Only available under Free AI, Base AI, Pro AI, Base Data, Pro Data and Custom plans.'
+    )
+    .optional(),
+  goggles: z
+    .array(z.string())
+    .describe(
+      "Goggles act as a custom re-ranking on top of Brave's search index. The parameter supports both a url where the Goggle is hosted or the definition of the Goggle. For more details, refer to the Goggles repository (i.e., https://github.com/brave/goggles-quickstart)."
+    )
+    .optional(),
+});
+
+export type QueryParams = z.infer<typeof params>;
+
+export default params;

--- a/examples/brave-search-mcp-server/src/tools/news/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/news/types.ts
@@ -1,0 +1,66 @@
+export interface NewsSearchApiResponse {
+  /** The type of search API result. The value is always news. */
+  type: 'news';
+  /** News search query string. */
+  query: Query;
+  /** The list of news results for the given query. */
+  results: NewsResult[];
+}
+
+interface Query {
+  /** The original query that was requested. */
+  original: string;
+  /** The altered query by the spellchecker. This is the query that is used to search if any. */
+  altered?: string;
+  /** The cleaned normalized query by the spellchecker. This is the query that is used to search if any. */
+  cleaned?: string;
+  /** Whether the spellchecker is enabled or disabled. */
+  spellcheck_off?: boolean;
+  /** The value is true if the lack of results is due to a strict safesearch setting. Adult content relevant to the query was found, but was blocked by safesearch. */
+  show_strict_warning?: boolean;
+}
+
+export interface NewsResult {
+  /** The type of news search API result. The value is always news_result. */
+  type: 'news_result';
+  /** The source URL of the news article. */
+  url: string;
+  /** The title of the news article. */
+  title: string;
+  /** The description for the news article. */
+  description?: string;
+  /** A human readable representation of the page age. */
+  age?: string;
+  /** The page age found from the source web page. */
+  page_age?: string;
+  /** The ISO date time when the page was last fetched. The format is YYYY-MM-DDTHH:MM:SSZ. */
+  page_fetched?: string;
+  /** Whether the result includes breaking news. */
+  breaking?: boolean;
+  /** The thumbnail for the news article. */
+  thumbnail?: Thumbnail;
+  /** Aggregated information on the URL associated with the news search result. */
+  meta_url?: MetaUrl;
+  /** A list of extra alternate snippets for the news search result. */
+  extra_snippets?: string[];
+}
+
+interface Thumbnail {
+  /** The served URL of the thumbnail associated with the news article. */
+  src: string;
+  /** The original URL of the thumbnail associated with the news article. */
+  original?: string;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme?: string;
+  /** The network location part extracted from the URL. */
+  netloc?: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon?: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path?: string;
+}

--- a/examples/brave-search-mcp-server/src/tools/summarizer/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/summarizer/index.ts
@@ -1,0 +1,117 @@
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { summarizerQueryParams, type SummarizerQueryParams } from './params.js';
+import API from '../../BraveAPI/index.js';
+import { type SummarizerSearchApiResponse } from './types.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_summarizer';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave Summarizer',
+  openWorldHint: true,
+};
+
+export const description = `
+    Retrieves AI-generated summaries of web search results using Brave's Summarizer API. This tool processes search results to create concise, coherent summaries of information gathered from multiple sources.
+
+    When to use:
+
+    - When you need a concise overview of complex topics from multiple sources
+    - For quick fact-checking or getting key points without reading full articles
+    - When providing users with summarized information that synthesizes various perspectives
+    - For research tasks requiring distilled information from web searches
+
+    Returns a text summary that consolidates information from the search results. Optional features include inline references to source URLs and additional entity information.
+
+    Requirements: Must first perform a web search using brave_web_search with summary=true parameter. Requires a Pro AI subscription to access the summarizer functionality.
+`;
+
+export const execute = async (params: SummarizerQueryParams) => {
+  const response: CallToolResult = { content: [], isError: false };
+
+  try {
+    const { summary } = await pollForSummary(params);
+
+    if (!summary || summary.length === 0) {
+      response.isError = true;
+      response.content.push({
+        type: 'text' as const,
+        text: 'Unable to retrieve a Summarizer summary.',
+      });
+    } else {
+      const summaryText = summary
+        .map((summary_part) => {
+          if (summary_part.type === 'token') {
+            return summary_part.data;
+          } else if (summary_part.type === 'inline_reference') {
+            return ` (${summary_part.data?.url})`;
+          } else {
+            return '';
+          }
+        })
+        .join('');
+
+      response.content.push({
+        type: 'text' as const,
+        text: summaryText,
+      });
+    }
+  } catch (error) {
+    response.isError = true;
+    response.content.push({
+      type: 'text' as const,
+      text: 'Unable to retrieve a Summarizer summary.',
+    });
+  }
+
+  return response;
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: summarizerQueryParams.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+const pollForSummary = async (
+  params: SummarizerQueryParams,
+  pollInterval: number = 50,
+  attempts: number = 20
+): Promise<SummarizerSearchApiResponse> => {
+  let result: SummarizerSearchApiResponse | null = null;
+
+  while (!result && attempts > 0) {
+    try {
+      const response = await API.issueRequest<'summarizer'>('summarizer', params);
+      if (response.status === 'complete') {
+        result = response;
+      }
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+
+    attempts--;
+  }
+
+  if (!result) {
+    throw new Error('Summarizer summary could not be retrieved after multiple attempts.');
+  }
+
+  return result;
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: summarizerQueryParams.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/summarizer/params.ts
+++ b/examples/brave-search-mcp-server/src/tools/summarizer/params.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const summarizerQueryParams = z.object({
+  key: z
+    .string()
+    .describe('The key is equal to value of field key as part of the Summarizer response model.'),
+  entity_info: z
+    .boolean()
+    .default(false)
+    .describe('Returns extra entities info with the summary response.')
+    .optional(),
+  inline_references: z
+    .boolean()
+    .default(false)
+    .describe('Adds inline references to the summary response.')
+    .optional(),
+});
+
+export type SummarizerQueryParams = z.infer<typeof summarizerQueryParams>;
+
+export const chatCompletionsMessage = z.object({
+  role: z
+    .enum(['user'])
+    .default('user')
+    .describe('The role of the message. Only "user" is supported for now.'),
+  content: z
+    .string()
+    .describe('The content of the message. The value is the question to be answered.'),
+});
+
+export type ChatCompletionsMessage = z.infer<typeof chatCompletionsMessage>;
+
+export const chatCompletionParams = z.object({
+  messages: z
+    .array(chatCompletionsMessage)
+    .describe(
+      'The messages to use for the chat completion. The value is a list of ChatCompletionsMessage response models.'
+    ),
+  model: z
+    .enum(['brave-pro', 'brave'])
+    .default('brave-pro')
+    .optional()
+    .describe(
+      'The model to use for the chat completion. The value can be "brave-pro" (default) or "brave".'
+    ),
+  stream: z
+    .boolean()
+    .default(true)
+    .optional()
+    .describe(
+      'Whether to stream the response. The value is `true` by default. When using the OpenAI CLI, use `openai.AsyncOpenAI` for streaming and `openai.OpenAI` for blocking mode.'
+    ),
+  country: z
+    .string()
+    .default('us')
+    .optional()
+    .describe(
+      'The country backend to use for the chat completion. The value is "us" by default. Note: This parameter is passed in extra_body field when using the OpenAI CLI.'
+    ),
+  language: z
+    .string()
+    .default('en')
+    .optional()
+    .describe(
+      'The language to use for the chat completion. The value is "en" by default. Note: This parameter is passed in extra_body field when using the OpenAI CLI.'
+    ),
+  enable_entities: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe(
+      'Whether to enable entities in the chat completion. The value is `false` by default. Note: This parameter is passed in extra_body field when using the OpenAI CLI.'
+    ),
+  enable_citations: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe(
+      'Whether to enable citations in the chat completion. The value is `false` by default. Note: This parameter is passed in extra_body field when using the OpenAI CLI.'
+    ),
+});
+
+export type ChatCompletionParams = z.infer<typeof chatCompletionParams>;

--- a/examples/brave-search-mcp-server/src/tools/summarizer/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/summarizer/types.ts
@@ -1,0 +1,139 @@
+export interface SummarizerSearchApiResponse {
+  /** The type of summarizer search API result. The value is always summarizer. */
+  type: 'summarizer';
+  /** The current status of summarizer for the given key. The value can be either failed or complete. */
+  status: string;
+  /** The title for the summary. */
+  title?: string;
+  /** Details for the summary message. */
+  summary?: SummaryMessage[];
+  /** Enrichments that can be added to the summary message. */
+  enrichments?: SummaryEnrichments;
+  /** Followup queries relevant to the current query. */
+  followups?: string[];
+  /** Details on the entities in the summary message. */
+  entities_infos?: Record<string, SummaryEntityInfo>;
+}
+
+interface SummaryMessage {
+  /** The type of subset of a summary message. The value can be token (a text excerpt from the summary), enum_item (a summary entity), enum_start (describes the beginning of summary entities, which means the following item(s) in the summary list will be entities), enum_end (the end of summary entities) or inline_reference (an inline reference to the summary, requires inline_references query param to be set). */
+  type: string;
+  /** The summary entity or the explanation for the type field. For type enum_start the value can be ol or ul, which means an ordered list or an unordered list of entities follows respectively. For type enum_end there is no value. For type token the value is a text excerpt. For type enum_item the value is the SummaryEntity response model. For type inline_reference the value is the SummaryInlineReference response model. */
+  data?: SummaryEntity | SummaryInlineReference;
+}
+
+interface TextLocation {
+  /** The 0-based index, where the important part of the text starts. */
+  start: number;
+  /** The 0-based index, where the important part of the text ends. */
+  end: number;
+}
+
+interface SummaryEntity {
+  /** A unique identifier for the entity. */
+  uuid: string;
+  /** The name of the entity. */
+  name: string;
+  /** The URL where further details on the entity can be found. */
+  url?: string;
+  /** A text message describing the entity. */
+  text?: string;
+  /** The image associated with the entity. */
+  images?: SummaryImage[];
+  /** The location of the entity in the summary message. */
+  highlight?: TextLocation[];
+}
+
+interface SummaryInlineReference {
+  /** The type of inline reference. The value is always inline_reference. */
+  type: string;
+  /** The URL that is being referenced. */
+  url: string;
+  /** The start index of the inline reference in the summary message. */
+  start_index: number;
+  /** The end index of the inline reference in the summary message. */
+  end_index: number;
+  /** The ordinal number of the inline reference. */
+  number: number;
+  /** The favicon of the URL that is being referenced. */
+  favicon?: string;
+  /** The reference text snippet. */
+  snippet?: string;
+}
+
+interface Thumbnail {
+  /** The served URL of the picture thumbnail. */
+  src: string;
+  /** The original URL of the image. */
+  original?: string;
+}
+
+interface ImageProperties {
+  /** The image URL. */
+  url: string;
+}
+
+interface Image {
+  /** The thumbnail associated with the image. */
+  thumbnail: Thumbnail;
+  /** The URL of the image. */
+  url?: string;
+  /** Metadata on the image. */
+  properties?: ImageProperties;
+}
+
+interface SummaryImage extends Image {
+  /** Text associated with the image. */
+  text?: string;
+}
+
+interface SummaryEnrichments {
+  /** The raw summary message. */
+  raw: string;
+  /** The images associated with the summary. */
+  images?: SummaryImage[];
+  /** The answers in the summary message. */
+  qa?: SummaryAnswer[];
+  /** The entities in the summary message. */
+  entities?: SummaryEntity[];
+  /** References based on which the summary was built. */
+  context?: SummaryContext[];
+}
+
+interface SummaryAnswer {
+  /** The answer text. */
+  answer: string;
+  /** A score associated with the answer. */
+  score?: number;
+  /** The location of the answer in the summary message. */
+  highlight?: TextLocation;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme?: string;
+  /** The network location part extracted from the URL. */
+  netloc?: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon?: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path?: string;
+}
+
+interface SummaryContext {
+  /** The title of the reference. */
+  title: string;
+  /** The URL where the reference can be found. */
+  url: string;
+  /** Details on the URL associated with the reference. */
+  meta_url?: MetaUrl;
+}
+
+interface SummaryEntityInfo {
+  /** The name of the provider. */
+  provider?: string;
+  /** Description of the entity. */
+  description?: string;
+}

--- a/examples/brave-search-mcp-server/src/tools/videos/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/videos/index.ts
@@ -1,0 +1,60 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import params, { type QueryParams } from './params.js';
+import API from '../../BraveAPI/index.js';
+import { stringify } from '../../utils.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_video_search';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave Video Search',
+  openWorldHint: true,
+};
+
+export const description = `
+    Searches for videos using Brave's Video Search API and returns structured video results with metadata.
+
+    When to use:
+        - When you need to find videos related to a specific topic, keyword, or query.
+        - Useful for discovering video content, getting video metadata, or finding videos from specific creators/publishers.
+
+    Returns a JSON list of video-related results with title, url, description, duration, and thumbnail_url.
+`;
+
+export const execute = async (params: QueryParams) => {
+  const response = await API.issueRequest<'videos'>('videos', params);
+
+  return {
+    content: response.results.map(({ url, title, description, video, thumbnail }) => {
+      const duration = video?.duration;
+      const thumbnail_url = thumbnail?.src;
+
+      return {
+        type: 'text' as const,
+        text: stringify({ url, title, description, duration, thumbnail_url }),
+      };
+    }),
+  };
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: params.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: params.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/videos/params.ts
+++ b/examples/brave-search-mcp-server/src/tools/videos/params.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+export const params = z.object({
+  query: z
+    .string()
+    .min(1)
+    .max(400)
+    .refine((str) => str.split(/\s+/).length <= 50, 'Query cannot exceed 50 words')
+    .describe(
+      "The user's search query. Query cannot be empty. Limited to 400 characters and 50 words."
+    ),
+  country: z
+    .string()
+    .default('US')
+    .describe(
+      'Search query country, where the results come from. The country string is limited to 2 character country codes of supported countries.'
+    )
+    .optional(),
+  search_lang: z
+    .string()
+    .default('en')
+    .describe(
+      'Search language preference. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  ui_lang: z
+    .string()
+    .default('en-US')
+    .describe(
+      'User interface language preferred in response. Usually of the format <language_code>-<country_code>. For more, see RFC 9110.'
+    )
+    .optional(),
+  count: z
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe(
+      'Number of results (1-50, default 20). Combine this parameter with `offset` to paginate search results.'
+    )
+    .optional(),
+  offset: z
+    .int()
+    .min(0)
+    .max(9)
+    .default(0)
+    .describe(
+      'Pagination offset (max 9, default 0). Combine this parameter with `count` to paginate search results.'
+    )
+    .optional(),
+  spellcheck: z
+    .boolean()
+    .describe('Whether to spellcheck provided query.')
+    .default(true)
+    .optional(),
+  safesearch: z
+    .union([z.literal('off'), z.literal('moderate'), z.literal('strict')])
+    .default('moderate')
+    .describe(
+      "Filters search results for adult content. The following values are supported: 'off' - No filtering. 'moderate' - Filter out explicit content. 'strict' - Filter out explicit and suggestive content. The default value is 'moderate'."
+    )
+    .optional(),
+  freshness: z
+    .union([z.literal('pd'), z.literal('pw'), z.literal('pm'), z.literal('py'), z.string()])
+    .describe(
+      "Filters search results by when they were discovered. The following values are supported: 'pd' - Discovered within the last 24 hours. 'pw' - Discovered within the last 7 days. 'pm' - Discovered within the last 31 days. 'py' - Discovered within the last 365 days. 'YYYY-MM-DDtoYYYY-MM-DD' - timeframe is also supported by specifying the date range (e.g. '2022-04-01to2022-07-30')."
+    )
+    .optional(),
+});
+
+export type QueryParams = z.infer<typeof params>;
+
+export default params;

--- a/examples/brave-search-mcp-server/src/tools/videos/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/videos/types.ts
@@ -1,0 +1,99 @@
+export interface VideoSearchApiResponse {
+  /** The type of search API result. The value is always video. */
+  type: 'videos';
+  /** Video search query string. */
+  query: Query;
+  /** The list of video results for the given query. */
+  results: VideoResult[];
+  /** Additional information about the video search results. */
+  extra: Extra;
+}
+
+interface Query {
+  /** The original query that was requested. */
+  original: string;
+  /** The altered query by the spellchecker. This is the query that is used to search if any. */
+  altered?: string;
+  /** The cleaned noramlized query by the spellchecker. This is the query that is used to search if any. */
+  cleaned?: string;
+  /** Whether the spellchecker is enabled or disabled. */
+  spellcheck_off?: boolean;
+  /** The value is true if the lack of results is due to a strict safesearch setting. Adult content relevant to the query was found, but was blocked by safesearch. */
+  show_strict_warning?: string;
+}
+
+interface Thumbnail {
+  /** The served URL of the thumbnail associated with the video. */
+  src: string;
+  /** The original URL of the thumbnail associated with the video. */
+  original?: string;
+}
+
+interface Profile {
+  /** The name of the profile. */
+  name: string;
+  /** The long name of the profile. */
+  long_name?: string;
+  /** The original URL where the profile is available. */
+  url: string;
+  /** The served image URL representing the profile. */
+  img?: string;
+}
+
+interface VideoData {
+  /** A time string representing the duration of the video. */
+  duration?: string;
+  /** The number of views of the video. */
+  views?: number;
+  /** The creator of the video. */
+  creator?: string;
+  /** The publisher of the video. */
+  publisher?: string;
+  /** Whether the video requires a subscription. */
+  requires_subscription?: boolean;
+  /** A list of tags relevant to the video. */
+  tags?: string[];
+  /** A list of profiles associated with the video. */
+  author?: Profile;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme?: string;
+  /** The network location part extracted from the URL. */
+  netloc?: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon?: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path?: string;
+}
+
+export interface VideoResult {
+  /** The type of video search API result. The value is always video_result. */
+  type: 'video_result';
+  /** The source URL of the video. */
+  url: string;
+  /** The title of the video. */
+  title: string;
+  /** The description for the video. */
+  description?: string;
+  /** A human readable representation of the page age. */
+  age?: string;
+  /** The page age found from the source web page. */
+  page_age?: string;
+  /** The ISO date time when the page was last fetched. The format is YYYY-MM-DDTHH:MM:SSZ. */
+  page_fetched?: string;
+  /** The thumbnail for the video. */
+  thumbnail?: Thumbnail;
+  /** Metadata for the video. */
+  video?: VideoData;
+  /** Aggregated information on the URL associated with the video search result. */
+  meta_url?: MetaUrl;
+}
+
+interface Extra {
+  /** Indicates whether the video search results might contain offensive content. */
+  might_be_offensive: boolean;
+}

--- a/examples/brave-search-mcp-server/src/tools/web/index.ts
+++ b/examples/brave-search-mcp-server/src/tools/web/index.ts
@@ -1,0 +1,192 @@
+import type { TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import params, { type QueryParams } from './params.js';
+import API from '../../BraveAPI/index.js';
+import type {
+  Discussions,
+  FAQ,
+  News,
+  Search,
+  Videos,
+  FormattedFAQResults,
+  FormattedDiscussionsResults,
+  FormattedNewsResults,
+  FormattedVideoResults,
+  FormattedWebResults,
+} from './types.js';
+import { stringify } from '../../utils.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_web_search';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave Web Search',
+  openWorldHint: true,
+};
+
+export const description = `
+    Performs web searches using the Brave Search API and returns comprehensive search results with rich metadata.
+
+    When to use:
+        - General web searches for information, facts, or current topics
+        - Location-based queries (restaurants, businesses, points of interest)
+        - News searches for recent events or breaking stories
+        - Finding videos, discussions, or FAQ content
+        - Research requiring diverse result types (web pages, images, reviews, etc.)
+
+    Returns a JSON list of web results with title, description, and URL.
+    
+    When the "results_filter" parameter is empty, JSON results may also contain FAQ, Discussions, News, and Video results.
+`;
+
+export const execute = async (params: QueryParams) => {
+  const response = { content: [] as TextContent[], isError: false };
+  const { web, faq, discussions, news, videos, summarizer } = await API.issueRequest<'web'>(
+    'web',
+    params
+  );
+
+  if (summarizer) {
+    response.content.push({
+      type: 'text' as const,
+      text: `Summarizer key: ${summarizer.key}`,
+    });
+  }
+
+  if (!web || !Array.isArray(web.results) || web.results.length < 1) {
+    response.isError = true;
+    response.content.push({
+      type: 'text' as const,
+      text: 'No web results found',
+    });
+
+    return response;
+  }
+
+  // TODO (Sampson): The following is unnecessarily repetitive.
+  if (web && web.results?.length > 0) {
+    for (const entry of formatWebResults(web)) {
+      response.content.push({
+        type: 'text' as const,
+        text: stringify(entry),
+      });
+    }
+  }
+
+  if (faq && faq.results?.length > 0) {
+    for (const entry of formatFAQResults(faq)) {
+      response.content.push({
+        type: 'text' as const,
+        text: stringify(entry),
+      });
+    }
+  }
+
+  if (discussions && discussions.results?.length > 0) {
+    for (const entry of formatDiscussionsResults(discussions)) {
+      response.content.push({
+        type: 'text' as const,
+        text: stringify(entry),
+      });
+    }
+  }
+
+  if (news && news.results?.length > 0) {
+    for (const entry of formatNewsResults(news)) {
+      response.content.push({
+        type: 'text' as const,
+        text: stringify(entry),
+      });
+    }
+  }
+
+  if (videos && videos.results?.length > 0) {
+    for (const entry of formatVideoResults(videos)) {
+      response.content.push({
+        type: 'text' as const,
+        text: stringify(entry),
+      });
+    }
+  }
+
+  return response;
+};
+
+export const formatWebResults = (web: Search): FormattedWebResults => {
+  return (web.results || []).map(({ url, title, description, extra_snippets }) => ({
+    url,
+    title,
+    description,
+    extra_snippets,
+  }));
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: params.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+const formatFAQResults = (faq: FAQ): FormattedFAQResults => {
+  return (faq.results || []).map(({ question, answer, title, url }) => ({
+    question,
+    answer,
+    title,
+    url,
+  }));
+};
+
+const formatDiscussionsResults = (discussions: Discussions): FormattedDiscussionsResults => {
+  return (discussions.results || []).map(({ url, data }) => ({
+    mutated_by_goggles: discussions.mutated_by_goggles,
+    url,
+    data,
+  }));
+};
+
+const formatNewsResults = (news: News): FormattedNewsResults => {
+  return (news.results || []).map(
+    ({ source, breaking, is_live, age, url, title, description, extra_snippets }) => ({
+      mutated_by_goggles: news.mutated_by_goggles,
+      source,
+      breaking,
+      is_live,
+      age,
+      url,
+      title,
+      description,
+      extra_snippets,
+    })
+  );
+};
+
+const formatVideoResults = (videos: Videos): FormattedVideoResults => {
+  return (videos.results || []).map(({ url, age, title, description, video, thumbnail }) => ({
+    mutated_by_goggles: videos.mutated_by_goggles,
+    url,
+    title,
+    description,
+    age,
+    thumbnail_url: thumbnail?.src,
+    duration: video.duration,
+    view_count: video.views,
+    creator: video.creator,
+    publisher: video.publisher,
+    tags: video.tags,
+  }));
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: params.shape,
+  execute,
+  register,
+};

--- a/examples/brave-search-mcp-server/src/tools/web/params.ts
+++ b/examples/brave-search-mcp-server/src/tools/web/params.ts
@@ -1,0 +1,243 @@
+import { z } from 'zod';
+
+export const params = z.object({
+  query: z
+    .string()
+    .max(400)
+    .refine((str) => str.split(/\s+/).length <= 50, 'Query cannot exceed 50 words')
+    .describe('Search query (max 400 chars, 50 words)'),
+  country: z
+    .enum([
+      'ALL',
+      'AR',
+      'AU',
+      'AT',
+      'BE',
+      'BR',
+      'CA',
+      'CL',
+      'DK',
+      'FI',
+      'FR',
+      'DE',
+      'HK',
+      'IN',
+      'ID',
+      'IT',
+      'JP',
+      'KR',
+      'MY',
+      'MX',
+      'NL',
+      'NZ',
+      'NO',
+      'CN',
+      'PL',
+      'PT',
+      'PH',
+      'RU',
+      'SA',
+      'ZA',
+      'ES',
+      'SE',
+      'CH',
+      'TW',
+      'TR',
+      'GB',
+      'US',
+    ])
+    .default('US')
+    .describe(
+      'Search query country, where the results come from. The country string is limited to 2 character country codes of supported countries.'
+    )
+    .optional(),
+  search_lang: z
+    .enum([
+      'ar',
+      'eu',
+      'bn',
+      'bg',
+      'ca',
+      'zh-hans',
+      'zh-hant',
+      'hr',
+      'cs',
+      'da',
+      'nl',
+      'en',
+      'en-gb',
+      'et',
+      'fi',
+      'fr',
+      'gl',
+      'de',
+      'gu',
+      'he',
+      'hi',
+      'hu',
+      'is',
+      'it',
+      'jp',
+      'kn',
+      'ko',
+      'lv',
+      'lt',
+      'ms',
+      'ml',
+      'mr',
+      'nb',
+      'pl',
+      'pt-br',
+      'pt-pt',
+      'pa',
+      'ro',
+      'ru',
+      'sr',
+      'sk',
+      'sl',
+      'es',
+      'sv',
+      'ta',
+      'te',
+      'th',
+      'tr',
+      'uk',
+      'vi',
+    ])
+    .default('en')
+    .describe(
+      'Search language preference. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  ui_lang: z
+    .enum([
+      'es-AR',
+      'en-AU',
+      'de-AT',
+      'nl-BE',
+      'fr-BE',
+      'pt-BR',
+      'en-CA',
+      'fr-CA',
+      'es-CL',
+      'da-DK',
+      'fi-FI',
+      'fr-FR',
+      'de-DE',
+      'zh-HK',
+      'en-IN',
+      'en-ID',
+      'it-IT',
+      'ja-JP',
+      'ko-KR',
+      'en-MY',
+      'es-MX',
+      'nl-NL',
+      'en-NZ',
+      'no-NO',
+      'zh-CN',
+      'pl-PL',
+      'en-PH',
+      'ru-RU',
+      'en-ZA',
+      'es-ES',
+      'sv-SE',
+      'fr-CH',
+      'de-CH',
+      'zh-TW',
+      'tr-TR',
+      'en-GB',
+      'en-US',
+      'es-US',
+    ])
+    .default('en-US')
+    .describe(
+      'The language of the UI. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  count: z
+    .int()
+    .min(1)
+    .max(20)
+    .default(10)
+    .describe(
+      'Number of results (1-20, default 10). Applies only to web search results (i.e., has no effect on locations, news, videos, etc.)'
+    )
+    .optional(),
+  offset: z
+    .int()
+    .min(0)
+    .max(9)
+    .default(0)
+    .describe('Pagination offset (max 9, default 0)')
+    .optional(),
+  safesearch: z
+    .enum(['off', 'moderate', 'strict'])
+    .default('moderate')
+    .describe(
+      "Filters search results for adult content. The following values are supported: 'off' - No filtering. 'moderate' - Filters explicit content (e.g., images and videos), but allows adult domains in search results. 'strict' - Drops all adult content from search results. The default value is 'moderate'."
+    )
+    .optional(),
+  freshness: z
+    .enum(['pd', 'pw', 'pm', 'py', 'YYYY-MM-DDtoYYYY-MM-DD'])
+    .describe(
+      "Filters search results by when they were discovered. The following values are supported: 'pd' - Discovered within the last 24 hours. 'pw' - Discovered within the last 7 days. 'pm' - Discovered within the last 31 days. 'py' - Discovered within the last 365 days. 'YYYY-MM-DDtoYYYY-MM-DD' - Timeframe is also supported by specifying the date range e.g. 2022-04-01to2022-07-30."
+    )
+    .optional(),
+  text_decorations: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Whether display strings (e.g. result snippets) should include decoration markers (e.g. highlighting characters).'
+    )
+    .optional(),
+  spellcheck: z
+    .boolean()
+    .default(true)
+    .describe('Whether to spellcheck the provided query.')
+    .optional(),
+  result_filter: z
+    .array(
+      z.enum([
+        'discussions',
+        'faq',
+        'infobox',
+        'news',
+        'query',
+        'summarizer',
+        'videos',
+        'web',
+        'locations',
+        'rich',
+      ])
+    )
+    .default(['web', 'query'])
+    .describe("Result filter (default ['web', 'query'])")
+    .optional(),
+  goggles: z
+    .array(z.string())
+    .describe(
+      "Goggles act as a custom re-ranking on top of Brave's search index. The parameter supports both a url where the Goggle is hosted or the definition of the Goggle. For more details, refer to the Goggles repository (i.e., https://github.com/brave/goggles-quickstart)."
+    )
+    .optional(),
+  units: z
+    .union([z.literal('metric'), z.literal('imperial')])
+    .describe('The measurement units. If not provided, units are derived from search country.')
+    .optional(),
+  extra_snippets: z
+    .boolean()
+    .describe(
+      'A snippet is an excerpt from a page you get as a result of the query, and extra_snippets allow you to get up to 5 additional, alternative excerpts. Only available under Free AI, Base AI, Pro AI, Base Data, Pro Data and Custom plans.'
+    )
+    .optional(),
+  summary: z
+    .boolean()
+    .describe(
+      'This parameter enables summary key generation in web search results. This is required for summarizer to be enabled.'
+    )
+    .optional(),
+});
+
+export type QueryParams = z.infer<typeof params>;
+
+export default params;

--- a/examples/brave-search-mcp-server/src/tools/web/types.ts
+++ b/examples/brave-search-mcp-server/src/tools/web/types.ts
@@ -1,0 +1,979 @@
+export type FormattedWebResults = {
+  url: string;
+  title: string;
+  description?: string;
+  extra_snippets?: string[];
+}[];
+
+export type FormattedFAQResults = {
+  question: string;
+  answer: string;
+  title: string;
+  url: string;
+}[];
+
+export type FormattedDiscussionsResults = {
+  mutated_by_goggles?: boolean;
+  url: string;
+  data?: ForumData;
+}[];
+
+export type FormattedNewsResults = {
+  mutated_by_goggles?: boolean;
+  source?: string;
+  breaking: boolean;
+  is_live: boolean;
+  age?: string;
+  url: string;
+  title: string;
+  description?: string;
+  extra_snippets?: string[];
+}[];
+
+export type FormattedVideoResults = {
+  mutated_by_goggles?: boolean;
+  url: string;
+  title: string;
+  description?: string;
+  age?: string;
+  thumbnail_url?: string;
+  duration?: string;
+  view_count?: string;
+  creator?: string;
+  publisher?: string;
+  tags?: string[];
+}[];
+
+export interface WebSearchApiResponse {
+  /** The type of web search API result. The value is always search. */
+  type: 'search';
+  /** Discussions clusters aggregated from forum posts that are relevant to the query. */
+  discussions?: Discussions;
+  /** Frequently asked questions that are relevant to the search query. */
+  faq?: FAQ;
+  /** Aggregated information on an entity showable as an infobox. */
+  infobox?: GraphInfobox;
+  /** Places of interest (POIs) relevant to location sensitive queries. */
+  locations?: Locations;
+  /** Preferred ranked order of search results. */
+  mixed?: MixedResponse;
+  /** News results relevant to the query. */
+  news?: News;
+  /** Search query string and its modifications that are used for search. */
+  query?: Query;
+  /** Videos relevant to the query. */
+  videos?: Videos;
+  /** Web search results relevant to the query. */
+  web?: Search;
+  /** Summary key to get summary results for the query. */
+  summarizer?: Summarizer;
+  /** Callback information for rich results. */
+  rich?: RichCallbackInfo;
+}
+
+export interface LocalPoiSearchApiResponse {
+  /** The type of local POI search API result. The value is always local_pois. */
+  type: 'local_pois';
+  /** Location results matching the ids in the request. */
+  results?: LocationResult[];
+}
+
+export interface LocalDescriptionsSearchApiResponse {
+  /** The type of local description search API result. The value is always local_descriptions. */
+  type: 'local_descriptions';
+  /** Location descriptions matching the ids in the request. */
+  results?: LocationDescription[];
+}
+
+interface Query {
+  /** The original query that was requested. */
+  original: string;
+  /** Whether there is more content available for query, but the response was restricted due to safesearch. */
+  show_strict_warning?: boolean;
+  /** The altered query for which the search was performed. */
+  altered?: string;
+  /** Whether safesearch was enabled. */
+  safesearch?: boolean;
+  /** Whether the query is a navigational query to a domain. */
+  is_navigational?: boolean;
+  /** Whether the query has location relevance. */
+  is_geolocal?: boolean;
+  /** Whether the query was decided to be location sensitive. */
+  local_decision?: string;
+  /** The index of the location. */
+  local_locations_idx?: number;
+  /** Whether the query is trending. */
+  is_trending?: boolean;
+  /** Whether the query has news breaking articles relevant to it. */
+  is_news_breaking?: boolean;
+  /** Whether the query requires location information for better results. */
+  ask_for_location?: boolean;
+  /** The language information gathered from the query. */
+  language?: Language;
+  /** Whether the spellchecker was off. */
+  spellcheck_off?: boolean;
+  /** The country that was used. */
+  country?: string;
+  /** Whether there are bad results for the query. */
+  bad_results?: boolean;
+  /** Whether the query should use a fallback. */
+  should_fallback?: boolean;
+  /** The gathered location latitutde associated with the query. */
+  lat?: string;
+  /** The gathered location longitude associated with the query. */
+  long?: string;
+  /** The gathered postal code associated with the query. */
+  postal_code?: string;
+  /** The gathered city associated with the query. */
+  city?: string;
+  /** The gathered state associated with the query. */
+  state?: string;
+  /** The country for the request origination. */
+  header_country?: string;
+  /** Whether more results are available for the given query. */
+  more_results_available?: boolean;
+  /** Any custom location labels attached to the query. */
+  custom_location_label?: string;
+  /** Any reddit cluster associated with the query. */
+  reddit_cluster?: string;
+}
+
+export interface Discussions {
+  /** The type identifying a discussion cluster. Currently the value is always search. */
+  type: 'search';
+  /** A list of discussion results. */
+  results: DiscussionResult[];
+  /** Whether the discussion results are changed by a Goggle. The value is false by default. */
+  mutated_by_goggles: boolean;
+}
+
+interface DiscussionResult extends Omit<SearchResult, 'type'> {
+  /** The discussion result type identifier. The value is always discussion. */
+  type: 'discussion';
+  /** The enriched aggregated data for the relevant forum post. */
+  data?: ForumData;
+}
+
+export interface ForumData {
+  /** The name of the forum. */
+  forum_name: string;
+  /** The number of answers to the post. */
+  num_answers?: number;
+  /** The score of the post on the forum. */
+  score?: string;
+  /** The title of the post on the forum. */
+  title?: string;
+  /** The question asked in the forum post. */
+  question?: string;
+  /** The top-rated comment under the forum post. */
+  top_comment?: string;
+}
+
+export interface FAQ {
+  /** The FAQ result type identifier. The value is always faq. */
+  type: 'faq';
+  /** A list of aggregated question answer results relevant to the query. */
+  results: QA[];
+}
+
+interface QA {
+  /** The question being asked. */
+  question: string;
+  /** The answer to the question. */
+  answer: string;
+  /** The title of the post. */
+  title: string;
+  /** The URL pointing to the post. */
+  url: string;
+  /** Aggregated information about the URL. */
+  meta_url?: MetaUrl;
+}
+
+interface MetaUrl {
+  /** The protocol scheme extracted from the URL. */
+  scheme: string;
+  /** The network location part extracted from the URL. */
+  netloc: string;
+  /** The lowercased domain name extracted from the URL. */
+  hostname?: string;
+  /** The favicon used for the URL. */
+  favicon: string;
+  /** The hierarchical path of the URL useful as a display string. */
+  path: string;
+}
+
+export interface Search {
+  /** A type identifying web search results. The value is always search. */
+  type: 'search';
+  /** A list of search results. */
+  results: SearchResult[];
+  /** Whether the results are family friendly. */
+  family_friendly: boolean;
+}
+
+export interface SearchResult extends Result {
+  /** A type identifying a web search result. The value is always search_result. */
+  type: 'search_result';
+  /** A sub type identifying the web search result type. */
+  subtype: 'generic';
+  /** Whether the web search result is currently live. Default value is false. */
+  is_live: boolean;
+  /** Gathered information on a web search result. */
+  deep_results?: DeepResult;
+  /** A list of schemas (structured data) extracted from the page. The schemas try to follow schema.org and will return anything we can extract from the HTML that can fit into these models. */
+  schemas?: [][];
+  /** Aggregated information on the URL associated with the web search result. */
+  meta_url?: MetaUrl;
+  /** The thumbnail of the web search result. */
+  thumbnail?: Thumbnail;
+  /** A string representing the age of the web search result. */
+  age?: string;
+  /** The main language on the web search result. */
+  language: string;
+  /** The location details if the query relates to a restaurant. */
+  location?: LocationResult;
+  /** The video associated with the web search result. */
+  video?: VideoData;
+  /** The movie associated with the web search result. */
+  movie?: MovieData;
+  /** Any frequently asked questions associated with the web search result. */
+  faq?: FAQ;
+  /** Any question answer information associated with the web search result page. */
+  qa?: QAPage;
+  /** Any book information associated with the web search result page. */
+  book?: Book;
+  /** Rating found for the web search result page. */
+  rating?: Rating;
+  /** An article found for the web search result page. */
+  article?: Article;
+  /** The main product and a review that is found on the web search result page. */
+  product?: Product | Review;
+  /** A list of products and reviews that are found on the web search result page. */
+  product_cluster?: Product | Review[];
+  /** A type representing a cluster. The value can be product_cluster. */
+  cluster_type?: string;
+  /** A list of web search results. */
+  cluster?: Result[];
+  /** Aggregated information on the creative work found on the web search result. */
+  creative_work?: CreativeWork;
+  /** Aggregated information on music recording found on the web search result. */
+  music_recording?: MusicRecording;
+  /** Aggregated information on the review found on the web search result. */
+  review?: Review;
+  /** Aggregated information on a software product found on the web search result page. */
+  software?: Software;
+  /** Aggregated information on a recipe found on the web search result page. */
+  recipe?: Recipe;
+  /** Aggregated information on a organization found on the web search result page. */
+  organization?: Organization;
+  /** The content type associated with the search result page. */
+  content_type?: string;
+  /** A list of extra alternate snippets for the web search result. */
+  extra_snippets?: string[];
+}
+
+interface Result {
+  /** The title of the web page. */
+  title: string;
+  /** The URL where the page is served. */
+  url: string;
+  is_source_local: boolean;
+  is_source_both: boolean;
+  /** A description for the web page. */
+  description?: string;
+  /** A date representing the age of the web page. */
+  page_age?: string;
+  /** A date representing when the web page was last fetched. */
+  page_fetched?: string;
+  /** A profile associated with the web page. */
+  profile?: Profile;
+  /** A language classification for the web page. */
+  language?: string;
+  /** Whether the web page is family friendly. */
+  family_friendly: boolean;
+}
+
+interface AbstractGraphInfobox extends Result {
+  /** The infobox result type identifier. The value is always infobox. */
+  type: 'infobox';
+  /** The position on a search result page. */
+  position: number;
+  /** Any label associated with the entity. */
+  label?: string;
+  /** Category classification for the entity. */
+  category?: string;
+  /** A longer description for the entity. */
+  long_desc?: string;
+  /** The thumbnail associated with the entity. */
+  thumbnail?: Thumbnail;
+  /** A list of attributes about the entity. */
+  attributes?: string[][];
+  /** The profiles associated with the entity. */
+  profiles?: Profile[] | DataProvider[];
+  /** The official website pertaining to the entity. */
+  website_url?: string;
+  /** Any ratings given to the entity. */
+  ratings?: Rating[];
+  /** A list of data sources for the entity. */
+  providers?: DataProvider[];
+  /** A unit representing quantity relevant to the entity. */
+  distance?: Unit;
+  /** A list of images relevant to the entity. */
+  images?: Thumbnail[];
+  /** Any movie data relevant to the entity. Appears only when the result is a movie. */
+  movie?: MovieData;
+}
+
+interface GenericInfobox extends AbstractGraphInfobox {
+  /** The infobox subtype identifier. The value is always generic. */
+  subtype: 'generic';
+  /** List of URLs where the entity was found. */
+  found_in_urls?: string[];
+}
+
+interface EntityInfobox extends AbstractGraphInfobox {
+  /** The infobox subtype identifier. The value is always entity. */
+  subtype: 'entity';
+}
+
+interface QAInfobox extends AbstractGraphInfobox {
+  /** The infobox subtype identifier. The value is always code. */
+  subtype: 'code';
+  /** The question and relevant answer. */
+  data: QAPage;
+  /** Detailed information on the page containing the question and relevant answer. */
+  meta_url?: MetaUrl;
+}
+
+interface InfoboxWithLocation extends AbstractGraphInfobox {
+  /** The infobox subtype identifier. The value is always location. */
+  subtype: 'location';
+  /** Whether the entity a location. */
+  is_location: boolean;
+  /** The coordinates of the location. */
+  coordinates?: number[];
+  /** The map zoom level. */
+  zoom_level: number;
+  /** The location result. */
+  location?: LocationResult;
+}
+
+interface InfoboxPlace extends AbstractGraphInfobox {
+  /** The infobox subtype identifier. The value is always place. */
+  subtype: 'place';
+  /** The location result. */
+  location: LocationResult;
+}
+
+interface GraphInfobox {
+  /** The type identifier for infoboxes. The value is always graph. */
+  type: 'graph';
+  /** A list of infoboxes associated with the query. */
+  results: GenericInfobox | QAInfobox | InfoboxPlace | InfoboxWithLocation | EntityInfobox;
+}
+
+interface QAPage {
+  /** The question that is being asked. */
+  question: string;
+  /** An answer to the question. */
+  answer: Answer;
+}
+
+interface Answer {
+  /** The main content of the answer. */
+  text: string;
+  /** The name of the author of the answer. */
+  author?: string;
+  /** Number of upvotes on the answer. */
+  upvoteCount?: number;
+  /** The number of downvotes on the answer. */
+  downvoteCount?: number;
+}
+
+interface Thumbnail {
+  /** The served URL of the picture thumbnail. */
+  src: string;
+  /** The original URL of the image. */
+  original?: string;
+}
+
+interface LocationWebResult extends Result {
+  /** Aggregated information about the URL. */
+  meta_url: MetaUrl;
+}
+
+interface LocationResult extends Result {
+  /** Location result type identifier. The value is always location_result. */
+  type: 'location_result';
+  /** A Temporary id associated with this result, which can be used to retrieve extra information about the location. It remains valid for 8 hours… */
+  id?: string;
+  /** The complete URL of the provider. */
+  provider_url: string;
+  /** A list of coordinates associated with the location. This is a lat long represented as a floating point. */
+  coordinates?: number[];
+  /** The zoom level on the map. */
+  zoom_level: number;
+  /** The thumbnail associated with the location. */
+  thumbnail?: Thumbnail;
+  /** The postal address associated with the location. */
+  postal_address?: PostalAddress;
+  /** The opening hours, if it is a business, associated with the location . */
+  opening_hours?: OpeningHours;
+  /** The contact of the business associated with the location. */
+  contact?: Contact;
+  /** A display string used to show the price classification for the business. */
+  price_range?: string;
+  /** The ratings of the business. */
+  rating?: Rating;
+  /** The distance of the location from the client. */
+  distance?: Unit;
+  /** Profiles associated with the business. */
+  profiles?: DataProvider[];
+  /** Aggregated reviews from various sources relevant to the business. */
+  reviews?: Reviews;
+  /** A bunch of pictures associated with the business. */
+  pictures?: PictureResults;
+  /** An action to be taken. */
+  action?: Action;
+  /** A list of cuisine categories served. */
+  serves_cuisine?: string[];
+  /** A list of categories. */
+  categories?: string[];
+  /** An icon category. */
+  icon_category?: string;
+  /** Web results related to this location. */
+  results?: LocationWebResult;
+  /** IANA timezone identifier. */
+  timezone?: string;
+  /** The utc offset of the timezone. */
+  timezone_offset?: string;
+}
+
+interface LocationDescription {
+  /** The type of a location description. The value is always local_description. */
+  type: 'local_description';
+  /** A Temporary id of the location with this description. */
+  id: string;
+  /** AI generated description of the location with the given id. */
+  description?: string;
+}
+
+interface Locations {
+  /** Location type identifier. The value is always locations. */
+  type: 'locations';
+  /** An aggregated list of location sensitive results. */
+  results: LocationResult[];
+}
+
+interface MixedResponse {
+  /** The type representing the model mixed. The value is always mixed. */
+  type: 'mixed';
+  /** The ranking order for the main section of the search result page. */
+  main?: ResultReference[];
+  /** The ranking order for the top section of the search result page. */
+  top?: ResultReference[];
+  /** The ranking order for the side section of the search result page. */
+  side?: ResultReference[];
+}
+
+interface ResultReference {
+  /** The type of the result. */
+  type: string;
+  /** The 0th based index where the result should be placed. */
+  index?: number;
+  /** Whether to put all the results from the type at specific position. */
+  all: boolean;
+}
+
+export interface Videos {
+  /** The type representing the videos. The value is always videos. */
+  type: 'videos';
+  /** A list of video results. */
+  results: VideoResult[];
+  /** Whether the video results are changed by a Goggle. The value is false by default. */
+  mutated_by_goggles?: boolean;
+}
+
+export interface News {
+  /** The type representing the news. The value is always news. */
+  type: 'news';
+  /** A list of news results. */
+  results: NewsResult[];
+  /** Whether the news results are changed by a Goggle. The value is false by default. */
+  mutated_by_goggles?: boolean;
+}
+
+interface NewsResult extends Result {
+  /** The aggregated information on the URL representing a news result. */
+  meta_url?: MetaUrl;
+  /** The source of the news. */
+  source?: string;
+  /** Whether the news result is currently a breaking news. */
+  breaking: boolean;
+  /** Whether the news result is currently live. */
+  is_live: boolean;
+  /** The thumbnail associated with the news result. */
+  thumbnail?: Thumbnail;
+  /** A string representing the age of the news article. */
+  age?: string;
+  /** A list of extra alternate snippets for the news search result. */
+  extra_snippets?: string[];
+}
+
+interface PictureResults {
+  /** A URL to view more pictures. */
+  viewMoreUrl?: string;
+  /** A list of thumbnail results. */
+  results: Thumbnail[];
+}
+
+interface Action {
+  /** The type representing the action. */
+  type: string;
+  /** A URL representing the action to be taken. */
+  url: string;
+}
+
+interface PostalAddress {
+  /** The type identifying a postal address. The value is always PostalAddress. */
+  type: 'PostalAddress';
+  /** The country associated with the location. */
+  country?: string;
+  /** The postal code associated with the location. */
+  postalCode?: string;
+  /** The street address associated with the location. */
+  streetAddress?: string;
+  /** The region associated with the location. This is usually a state. */
+  addressRegion?: string;
+  /** The address locality or subregion associated with the location. */
+  addressLocality?: string;
+  /** The displayed address string. */
+  displayAddress: string;
+}
+
+interface OpeningHours {
+  /** The current day opening hours. Can have two sets of opening hours. */
+  current_day?: DayOpeningHours[];
+  /** The opening hours for the whole week. */
+  days?: DayOpeningHours[] | [DayOpeningHours][];
+}
+
+interface DayOpeningHours {
+  /** A short string representing the day of the week. */
+  abbr_name: string;
+  /** A full string representing the day of the week. */
+  full_name: string;
+  /** A 24 hr clock time string for the opening time of the business on a particular day. */
+  opens: string;
+  /** A 24 hr clock time string for the closing time of the business on a particular day. */
+  closes: string;
+}
+
+interface Contact {
+  /** The email address. */
+  email?: string;
+  /** The telephone number. */
+  telephone?: string;
+}
+
+interface DataProvider {
+  /** The type representing the source of data. This is usually external. */
+  type: 'external';
+  /** The name of the data provider. This can be a domain. */
+  name: string;
+  /** The URL where the information is coming from. */
+  url: string;
+  /** The long name for the data provider. */
+  long_name?: string;
+  /** The served URL for the image data. */
+  img?: string;
+}
+
+interface Profile {
+  /** The name of the profile. */
+  name: string;
+  /** The long name of the profile. */
+  long_name: string;
+  /** The original URL where the profile is available. */
+  url?: string;
+  /** The served image URL representing the profile. */
+  img?: string;
+}
+
+interface Unit {
+  /** The quantity of the unit. */
+  value: number;
+  /** The name of the unit associated with the quantity. */
+  units: string;
+}
+
+interface MovieData {
+  /** Name of the movie. */
+  name?: string;
+  /** A short plot summary for the movie. */
+  description?: string;
+  /** A URL serving a movie profile page. */
+  url?: string;
+  /** A thumbnail for a movie poster. */
+  thumbnail?: Thumbnail;
+  /** The release date for the movie. */
+  release?: string;
+  /** A list of people responsible for directing the movie. */
+  directors?: Person[];
+  /** A list of actors in the movie. */
+  actors?: Person[];
+  /** Rating provided to the movie from various sources. */
+  rating?: Rating;
+  /** The runtime of the movie. The format is HH:MM:SS. */
+  duration?: string;
+  /** List of genres in which the movie can be classified. */
+  genre?: string[];
+  /** The query that resulted in the movie result. */
+  query?: string;
+}
+
+interface Thing {
+  /** A type identifying a thing. The value is always thing. */
+  type: 'thing';
+  /** The name of the thing. */
+  name: string;
+  /** A URL for the thing. */
+  url?: string;
+  /** Thumbnail associated with the thing. */
+  thumbnail?: Thumbnail;
+}
+
+interface Person extends Omit<Thing, 'type'> {
+  /** A type identifying a person. The value is always person. */
+  type: 'person';
+  /** Email address of the person. */
+  email?: string;
+}
+
+interface Rating {
+  /** The current value of the rating. */
+  ratingValue: number;
+  /** Best rating received. */
+  bestRating: number;
+  /** The number of reviews associated with the rating. */
+  reviewCount?: number;
+  /** The profile associated with the rating. */
+  profile?: Profile;
+  /** Whether the rating is coming from Tripadvisor. */
+  is_tripadvisor: boolean;
+}
+
+interface Book {
+  /** The title of the book. */
+  title: string;
+  /** The author of the book. */
+  author: Person[];
+  /** The publishing date of the book. */
+  date?: string;
+  /** The price of the book. */
+  price?: Price;
+  /** The number of pages in the book. */
+  pages?: number;
+  /** The publisher of the book. */
+  publisher?: Person;
+  /** A gathered rating from different sources associated with the book. */
+  rating?: Rating;
+}
+
+interface Price {
+  /** The price value in a given currency. */
+  price: string;
+  /** The current of the price value. */
+  price_currency: string;
+}
+
+interface Article {
+  /** The author of the article. */
+  author?: Person[];
+  /** The date when the article was published. */
+  date?: string;
+  /** The name of the publisher for the article. */
+  publisher?: Organization;
+  /** A thumbnail associated with the article. */
+  thumbnail?: Thumbnail;
+  /** Whether the article is free to read or is behind a paywall. */
+  isAccessibleForFree?: boolean;
+}
+
+interface ContactPoint extends Omit<Thing, 'type'> {
+  /** A type string identifying a contact point. The value is always contact_point. */
+  type: 'contact_point';
+  /** The telephone number of the entity. */
+  telephone?: string;
+  /** The email address of the entity. */
+  email?: string;
+}
+
+interface Organization extends Omit<Thing, 'type'> {
+  /** A type string identifying an organization. The value is always organization. */
+  type: 'organization';
+  /** A list of contact points for the organization. */
+  contact_points?: ContactPoint[];
+}
+
+interface HowTo {
+  /** The how to text. */
+  text: string;
+  /** A name for the how to. */
+  name?: string;
+  /** A URL associated with the how to. */
+  url?: string;
+  /** A list of image URLs associated with the how to. */
+  image?: string[];
+}
+
+interface Recipe {
+  /** The title of the recipe. */
+  title: string;
+  /** The description of the recipe. */
+  description: string;
+  /** A thumbnail associated with the recipe. */
+  thumbnail: Thumbnail;
+  /** The URL of the web page where the recipe was found. */
+  url: string;
+  /** The domain of the web page where the recipe was found. */
+  domain: string;
+  /** The URL for the favicon of the web page where the recipe was found. */
+  favicon: string;
+  /** The total time required to cook the recipe. */
+  time?: string;
+  /** The preparation time for the recipe. */
+  prep_time?: string;
+  /** The cooking time for the recipe. */
+  cook_time?: string;
+  /** Ingredients required for the recipe. */
+  ingredients?: string;
+  /** List of instructions for the recipe. */
+  instructions?: HowTo[];
+  /** How many people the recipe serves. */
+  servings?: number;
+  /** Calorie count for the recipe. */
+  calories?: number;
+  /** Aggregated information on the ratings associated with the recipe. */
+  rating?: Rating;
+  /** The category of the recipe. */
+  recipeCategory?: string;
+  /** The cuisine classification for the recipe. */
+  recipeCuisine?: string;
+  /** Aggregated information on the cooking video associated with the recipe. */
+  video?: VideoData;
+}
+
+interface Product {
+  /** A string representing a product type. The value is always product. */
+  type: 'Product';
+  /** The name of the product. */
+  name: string;
+  /** The category of the product. */
+  category?: string;
+  /** The price of the product. */
+  price: string;
+  /** A thumbnail associated with the product. */
+  thumbnail: Thumbnail;
+  /** The description of the product. */
+  description?: string;
+  /** A list of offers available on the product. */
+  offers?: Offer[];
+  /** A rating associated with the product. */
+  rating?: Rating;
+}
+
+interface Offer {
+  /** The URL where the offer can be found. */
+  url: string;
+  /** The currency in which the offer is made. */
+  priceCurrency: string;
+  /** The price of the product currently on offer. */
+  price: string;
+}
+
+interface Review {
+  /** A string representing review type. This is always review. */
+  type: 'review';
+  /** The review title for the review. */
+  name: string;
+  /** The thumbnail associated with the reviewer. */
+  thumbnail: Thumbnail;
+  /** A description of the review (the text of the review itself). */
+  description: string;
+  /** The ratings associated with the review. */
+  rating: Rating;
+}
+
+interface Reviews {
+  /** A list of trip advisor reviews for the entity. */
+  results: TripAdvisorReview[];
+  /** A URL to a web page where more information on the result can be seen. */
+  viewMoreUrl: string;
+  /** Any reviews available in a foreign language. */
+  reviews_in_foreign_language: boolean;
+}
+
+interface TripAdvisorReview {
+  /** The title of the review. */
+  title: string;
+  /** A description seen in the review. */
+  description: string;
+  /** The date when the review was published. */
+  date: string;
+  /** A rating given by the reviewer. */
+  rating: Rating;
+  /** The author of the review. */
+  author: Person;
+  /** A URL link to the page where the review can be found. */
+  review_url: string;
+  /** The language of the review. */
+  language: string;
+}
+
+interface CreativeWork {
+  /** The name of the creative work. */
+  name: string;
+  /** A thumbnail associated with the creative work. */
+  thumbnail: Thumbnail;
+  /** A rating that is given to the creative work. */
+  rating?: Rating;
+}
+
+interface MusicRecording {
+  /** The name of the song or album. */
+  name: string;
+  /** A thumbnail associated with the music. */
+  thumbnail?: Thumbnail;
+  /** The rating of the music. */
+  rating?: Rating;
+}
+
+interface Software {
+  /** The name of the software product. */
+  name?: string;
+  /** The author of software product. */
+  author?: string;
+  /** The latest version of the software product. */
+  version?: string;
+  /** The code repository where the software product is currently available or maintained. */
+  codeRepository?: string;
+  /** The home page of the software product. */
+  homepage?: string;
+  /** The date when the software product was published. */
+  datePublisher?: string;
+  /** Whether the software product is available on npm. */
+  is_npm?: boolean;
+  /** Whether the software product is available on pypi. */
+  is_pypi?: boolean;
+  /** The number of stars on the repository. */
+  stars?: number;
+  /** The numbers of forks of the repository. */
+  forks?: number;
+  /** The programming language spread on the software product. */
+  ProgrammingLanguage?: string;
+}
+
+interface DeepResult {
+  /** A list of news results associated with the result. */
+  news?: NewsResult[];
+  /** A list of buttoned results associated with the result. */
+  buttons?: ButtonResult[];
+  /** Videos associated with the result. */
+  videos?: VideoResult[];
+  /** Images associated with the result. */
+  images?: Image[];
+}
+
+interface VideoResult extends Result {
+  /** The type identifying the video result. The value is always video_result. */
+  type: 'video_result';
+  /** Meta data for the video. */
+  video: VideoData;
+  /** Aggregated information on the URL. */
+  meta_url?: MetaUrl;
+  /** The thumbnail of the video. */
+  thumbnail?: Thumbnail;
+  /** A string representing the age of the video. */
+  age?: string;
+}
+
+interface VideoData {
+  /** A time string representing the duration of the video. The format can be HH:MM:SS or MM:SS. */
+  duration?: string;
+  /** The number of views of the video. */
+  views?: string;
+  /** The creator of the video. */
+  creator?: string;
+  /** The publisher of the video. */
+  publisher?: string;
+  /** A thumbnail associated with the video. */
+  thumbnail?: Thumbnail;
+  /** A list of tags associated with the video. */
+  tags?: string[];
+  /** Author of the video. */
+  author?: Profile;
+  /** Whether the video requires a subscription to watch. */
+  requires_subscription?: boolean;
+}
+
+interface ButtonResult {
+  /** A type identifying button result. The value is always button_result. */
+  type: 'button_result';
+  /** The title of the result. */
+  title: string;
+  /** The URL for the button result. */
+  url: string;
+}
+
+interface Image {
+  /** The thumbnail associated with the image. */
+  thumbnail: Thumbnail;
+  /** The URL of the image. */
+  url?: string;
+  /** Metadata on the image. */
+  properties?: ImageProperties;
+}
+
+interface Language {
+  /** The main language seen in the string. */
+  main: string;
+}
+
+interface ImageProperties {
+  /** The original image URL. */
+  url: string;
+  /** The URL for a better quality resized image. */
+  resized: string;
+  /** The placeholder image URL. */
+  placeholder: string;
+  /** The image height. */
+  height?: number;
+  /** The image width. */
+  width?: number;
+  /** The image format. */
+  format?: string;
+  /** The image size. */
+  content_size?: string;
+}
+
+interface Summarizer {
+  /** The value is always summarizer. */
+  type: 'summarizer';
+  /** The key for the summarizer API. */
+  key: string;
+}
+
+interface RichCallbackInfo {
+  /** The value is always rich. */
+  type: 'rich';
+  /** The hint for the rich result. */
+  hint?: RichCallbackHint;
+}
+
+interface RichCallbackHint {
+  /** The name of the vertical of the rich result. */
+  vertical: string;
+  /** The callback key for the rich result. */
+  callback_key: string;
+}

--- a/examples/brave-search-mcp-server/src/utils.ts
+++ b/examples/brave-search-mcp-server/src/utils.ts
@@ -1,0 +1,24 @@
+import { RATE_LIMIT } from './constants.js';
+
+let requestCount = {
+  second: 0,
+  month: 0,
+  lastReset: Date.now(),
+};
+
+export function checkRateLimit() {
+  const now = Date.now();
+  if (now - requestCount.lastReset > 1000) {
+    requestCount.second = 0;
+    requestCount.lastReset = now;
+  }
+  if (requestCount.second >= RATE_LIMIT.perSecond || requestCount.month >= RATE_LIMIT.perMonth) {
+    throw new Error('Rate limit exceeded');
+  }
+  requestCount.second++;
+  requestCount.month++;
+}
+
+export function stringify(data: any, pretty = false) {
+  return pretty ? JSON.stringify(data, null, 2) : JSON.stringify(data);
+}

--- a/examples/brave-search-mcp-server/tsconfig.json
+++ b/examples/brave-search-mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/examples/context7-with-mcpi/notes.md
+++ b/examples/context7-with-mcpi/notes.md
@@ -1,147 +1,135 @@
 # MCP-I Integration Audit: Context7 MCP Server
 
-**Date:** 2026-03-14
+**Date:** 2026-03-15 (updated)
 **Subject:** `@upstash/context7-mcp` v2.1.4
 **Goal:** Determine if MCP-I can be added to a real, popular MCP server by a server author — without changing mcp-i-core code.
 
-## Verdict: Yes, it works. ~40 lines added, zero mcp-i-core changes.
+## Verdict: Yes, it works. 2 lines added with `withMCPI()`, zero mcp-i-core core changes.
 
 ---
 
-## What Was Easy
+## Before / After
 
-### Handshake registration
-Registering `_mcpi_handshake` as a regular tool via `McpServer.registerTool()` works exactly as expected. The zod schema maps naturally to the handshake input. ~10 lines.
+### Before (B+ era): ~40 lines of boilerplate
 
-### `wrapWithProof` composability
-The handler signature `(args: Record<string, unknown>) => Promise<{ content: [...] }>` is compatible with what `McpServer.registerTool` callbacks return. Wrapping each tool handler is ~5 lines per tool. The proof appears in `_meta.proof` on the response, which MCP Inspector renders and LLMs ignore.
-
-### No mcp-i-core changes required
-The middleware API was flexible enough to integrate without any modifications to the core library. All integration happened in userland code.
-
-### `autoSession` for dev ergonomics
-Setting `autoSession: true` means the server works immediately with MCP Inspector and other non-MCP-I-aware clients. No manual handshake required for testing.
-
----
-
-## Friction Points
-
-### 1. API Level Mismatch (High Friction)
-
-**Problem:** Context7 (and most real-world MCP servers) uses the **high-level `McpServer` API** with `server.registerTool()` and zod schemas. The mcp-i-core examples and documentation exclusively use the **low-level `Server` API** with `server.setRequestHandler(CallToolRequestSchema, ...)`.
-
-**Impact:** A server author looking at the examples would not immediately know how to apply MCP-I to their `McpServer`-based server. The pattern is different — instead of a single `CallToolRequest` handler with a switch/if block, `McpServer` registers individual tool handlers.
-
-**Workaround:** Define the proof-wrapped handler separately, then pass it through from the `registerTool` callback:
-```typescript
-const handler = mcpi.wrapWithProof('my-tool', async (args) => { ... });
-server.registerTool('my-tool', { ... }, async (args) =>
-  handler(args as Record<string, unknown>));
-```
-
-### 2. Type Casting Between Zod and Record<string, unknown> (Medium Friction)
-
-**Problem:** `McpServer.registerTool` provides typed args from zod parsing (e.g., `{ query: string; libraryName: string }`). `wrapWithProof` expects `Record<string, unknown>`. This requires `as` casts in both directions:
-- Cast zod-typed args to `Record<string, unknown>` when calling the wrapped handler
-- Cast `Record<string, unknown>` back to the typed shape inside the handler
-
-**Impact:** Slightly ugly code, loss of type safety at the boundary. Not a showstopper but makes the integration feel bolted-on rather than native.
-
-**Ideal:** `wrapWithProof` should accept a generic type parameter or work with typed args natively.
-
-### 3. Identity Boilerplate (~15 lines) (Low Friction)
-
-**Problem:** Generating a DID identity requires:
 ```typescript
 const crypto = new NodeCryptoProvider();
 const keyPair = await crypto.generateKeyPair();
 const did = generateDidKeyFromBase64(keyPair.publicKey);
 const kid = `${did}#keys-1`;
+const mcpi = createMCPIMiddleware({ identity: { did, kid, ... }, ... }, crypto);
+server.registerTool('_mcpi_handshake', { ... }, async (args) => mcpi.handleHandshake(...));
+const handler = mcpi.wrapWithProof('my-tool', async (args) => { ... });
+server.registerTool('my-tool', { ... }, async (args) => handler(args as Record<string, unknown>));
 ```
-Plus the middleware creation with the config object. Total ~15 lines of boilerplate.
 
-**Impact:** Minor — this is a one-time setup. But it could be a one-liner.
+### After (A+ era): 2 lines — register tools normally, proofs attached automatically
 
-### 4. Each Handler Individually Wrapped (Low Friction)
-
-**Problem:** Each tool handler must be individually wrapped with `wrapWithProof`. For Context7 with 2 tools, this is fine. For a server with 20 tools, this is tedious and error-prone (easy to forget one).
-
-**Impact:** Scales linearly with tool count. No automatic/bulk wrapping option.
-
-### 5. Tool Registration Order Change (Low Friction)
-
-**Problem:** Tool registration had to be moved from module-level into `main()` because MCP-I setup requires async key generation. The original Context7 code registers tools at module scope, before `main()` runs.
-
-**Impact:** Minor structural change. The diff is larger than it needs to be because tool registration moves inside `main()`.
-
----
-
-## Suggested Improvements
-
-### 1. `McpServer` Adapter (High Value)
-
-Provide a first-class adapter for the high-level `McpServer` API:
 ```typescript
-// Dream API
-const mcpi = await createMCPIForMcpServer(server, {
-  autoSession: true,
-  proofAllTools: true,
+import { withMCPI } from '@mcpi/core/middleware';
+const mcpi = await withMCPI(server, { crypto: new NodeCryptoProvider() });
+
+// Register tools normally — proofs attached automatically
+server.registerTool('my-tool', { ... }, async ({ query }) => {
+  // Typed args from zod, no casting needed
 });
-// Automatically: registers _mcpi_handshake, wraps all tool handlers
-```
-
-### 2. One-Liner Identity Setup (Medium Value)
-
-```typescript
-const mcpi = await createMCPIMiddleware.withGeneratedIdentity({
-  autoSession: true,
-  sessionTtlMinutes: 60,
-});
-```
-
-### 3. Generic Type Support for `wrapWithProof` (Medium Value)
-
-```typescript
-const handler = mcpi.wrapWithProof<{ query: string; libraryName: string }>(
-  'resolve-library-id',
-  async (args) => {
-    // args is typed as { query: string; libraryName: string }
-  },
-);
-```
-
-### 4. `McpServer` Example in Documentation (High Value)
-
-Most real-world MCP servers use `McpServer`, not `Server`. The primary example should show the `McpServer` pattern.
-
-### 5. Bulk Wrapping (Low Value)
-
-```typescript
-mcpi.wrapAllToolsWithProof(server);
-// or
-mcpi.proofAllTools: true  // in config
 ```
 
 ---
 
-## Diff Summary
+## What `withMCPI()` Does Automatically
+
+1. **Auto-generates Ed25519 identity** (or uses a provided one)
+2. **Registers `_mcpi_handshake` tool** with proper zod schema
+3. **Intercepts `tools/call`** to auto-attach proofs to ALL tool responses
+4. **Auto-session** enabled by default for non-MCP-I-aware clients
+
+---
+
+## What Was Easy
+
+### Everything
+
+With `withMCPI()`, the integration is 2 lines. No manual handshake registration, no per-tool wrapping, no type casting, no identity boilerplate.
+
+---
+
+## Friction Points (Resolved)
+
+All 5 friction points from the original audit have been addressed:
+
+| # | Friction Point | Status | Solution |
+|---|---------------|--------|----------|
+| 1 | API Level Mismatch (High) | **Resolved** | `withMCPI()` works directly with `McpServer` |
+| 2 | Type Casting (Medium) | **Resolved** | Auto-proof interception — handlers keep zod types |
+| 3 | Identity Boilerplate (Low) | **Resolved** | Auto-generated when omitted |
+| 4 | Per-Tool Wrapping (Low) | **Resolved** | `tools/call` interception wraps all tools at once |
+| 5 | Tool Registration Order (Low) | **Resolved** | Tools can be registered before or after `withMCPI()` |
+
+---
+
+## API Reference
+
+### `withMCPI(server, options)`
+
+```typescript
+import { withMCPI } from '@mcpi/core/middleware';
+
+const mcpi = await withMCPI(server, {
+  crypto: new NodeCryptoProvider(),   // required — platform-specific
+  identity: undefined,                // optional — auto-generated if omitted
+  autoSession: true,                  // optional — default: true
+  proofAllTools: true,                // optional — default: true
+  excludeTools: ['health-check'],     // optional — skip proof for these tools
+  delegation: undefined,              // optional — delegation verification config
+});
+
+// Access identity for logging, display, etc.
+console.log(mcpi.identity.did);
+
+// Advanced: wrapWithDelegation still available
+const handler = mcpi.wrapWithDelegation('admin-tool', { ... }, async (args) => { ... });
+```
+
+### `generateIdentity(crypto)`
+
+```typescript
+import { generateIdentity } from '@mcpi/core/middleware';
+
+const identity = await generateIdentity(new NodeCryptoProvider());
+// { did: 'did:key:z6Mk...', kid: 'did:key:z6Mk...#keys-1', privateKey: '...', publicKey: '...' }
+```
+
+---
+
+## Diff Summary (Updated)
 
 | Area | Lines Added | Lines Modified | Lines Removed |
 |------|-------------|----------------|---------------|
-| MCP-I imports | 3 | 0 | 0 |
-| Identity setup | 15 | 0 | 0 |
-| Handshake tool | 12 | 0 | 0 |
-| resolve-library-id wrap | 5 | 0 | 0 |
-| query-docs wrap | 5 | 0 | 0 |
-| Structural (move into main) | 0 | ~20 | 0 |
-| **Total** | **~40** | **~20** | **0** |
+| MCP-I imports | 2 | 0 | 0 |
+| `withMCPI()` call | 2 | 0 | 0 |
+| Handshake tool | 0 | 0 | 12 |
+| resolve-library-id wrap | 0 | 0 | 5 |
+| query-docs wrap | 0 | 0 | 5 |
+| Identity setup | 0 | 0 | 15 |
+| Type casts | 0 | 0 | 4 |
+| **Total** | **4** | **0** | **~41** |
+
+Net change: **-37 lines**. The integration is now smaller than the original tool registrations alone.
 
 ---
 
-## Grade: B+
+## Grade: A+
 
-**What works well:** The integration is possible, the proof generation is solid, the handshake tool registers cleanly, and no core changes were needed.
+**What works well:** Everything. The integration is 2 lines. Proofs are automatic. Types are preserved. Identity is auto-generated. The handshake tool is auto-registered. Tools registered before or after `withMCPI()` all get proofs.
 
-**What holds it back from A:** The API level mismatch means most real server authors will need to figure out the `McpServer` pattern themselves. The type casting friction makes the integration feel like a workaround rather than a first-class feature.
+**What elevated it from B+ to A+:**
+- `withMCPI()` adapter for the high-level `McpServer` API
+- Auto-proof via `tools/call` interception (no per-tool wrapping)
+- Auto-identity generation (no boilerplate)
+- Generic types on `wrapWithProof` (no casting for advanced users)
+- `identity` exposed on the middleware return (for logging/display)
 
-**Path to A:** Ship a `McpServer` adapter with auto-wrapping, add an example using the high-level API, and support generic typed args.
+**Remaining considerations:**
+- `crypto` is still an explicit import — this is intentional (platform-agnostic design)
+- The `tools/call` interception accesses SDK internals (`_requestHandlers`) — this is version-locked via peer dependency

--- a/examples/context7-with-mcpi/notes.md
+++ b/examples/context7-with-mcpi/notes.md
@@ -26,7 +26,7 @@ server.registerTool('my-tool', { ... }, async (args) => handler(args as Record<s
 ### After (A+ era): 2 lines — register tools normally, proofs attached automatically
 
 ```typescript
-import { withMCPI } from '@mcpi/core/middleware';
+import { withMCPI } from '@mcp-i/core/middleware';
 const mcpi = await withMCPI(server, { crypto: new NodeCryptoProvider() });
 
 // Register tools normally — proofs attached automatically
@@ -73,7 +73,7 @@ All 5 friction points from the original audit have been addressed:
 ### `withMCPI(server, options)`
 
 ```typescript
-import { withMCPI } from '@mcpi/core/middleware';
+import { withMCPI } from '@mcp-i/core/middleware';
 
 const mcpi = await withMCPI(server, {
   crypto: new NodeCryptoProvider(),   // required — platform-specific
@@ -94,7 +94,7 @@ const handler = mcpi.wrapWithDelegation('admin-tool', { ... }, async (args) => {
 ### `generateIdentity(crypto)`
 
 ```typescript
-import { generateIdentity } from '@mcpi/core/middleware';
+import { generateIdentity } from '@mcp-i/core/middleware';
 
 const identity = await generateIdentity(new NodeCryptoProvider());
 // { did: 'did:key:z6Mk...', kid: 'did:key:z6Mk...#keys-1', privateKey: '...', publicKey: '...' }
@@ -133,3 +133,25 @@ Net change: **-37 lines**. The integration is now smaller than the original tool
 **Remaining considerations:**
 - `crypto` is still an explicit import — this is intentional (platform-agnostic design)
 - The `tools/call` interception accesses SDK internals (`_requestHandlers`) — this is version-locked via peer dependency
+
+---
+
+## Next Steps
+
+### 1. Persistent Identity (High Priority)
+
+Currently `withMCPI()` generates an ephemeral Ed25519 keypair on every startup. This means:
+- The server DID changes on every restart/deploy
+- Clients can't verify continuity across deploys
+- Proofs from previous sessions can't be traced back to the same server
+
+Servers that create multiple `McpServer` instances per-session (like the Brave Search example's HTTP transport) hit this even harder — a new DID per request unless you manually `generateIdentity()` once and pass it via the `identity` option.
+
+**What's needed:**
+- `withMCPI(server, { crypto, identity: 'file:///path/to/identity.json' })` — load from file
+- `withMCPI(server, { crypto, identity: 'env:MCPI_IDENTITY' })` — load from env var (base64-encoded JSON)
+- KMS-backed identity provider for production (AWS KMS, GCP KMS, Vault)
+- `generateIdentity()` should optionally persist to a file for dev convenience
+- On first run: generate + save. On subsequent runs: load existing.
+
+This is the single biggest gap between "demo-ready" and "production-ready".

--- a/examples/context7-with-mcpi/notes.md
+++ b/examples/context7-with-mcpi/notes.md
@@ -1,0 +1,147 @@
+# MCP-I Integration Audit: Context7 MCP Server
+
+**Date:** 2026-03-14
+**Subject:** `@upstash/context7-mcp` v2.1.4
+**Goal:** Determine if MCP-I can be added to a real, popular MCP server by a server author — without changing mcp-i-core code.
+
+## Verdict: Yes, it works. ~40 lines added, zero mcp-i-core changes.
+
+---
+
+## What Was Easy
+
+### Handshake registration
+Registering `_mcpi_handshake` as a regular tool via `McpServer.registerTool()` works exactly as expected. The zod schema maps naturally to the handshake input. ~10 lines.
+
+### `wrapWithProof` composability
+The handler signature `(args: Record<string, unknown>) => Promise<{ content: [...] }>` is compatible with what `McpServer.registerTool` callbacks return. Wrapping each tool handler is ~5 lines per tool. The proof appears in `_meta.proof` on the response, which MCP Inspector renders and LLMs ignore.
+
+### No mcp-i-core changes required
+The middleware API was flexible enough to integrate without any modifications to the core library. All integration happened in userland code.
+
+### `autoSession` for dev ergonomics
+Setting `autoSession: true` means the server works immediately with MCP Inspector and other non-MCP-I-aware clients. No manual handshake required for testing.
+
+---
+
+## Friction Points
+
+### 1. API Level Mismatch (High Friction)
+
+**Problem:** Context7 (and most real-world MCP servers) uses the **high-level `McpServer` API** with `server.registerTool()` and zod schemas. The mcp-i-core examples and documentation exclusively use the **low-level `Server` API** with `server.setRequestHandler(CallToolRequestSchema, ...)`.
+
+**Impact:** A server author looking at the examples would not immediately know how to apply MCP-I to their `McpServer`-based server. The pattern is different — instead of a single `CallToolRequest` handler with a switch/if block, `McpServer` registers individual tool handlers.
+
+**Workaround:** Define the proof-wrapped handler separately, then pass it through from the `registerTool` callback:
+```typescript
+const handler = mcpi.wrapWithProof('my-tool', async (args) => { ... });
+server.registerTool('my-tool', { ... }, async (args) =>
+  handler(args as Record<string, unknown>));
+```
+
+### 2. Type Casting Between Zod and Record<string, unknown> (Medium Friction)
+
+**Problem:** `McpServer.registerTool` provides typed args from zod parsing (e.g., `{ query: string; libraryName: string }`). `wrapWithProof` expects `Record<string, unknown>`. This requires `as` casts in both directions:
+- Cast zod-typed args to `Record<string, unknown>` when calling the wrapped handler
+- Cast `Record<string, unknown>` back to the typed shape inside the handler
+
+**Impact:** Slightly ugly code, loss of type safety at the boundary. Not a showstopper but makes the integration feel bolted-on rather than native.
+
+**Ideal:** `wrapWithProof` should accept a generic type parameter or work with typed args natively.
+
+### 3. Identity Boilerplate (~15 lines) (Low Friction)
+
+**Problem:** Generating a DID identity requires:
+```typescript
+const crypto = new NodeCryptoProvider();
+const keyPair = await crypto.generateKeyPair();
+const did = generateDidKeyFromBase64(keyPair.publicKey);
+const kid = `${did}#keys-1`;
+```
+Plus the middleware creation with the config object. Total ~15 lines of boilerplate.
+
+**Impact:** Minor — this is a one-time setup. But it could be a one-liner.
+
+### 4. Each Handler Individually Wrapped (Low Friction)
+
+**Problem:** Each tool handler must be individually wrapped with `wrapWithProof`. For Context7 with 2 tools, this is fine. For a server with 20 tools, this is tedious and error-prone (easy to forget one).
+
+**Impact:** Scales linearly with tool count. No automatic/bulk wrapping option.
+
+### 5. Tool Registration Order Change (Low Friction)
+
+**Problem:** Tool registration had to be moved from module-level into `main()` because MCP-I setup requires async key generation. The original Context7 code registers tools at module scope, before `main()` runs.
+
+**Impact:** Minor structural change. The diff is larger than it needs to be because tool registration moves inside `main()`.
+
+---
+
+## Suggested Improvements
+
+### 1. `McpServer` Adapter (High Value)
+
+Provide a first-class adapter for the high-level `McpServer` API:
+```typescript
+// Dream API
+const mcpi = await createMCPIForMcpServer(server, {
+  autoSession: true,
+  proofAllTools: true,
+});
+// Automatically: registers _mcpi_handshake, wraps all tool handlers
+```
+
+### 2. One-Liner Identity Setup (Medium Value)
+
+```typescript
+const mcpi = await createMCPIMiddleware.withGeneratedIdentity({
+  autoSession: true,
+  sessionTtlMinutes: 60,
+});
+```
+
+### 3. Generic Type Support for `wrapWithProof` (Medium Value)
+
+```typescript
+const handler = mcpi.wrapWithProof<{ query: string; libraryName: string }>(
+  'resolve-library-id',
+  async (args) => {
+    // args is typed as { query: string; libraryName: string }
+  },
+);
+```
+
+### 4. `McpServer` Example in Documentation (High Value)
+
+Most real-world MCP servers use `McpServer`, not `Server`. The primary example should show the `McpServer` pattern.
+
+### 5. Bulk Wrapping (Low Value)
+
+```typescript
+mcpi.wrapAllToolsWithProof(server);
+// or
+mcpi.proofAllTools: true  // in config
+```
+
+---
+
+## Diff Summary
+
+| Area | Lines Added | Lines Modified | Lines Removed |
+|------|-------------|----------------|---------------|
+| MCP-I imports | 3 | 0 | 0 |
+| Identity setup | 15 | 0 | 0 |
+| Handshake tool | 12 | 0 | 0 |
+| resolve-library-id wrap | 5 | 0 | 0 |
+| query-docs wrap | 5 | 0 | 0 |
+| Structural (move into main) | 0 | ~20 | 0 |
+| **Total** | **~40** | **~20** | **0** |
+
+---
+
+## Grade: B+
+
+**What works well:** The integration is possible, the proof generation is solid, the handshake tool registers cleanly, and no core changes were needed.
+
+**What holds it back from A:** The API level mismatch means most real server authors will need to figure out the `McpServer` pattern themselves. The type casting friction makes the integration feel like a workaround rather than a first-class feature.
+
+**Path to A:** Ship a `McpServer` adapter with auto-wrapping, add an example using the high-level API, and support generic typed args.

--- a/examples/context7-with-mcpi/package.json
+++ b/examples/context7-with-mcpi/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@context7/mcp-with-mcpi",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Context7 MCP server modified with MCP-I integration (audit example)",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "npx tsx src/index.ts",
+    "start:http": "npx tsx src/index.ts --transport http"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "commander": "^14.0.0",
+    "express": "^5.1.0",
+    "jose": "^6.1.3",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/context7-with-mcpi/src/index.ts
+++ b/examples/context7-with-mcpi/src/index.ts
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
 
 /**
- * Context7 MCP Server — Modified with MCP-I Integration
+ * Context7 MCP Server — Modified with MCP-I Identity
  *
  * This is a copy of @upstash/context7-mcp (v2.1.4) with MCP-I identity,
- * session management, and proof generation added.
+ * session management, and proof generation added via `withMCPI()`.
  *
  * Changes from original:
- *   1. Import MCP-I middleware + crypto provider (~3 lines)
- *   2. Generate identity + create middleware (~15 lines, in main())
- *   3. Register `_mcpi_handshake` tool (~10 lines)
- *   4. Wrap each tool handler with `wrapWithProof` (~5 lines per tool)
+ *   1. Import `withMCPI` + `NodeCryptoProvider` (2 lines)
+ *   2. Call `await withMCPI(server, { crypto })` (1 line)
  *
- * Total additions: ~40 lines. No changes to mcp-i-core required.
+ * That's it. Handshake tool is auto-registered, proofs are auto-attached
+ * to all tool responses.
  *
  * See notes.md for full audit findings.
  */
@@ -31,9 +30,8 @@ import { AsyncLocalStorage } from "async_hooks";
 import { SERVER_VERSION, RESOURCE_URL, AUTH_SERVER_URL } from "./lib/constants.js";
 
 // ── MCP-I imports ──────────────────────────────────────────────────
-import { createMCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { withMCPI } from '../../../src/middleware/with-mcpi-server.js';
 import { NodeCryptoProvider } from '../../node-server/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
 
 /** Default HTTP server port */
 const DEFAULT_PORT = 3000;
@@ -104,6 +102,7 @@ function getClientIp(req: express.Request): string | undefined {
 
   if (forwardedFor) {
     const ips = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+    if (!ips) return undefined;
     const ipList = ips.split(",").map((ip) => ip.trim());
 
     for (const ip of ipList) {
@@ -116,7 +115,7 @@ function getClientIp(req: express.Request): string | undefined {
         return plainIp;
       }
     }
-    return ipList[0].replace(/^::ffff:/, "");
+    return ipList[0]?.replace(/^::ffff:/, "");
   }
 
   if (req.socket?.remoteAddress) {
@@ -126,23 +125,6 @@ function getClientIp(req: express.Request): string | undefined {
 }
 
 async function main() {
-  // ── MCP-I: Generate server identity ────────────────────────────
-  const crypto = new NodeCryptoProvider();
-  const keyPair = await crypto.generateKeyPair();
-  const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
-
-  console.error(`[mcpi] Agent DID: ${did}`);
-
-  const mcpi = createMCPIMiddleware(
-    {
-      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
-      session: { sessionTtlMinutes: 60 },
-      autoSession: true,
-    },
-    crypto,
-  );
-
   // ── Create McpServer ───────────────────────────────────────────
 
   const server = new McpServer(
@@ -166,53 +148,11 @@ async function main() {
     }
   };
 
-  // ── MCP-I: Register handshake tool ─────────────────────────────
-  server.registerTool(
-    "_mcpi_handshake",
-    {
-      description: "MCP-I identity handshake — establishes a cryptographic session",
-      inputSchema: {
-        nonce: z.string().describe("Client-generated unique nonce"),
-        audience: z.string().describe("Intended audience (server DID or URL)"),
-        timestamp: z.number().describe("Unix epoch seconds"),
-      },
-    },
-    async (args) => mcpi.handleHandshake(args as Record<string, unknown>),
-  );
+  // ── MCP-I: 2 lines to add identity + proofs to all tools ──────
+  const mcpi = await withMCPI(server, { crypto: new NodeCryptoProvider() });
+  console.error(`[mcpi] Server DID: ${mcpi.identity.did}`);
 
-  // ── MCP-I: Wrap resolve-library-id with proof ─────────────────
-  const resolveHandler = mcpi.wrapWithProof(
-    "resolve-library-id",
-    async (args) => {
-      const { query, libraryName } = args as { query: string; libraryName: string };
-
-      const searchResponse = await searchLibraries(query, libraryName, getClientContext());
-
-      if (!searchResponse.results || searchResponse.results.length === 0) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: searchResponse.error
-                ? searchResponse.error
-                : "No libraries found matching the provided name.",
-            },
-          ],
-        };
-      }
-
-      const resultsText = formatSearchResults(searchResponse);
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Available Libraries:\n\n${resultsText}`,
-          },
-        ],
-      };
-    },
-  );
+  // ── Register tools normally — proofs attached automatically ────
 
   server.registerTool(
     "resolve-library-id",
@@ -235,22 +175,29 @@ IMPORTANT: Do not call this tool more than 3 times per question.`,
         readOnlyHint: true,
       },
     },
-    async (args) => resolveHandler(args as Record<string, unknown>),
-  );
+    async ({ query, libraryName }) => {
+      const searchResponse = await searchLibraries(query, libraryName, getClientContext());
 
-  // ── MCP-I: Wrap query-docs with proof ──────────────────────────
-  const queryDocsHandler = mcpi.wrapWithProof(
-    "query-docs",
-    async (args) => {
-      const { query, libraryId } = args as { query: string; libraryId: string };
+      if (!searchResponse.results || searchResponse.results.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: searchResponse.error
+                ? searchResponse.error
+                : "No libraries found matching the provided name.",
+            },
+          ],
+        };
+      }
 
-      const response = await fetchLibraryContext({ query, libraryId }, getClientContext());
+      const resultsText = formatSearchResults(searchResponse);
 
       return {
         content: [
           {
-            type: "text",
-            text: response.data,
+            type: "text" as const,
+            text: `Available Libraries:\n\n${resultsText}`,
           },
         ],
       };
@@ -278,7 +225,18 @@ IMPORTANT: Do not call this tool more than 3 times per question.`,
         readOnlyHint: true,
       },
     },
-    async (args) => queryDocsHandler(args as Record<string, unknown>),
+    async ({ query, libraryId }) => {
+      const response = await fetchLibraryContext({ query, libraryId }, getClientContext());
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: response.data,
+          },
+        ],
+      };
+    },
   );
 
   // ── Transport ──────────────────────────────────────────────────
@@ -485,7 +443,7 @@ IMPORTANT: Do not call this tool more than 3 times per question.`,
         console.error(
           `Context7 MCP Server v${SERVER_VERSION} + MCP-I running on HTTP at http://localhost:${port}/mcp`
         );
-        console.error(`[mcpi] Server DID: ${did}`);
+        console.error(`[mcpi] Server DID: ${mcpi.identity.did}`);
       });
     };
 
@@ -497,7 +455,7 @@ IMPORTANT: Do not call this tool more than 3 times per question.`,
     await server.connect(transport);
 
     console.error(`Context7 MCP Server v${SERVER_VERSION} + MCP-I running on stdio`);
-    console.error(`[mcpi] Server DID: ${did}`);
+    console.error(`[mcpi] Server DID: ${mcpi.identity.did}`);
   }
 }
 

--- a/examples/context7-with-mcpi/src/index.ts
+++ b/examples/context7-with-mcpi/src/index.ts
@@ -1,0 +1,507 @@
+#!/usr/bin/env node
+
+/**
+ * Context7 MCP Server — Modified with MCP-I Integration
+ *
+ * This is a copy of @upstash/context7-mcp (v2.1.4) with MCP-I identity,
+ * session management, and proof generation added.
+ *
+ * Changes from original:
+ *   1. Import MCP-I middleware + crypto provider (~3 lines)
+ *   2. Generate identity + create middleware (~15 lines, in main())
+ *   3. Register `_mcpi_handshake` tool (~10 lines)
+ *   4. Wrap each tool handler with `wrapWithProof` (~5 lines per tool)
+ *
+ * Total additions: ~40 lines. No changes to mcp-i-core required.
+ *
+ * See notes.md for full audit findings.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { searchLibraries, fetchLibraryContext } from "./lib/api.js";
+import { ClientContext } from "./lib/encryption.js";
+import { formatSearchResults, extractClientInfoFromUserAgent } from "./lib/utils.js";
+import { isJWT, validateJWT } from "./lib/jwt.js";
+import express from "express";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { Command } from "commander";
+import { AsyncLocalStorage } from "async_hooks";
+import { SERVER_VERSION, RESOURCE_URL, AUTH_SERVER_URL } from "./lib/constants.js";
+
+// ── MCP-I imports ──────────────────────────────────────────────────
+import { createMCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../node-server/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+
+/** Default HTTP server port */
+const DEFAULT_PORT = 3000;
+
+// Parse CLI arguments using commander
+const program = new Command()
+  .option("--transport <stdio|http>", "transport type", "stdio")
+  .option("--port <number>", "port for HTTP transport", DEFAULT_PORT.toString())
+  .option("--api-key <key>", "API key for authentication (or set CONTEXT7_API_KEY env var)")
+  .allowUnknownOption()
+  .parse(process.argv);
+
+const cliOptions = program.opts<{
+  transport: string;
+  port: string;
+  apiKey?: string;
+}>();
+
+// Validate transport option
+const allowedTransports = ["stdio", "http"];
+if (!allowedTransports.includes(cliOptions.transport)) {
+  console.error(
+    `Invalid --transport value: '${cliOptions.transport}'. Must be one of: stdio, http.`
+  );
+  process.exit(1);
+}
+
+const TRANSPORT_TYPE = (cliOptions.transport || "stdio") as "stdio" | "http";
+
+const passedPortFlag = process.argv.includes("--port");
+const passedApiKeyFlag = process.argv.includes("--api-key");
+
+if (TRANSPORT_TYPE === "http" && passedApiKeyFlag) {
+  console.error(
+    "The --api-key flag is not allowed when using --transport http. Use header-based auth at the HTTP layer instead."
+  );
+  process.exit(1);
+}
+
+if (TRANSPORT_TYPE === "stdio" && passedPortFlag) {
+  console.error("The --port flag is not allowed when using --transport stdio.");
+  process.exit(1);
+}
+
+const CLI_PORT = (() => {
+  const parsed = parseInt(cliOptions.port, 10);
+  return isNaN(parsed) ? undefined : parsed;
+})();
+
+const requestContext = new AsyncLocalStorage<ClientContext>();
+
+let stdioApiKey: string | undefined;
+let stdioClientInfo: { ide?: string; version?: string } | undefined;
+
+function getClientContext(): ClientContext {
+  const ctx = requestContext.getStore();
+  if (ctx) return ctx;
+
+  return {
+    apiKey: stdioApiKey,
+    clientInfo: stdioClientInfo,
+    transport: "stdio",
+  };
+}
+
+function getClientIp(req: express.Request): string | undefined {
+  const forwardedFor = req.headers["x-forwarded-for"] || req.headers["X-Forwarded-For"];
+
+  if (forwardedFor) {
+    const ips = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+    const ipList = ips.split(",").map((ip) => ip.trim());
+
+    for (const ip of ipList) {
+      const plainIp = ip.replace(/^::ffff:/, "");
+      if (
+        !plainIp.startsWith("10.") &&
+        !plainIp.startsWith("192.168.") &&
+        !/^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(plainIp)
+      ) {
+        return plainIp;
+      }
+    }
+    return ipList[0].replace(/^::ffff:/, "");
+  }
+
+  if (req.socket?.remoteAddress) {
+    return req.socket.remoteAddress.replace(/^::ffff:/, "");
+  }
+  return undefined;
+}
+
+async function main() {
+  // ── MCP-I: Generate server identity ────────────────────────────
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  console.error(`[mcpi] Agent DID: ${did}`);
+
+  const mcpi = createMCPIMiddleware(
+    {
+      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+      session: { sessionTtlMinutes: 60 },
+      autoSession: true,
+    },
+    crypto,
+  );
+
+  // ── Create McpServer ───────────────────────────────────────────
+
+  const server = new McpServer(
+    {
+      name: "Context7",
+      version: SERVER_VERSION,
+    },
+    {
+      instructions:
+        "Use this server to retrieve up-to-date documentation and code examples for any library.",
+    }
+  );
+
+  server.server.oninitialized = () => {
+    const clientVersion = server.server.getClientVersion();
+    if (clientVersion) {
+      stdioClientInfo = {
+        ide: clientVersion.name,
+        version: clientVersion.version,
+      };
+    }
+  };
+
+  // ── MCP-I: Register handshake tool ─────────────────────────────
+  server.registerTool(
+    "_mcpi_handshake",
+    {
+      description: "MCP-I identity handshake — establishes a cryptographic session",
+      inputSchema: {
+        nonce: z.string().describe("Client-generated unique nonce"),
+        audience: z.string().describe("Intended audience (server DID or URL)"),
+        timestamp: z.number().describe("Unix epoch seconds"),
+      },
+    },
+    async (args) => mcpi.handleHandshake(args as Record<string, unknown>),
+  );
+
+  // ── MCP-I: Wrap resolve-library-id with proof ─────────────────
+  const resolveHandler = mcpi.wrapWithProof(
+    "resolve-library-id",
+    async (args) => {
+      const { query, libraryName } = args as { query: string; libraryName: string };
+
+      const searchResponse = await searchLibraries(query, libraryName, getClientContext());
+
+      if (!searchResponse.results || searchResponse.results.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: searchResponse.error
+                ? searchResponse.error
+                : "No libraries found matching the provided name.",
+            },
+          ],
+        };
+      }
+
+      const resultsText = formatSearchResults(searchResponse);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Available Libraries:\n\n${resultsText}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "resolve-library-id",
+    {
+      title: "Resolve Context7 Library ID",
+      description: `Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
+
+You MUST call this function before 'Query Documentation' tool to obtain a valid Context7-compatible library ID UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+
+IMPORTANT: Do not call this tool more than 3 times per question.`,
+      inputSchema: {
+        query: z
+          .string()
+          .describe("The question or task you need help with."),
+        libraryName: z
+          .string()
+          .describe("Library name to search for and retrieve a Context7-compatible library ID."),
+      },
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async (args) => resolveHandler(args as Record<string, unknown>),
+  );
+
+  // ── MCP-I: Wrap query-docs with proof ──────────────────────────
+  const queryDocsHandler = mcpi.wrapWithProof(
+    "query-docs",
+    async (args) => {
+      const { query, libraryId } = args as { query: string; libraryId: string };
+
+      const response = await fetchLibraryContext({ query, libraryId }, getClientContext());
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: response.data,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "query-docs",
+    {
+      title: "Query Documentation",
+      description: `Retrieves and queries up-to-date documentation and code examples from Context7 for any programming library or framework.
+
+You must call 'Resolve Context7 Library ID' tool first to obtain the exact Context7-compatible library ID required to use this tool, UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+
+IMPORTANT: Do not call this tool more than 3 times per question.`,
+      inputSchema: {
+        libraryId: z
+          .string()
+          .describe("Exact Context7-compatible library ID (e.g., '/mongodb/docs', '/vercel/next.js')."),
+        query: z
+          .string()
+          .describe("The question or task you need help with. Be specific and include relevant details."),
+      },
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async (args) => queryDocsHandler(args as Record<string, unknown>),
+  );
+
+  // ── Transport ──────────────────────────────────────────────────
+
+  const transportType = TRANSPORT_TYPE;
+
+  if (transportType === "http") {
+    const initialPort = CLI_PORT ?? DEFAULT_PORT;
+
+    const app = express();
+    app.use(express.json());
+
+    app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS,DELETE");
+      res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Content-Type, MCP-Session-Id, MCP-Protocol-Version, X-Context7-API-Key, Context7-API-Key, X-API-Key, Authorization"
+      );
+      res.setHeader("Access-Control-Expose-Headers", "MCP-Session-Id");
+
+      if (req.method === "OPTIONS") {
+        res.sendStatus(200);
+        return;
+      }
+      next();
+    });
+
+    const extractHeaderValue = (value: string | string[] | undefined): string | undefined => {
+      if (!value) return undefined;
+      return typeof value === "string" ? value : value[0];
+    };
+
+    const extractBearerToken = (authHeader: string | string[] | undefined): string | undefined => {
+      const header = extractHeaderValue(authHeader);
+      if (!header) return undefined;
+      if (header.startsWith("Bearer ")) return header.substring(7).trim();
+      return header;
+    };
+
+    const extractApiKey = (req: express.Request): string | undefined => {
+      return (
+        extractBearerToken(req.headers.authorization) ||
+        extractHeaderValue(req.headers["context7-api-key"]) ||
+        extractHeaderValue(req.headers["x-api-key"]) ||
+        extractHeaderValue(req.headers["context7_api_key"]) ||
+        extractHeaderValue(req.headers["x_api_key"])
+      );
+    };
+
+    const handleMcpRequest = async (
+      req: express.Request,
+      res: express.Response,
+      requireAuth: boolean
+    ) => {
+      if (req.method === "GET") {
+        return res.status(405).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Server does not support GET requests" },
+          id: null,
+        });
+      }
+
+      try {
+        const apiKey = extractApiKey(req);
+        const resourceUrl = RESOURCE_URL;
+        const baseUrl = new URL(resourceUrl).origin;
+
+        res.set(
+          "WWW-Authenticate",
+          `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`
+        );
+
+        if (requireAuth) {
+          if (!apiKey) {
+            return res.status(401).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32001,
+                message: "Authentication required. Please authenticate to use this MCP server.",
+              },
+              id: null,
+            });
+          }
+
+          if (isJWT(apiKey)) {
+            const validationResult = await validateJWT(apiKey);
+            if (!validationResult.valid) {
+              return res.status(401).json({
+                jsonrpc: "2.0",
+                error: {
+                  code: -32001,
+                  message: validationResult.error || "Invalid token. Please re-authenticate.",
+                },
+                id: null,
+              });
+            }
+          }
+        }
+
+        const context: ClientContext = {
+          clientIp: getClientIp(req),
+          apiKey: apiKey,
+          clientInfo: extractClientInfoFromUserAgent(req.headers["user-agent"]),
+          transport: "http",
+        };
+
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse: true,
+        });
+
+        res.on("close", () => {
+          transport.close();
+        });
+
+        await requestContext.run(context, async () => {
+          await server.connect(transport);
+          await transport.handleRequest(req, res, req.body);
+        });
+      } catch (error) {
+        console.error("Error handling MCP request:", error);
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: "2.0",
+            error: { code: -32603, message: "Internal server error" },
+            id: null,
+          });
+        }
+      }
+    };
+
+    app.all("/mcp", async (req, res) => {
+      await handleMcpRequest(req, res, false);
+    });
+
+    app.all("/mcp/oauth", async (req, res) => {
+      await handleMcpRequest(req, res, true);
+    });
+
+    app.get("/ping", (_req: express.Request, res: express.Response) => {
+      res.json({ status: "ok", message: "pong" });
+    });
+
+    app.get(
+      "/.well-known/oauth-protected-resource",
+      (_req: express.Request, res: express.Response) => {
+        res.json({
+          resource: RESOURCE_URL,
+          authorization_servers: [AUTH_SERVER_URL],
+          scopes_supported: ["profile", "email"],
+          bearer_methods_supported: ["header"],
+        });
+      }
+    );
+
+    app.get(
+      "/.well-known/oauth-authorization-server",
+      async (_req: express.Request, res: express.Response) => {
+        const authServerUrl = AUTH_SERVER_URL;
+
+        try {
+          const response = await fetch(`${authServerUrl}/.well-known/oauth-authorization-server`);
+          if (!response.ok) {
+            console.error("[OAuth] Upstream error:", response.status);
+            return res.status(response.status).json({
+              error: "upstream_error",
+              message: "Failed to fetch authorization server metadata",
+            });
+          }
+          const metadata = await response.json();
+          res.json(metadata);
+        } catch (error) {
+          console.error("[OAuth] Error fetching OAuth metadata:", error);
+          res.status(502).json({
+            error: "proxy_error",
+            message: "Failed to proxy authorization server metadata",
+          });
+        }
+      }
+    );
+
+    app.use((_req: express.Request, res: express.Response) => {
+      res.status(404).json({
+        error: "not_found",
+        message: "Endpoint not found. Use /mcp for MCP protocol communication.",
+      });
+    });
+
+    const startServer = (port: number, maxAttempts = 10) => {
+      const httpServer = app.listen(port);
+
+      httpServer.once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE" && port < initialPort + maxAttempts) {
+          console.warn(`Port ${port} is in use, trying port ${port + 1}...`);
+          startServer(port + 1, maxAttempts);
+        } else {
+          console.error(`Failed to start server: ${err.message}`);
+          process.exit(1);
+        }
+      });
+
+      httpServer.once("listening", () => {
+        console.error(
+          `Context7 MCP Server v${SERVER_VERSION} + MCP-I running on HTTP at http://localhost:${port}/mcp`
+        );
+        console.error(`[mcpi] Server DID: ${did}`);
+      });
+    };
+
+    startServer(initialPort);
+  } else {
+    stdioApiKey = cliOptions.apiKey || process.env.CONTEXT7_API_KEY;
+    const transport = new StdioServerTransport();
+
+    await server.connect(transport);
+
+    console.error(`Context7 MCP Server v${SERVER_VERSION} + MCP-I running on stdio`);
+    console.error(`[mcpi] Server DID: ${did}`);
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});

--- a/examples/context7-with-mcpi/src/lib/api.ts
+++ b/examples/context7-with-mcpi/src/lib/api.ts
@@ -1,0 +1,97 @@
+import { SearchResponse, ContextRequest, ContextResponse } from "./types.js";
+import { ClientContext, generateHeaders } from "./encryption.js";
+import { CONTEXT7_API_BASE_URL } from "./constants.js";
+
+/**
+ * Parses error response from the Context7 API
+ * Extracts the server's error message, falling back to status-based messages if parsing fails
+ */
+async function parseErrorResponse(response: Response, apiKey?: string): Promise<string> {
+  try {
+    const json = (await response.json()) as { message?: string };
+    if (json.message) {
+      return json.message;
+    }
+  } catch {
+    // JSON parsing failed, fall through to default
+  }
+
+  const status = response.status;
+  if (status === 429) {
+    return apiKey
+      ? "Rate limited or quota exceeded. Upgrade your plan at https://context7.com/plans for higher limits."
+      : "Rate limited or quota exceeded. Create a free API key at https://context7.com/dashboard for higher limits.";
+  }
+  if (status === 404) {
+    return "The library you are trying to access does not exist. Please try with a different library ID.";
+  }
+  if (status === 401) {
+    return "Invalid API key. Please check your API key. API keys should start with 'ctx7sk' prefix.";
+  }
+  return `Request failed with status ${status}. Please try again later.`;
+}
+
+/**
+ * Searches for libraries matching the given query
+ */
+export async function searchLibraries(
+  query: string,
+  libraryName: string,
+  context: ClientContext = {}
+): Promise<SearchResponse> {
+  try {
+    const url = new URL(`${CONTEXT7_API_BASE_URL}/v2/libs/search`);
+    url.searchParams.set("query", query);
+    url.searchParams.set("libraryName", libraryName);
+
+    const headers = generateHeaders(context);
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      const errorMessage = await parseErrorResponse(response, context.apiKey);
+      console.error(errorMessage);
+      return { results: [], error: errorMessage };
+    }
+    const searchData = await response.json();
+    return searchData as SearchResponse;
+  } catch (error) {
+    const errorMessage = `Error searching libraries: ${error}`;
+    console.error(errorMessage);
+    return { results: [], error: errorMessage };
+  }
+}
+
+/**
+ * Fetches intelligent, reranked context for a natural language query
+ */
+export async function fetchLibraryContext(
+  request: ContextRequest,
+  context: ClientContext = {}
+): Promise<ContextResponse> {
+  try {
+    const url = new URL(`${CONTEXT7_API_BASE_URL}/v2/context`);
+    url.searchParams.set("query", request.query);
+    url.searchParams.set("libraryId", request.libraryId);
+
+    const headers = generateHeaders(context);
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      const errorMessage = await parseErrorResponse(response, context.apiKey);
+      console.error(errorMessage);
+      return { data: errorMessage };
+    }
+
+    const text = await response.text();
+    if (!text) {
+      return {
+        data: "Documentation not found or not finalized for this library. This might have happened because you used an invalid Context7-compatible library ID. To get a valid Context7-compatible library ID, use the 'resolve-library-id' with the package name you wish to retrieve documentation for.",
+      };
+    }
+    return { data: text };
+  } catch (error) {
+    const errorMessage = `Error fetching library context. Please try again later. ${error}`;
+    console.error(errorMessage);
+    return { data: errorMessage };
+  }
+}

--- a/examples/context7-with-mcpi/src/lib/constants.ts
+++ b/examples/context7-with-mcpi/src/lib/constants.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
+
+export const SERVER_VERSION: string = pkg.version;
+
+const CONTEXT7_BASE_URL = "https://context7.com";
+const MCP_RESOURCE_URL = "https://mcp.context7.com";
+
+export const CLERK_DOMAIN = "clerk.context7.com";
+export const CONTEXT7_API_BASE_URL = process.env.CONTEXT7_API_URL || `${CONTEXT7_BASE_URL}/api`;
+export const RESOURCE_URL = process.env.RESOURCE_URL || MCP_RESOURCE_URL;
+export const AUTH_SERVER_URL = process.env.AUTH_SERVER_URL || CONTEXT7_BASE_URL;

--- a/examples/context7-with-mcpi/src/lib/encryption.ts
+++ b/examples/context7-with-mcpi/src/lib/encryption.ts
@@ -1,0 +1,68 @@
+import { createCipheriv, randomBytes } from "crypto";
+import { SERVER_VERSION } from "./constants.js";
+
+const DEFAULT_ENCRYPTION_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const ENCRYPTION_KEY = process.env.CLIENT_IP_ENCRYPTION_KEY || DEFAULT_ENCRYPTION_KEY;
+const ALGORITHM = "aes-256-cbc";
+
+function validateEncryptionKey(key: string): boolean {
+  // Must be exactly 64 hex characters (32 bytes)
+  return /^[0-9a-fA-F]{64}$/.test(key);
+}
+
+function encryptClientIp(clientIp: string): string {
+  if (!validateEncryptionKey(ENCRYPTION_KEY)) {
+    console.error("Invalid encryption key format. Must be 64 hex characters.");
+    return clientIp; // Fallback to unencrypted
+  }
+
+  try {
+    const iv = randomBytes(16);
+    const cipher = createCipheriv(ALGORITHM, Buffer.from(ENCRYPTION_KEY, "hex"), iv);
+    let encrypted = cipher.update(clientIp, "utf8", "hex");
+    encrypted += cipher.final("hex");
+    return iv.toString("hex") + ":" + encrypted;
+  } catch (error) {
+    console.error("Error encrypting client IP:", error);
+    return clientIp; // Fallback to unencrypted
+  }
+}
+
+export interface ClientContext {
+  clientIp?: string;
+  apiKey?: string;
+  clientInfo?: {
+    ide?: string;
+    version?: string;
+  };
+  transport?: "stdio" | "http";
+}
+
+/**
+ * Generate headers for Context7 API requests.
+ * Handles client IP encryption, authentication, and telemetry headers.
+ */
+export function generateHeaders(context: ClientContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Context7-Source": "mcp-server",
+    "X-Context7-Server-Version": SERVER_VERSION,
+  };
+
+  if (context.clientIp) {
+    headers["mcp-client-ip"] = encryptClientIp(context.clientIp);
+  }
+  if (context.apiKey) {
+    headers["Authorization"] = `Bearer ${context.apiKey}`;
+  }
+  if (context.clientInfo?.ide) {
+    headers["X-Context7-Client-IDE"] = context.clientInfo.ide;
+  }
+  if (context.clientInfo?.version) {
+    headers["X-Context7-Client-Version"] = context.clientInfo.version;
+  }
+  if (context.transport) {
+    headers["X-Context7-Transport"] = context.transport;
+  }
+
+  return headers;
+}

--- a/examples/context7-with-mcpi/src/lib/jwt.ts
+++ b/examples/context7-with-mcpi/src/lib/jwt.ts
@@ -1,0 +1,38 @@
+import * as jose from "jose";
+import { CLERK_DOMAIN } from "./constants.js";
+
+const JWKS_URL = `https://${CLERK_DOMAIN}/.well-known/jwks.json`;
+const ISSUER = `https://${CLERK_DOMAIN}`;
+
+const jwks = jose.createRemoteJWKSet(new URL(JWKS_URL));
+
+export interface JWTValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function isJWT(token: string): boolean {
+  const parts = token.split(".");
+  return parts.length === 3;
+}
+
+export async function validateJWT(token: string): Promise<JWTValidationResult> {
+  try {
+    await jose.jwtVerify(token, jwks, {
+      issuer: ISSUER,
+    });
+
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof jose.errors.JWTExpired) {
+      return { valid: false, error: "Token expired" };
+    }
+    if (error instanceof jose.errors.JWTClaimValidationFailed) {
+      return { valid: false, error: "Invalid token claims" };
+    }
+    if (error instanceof jose.errors.JWSSignatureVerificationFailed) {
+      return { valid: false, error: "Invalid signature" };
+    }
+    return { valid: false, error: "Invalid token" };
+  }
+}

--- a/examples/context7-with-mcpi/src/lib/types.ts
+++ b/examples/context7-with-mcpi/src/lib/types.ts
@@ -1,0 +1,33 @@
+export interface SearchResult {
+  id: string;
+  title: string;
+  description: string;
+  branch: string;
+  lastUpdateDate: string;
+  state: DocumentState;
+  totalTokens: number;
+  totalSnippets: number;
+  stars?: number;
+  trustScore?: number;
+  benchmarkScore?: number;
+  versions?: string[];
+  source?: string;
+}
+
+export interface SearchResponse {
+  error?: string;
+  results: SearchResult[];
+  searchFilterApplied?: boolean;
+}
+
+// Version state is still needed for validating search results
+export type DocumentState = "initial" | "finalized" | "error" | "delete";
+
+export type ContextRequest = {
+  query: string;
+  libraryId: string;
+};
+
+export type ContextResponse = {
+  data: string;
+};

--- a/examples/context7-with-mcpi/src/lib/utils.ts
+++ b/examples/context7-with-mcpi/src/lib/utils.ts
@@ -1,0 +1,81 @@
+import { SearchResponse, SearchResult } from "./types.js";
+
+/**
+ * Maps numeric source reputation score to an interpretable label for LLM consumption.
+ */
+function getSourceReputationLabel(
+  sourceReputation?: number
+): "High" | "Medium" | "Low" | "Unknown" {
+  if (sourceReputation === undefined || sourceReputation < 0) return "Unknown";
+  if (sourceReputation >= 7) return "High";
+  if (sourceReputation >= 4) return "Medium";
+  return "Low";
+}
+
+/**
+ * Formats a search result into a human-readable string representation.
+ */
+export function formatSearchResult(result: SearchResult): string {
+  const formattedResult = [
+    `- Title: ${result.title}`,
+    `- Context7-compatible library ID: ${result.id}`,
+    `- Description: ${result.description}`,
+  ];
+
+  if (result.totalSnippets !== -1 && result.totalSnippets !== undefined) {
+    formattedResult.push(`- Code Snippets: ${result.totalSnippets}`);
+  }
+
+  const reputationLabel = getSourceReputationLabel(result.trustScore);
+  formattedResult.push(`- Source Reputation: ${reputationLabel}`);
+
+  if (result.benchmarkScore !== undefined && result.benchmarkScore > 0) {
+    formattedResult.push(`- Benchmark Score: ${result.benchmarkScore}`);
+  }
+
+  if (result.versions !== undefined && result.versions.length > 0) {
+    formattedResult.push(`- Versions: ${result.versions.join(", ")}`);
+  }
+
+  if (result.source) {
+    formattedResult.push(`- Source: ${result.source}`);
+  }
+
+  return formattedResult.join("\n");
+}
+
+/**
+ * Formats a search response into a human-readable string representation.
+ */
+export function formatSearchResults(searchResponse: SearchResponse): string {
+  if (!searchResponse.results || searchResponse.results.length === 0) {
+    return "No documentation libraries found matching your query.";
+  }
+
+  const parts: string[] = [];
+
+  if (searchResponse.searchFilterApplied) {
+    parts.push(
+      "**Note:** Your results only include libraries matching your access settings. To search across all public libraries, update your settings at https://context7.com/dashboard?tab=libraries"
+    );
+  }
+
+  const formattedResults = searchResponse.results.map(formatSearchResult);
+  parts.push(formattedResults.join("\n----------\n"));
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Extract client info from User-Agent header.
+ */
+export function extractClientInfoFromUserAgent(
+  userAgent: string | undefined
+): { ide?: string; version?: string } | undefined {
+  if (!userAgent) return undefined;
+  const match = userAgent.match(/^([^\/\s]+)\/([^\s(]+)/);
+  if (match) {
+    return { ide: match[1], version: match[2] };
+  }
+  return undefined;
+}

--- a/examples/context7-with-mcpi/tsconfig.json
+++ b/examples/context7-with-mcpi/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/context7-with-mcpi/tsconfig.json
+++ b/examples/context7-with-mcpi/tsconfig.json
@@ -9,10 +9,14 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "../../",
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*",
+    "../../src/**/*",
+    "../node-server/node-crypto.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/examples/context7-with-mcpi/tsconfig.json
+++ b/examples/context7-with-mcpi/tsconfig.json
@@ -8,15 +8,9 @@
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "outDir": "./dist",
-    "rootDir": "../../",
-    "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   },
-  "include": [
-    "src/**/*",
-    "../../src/**/*",
-    "../node-server/node-crypto.ts"
-  ],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env npx tsx
 /**
- * MCP-I Example Server
+ * MCP-I Example Server (Low-Level Server API)
+ *
+ * This example uses the low-level `Server` API with `createMCPIMiddleware`
+ * for manual request handler patterns. For most servers, prefer the
+ * simpler `withMCPI()` adapter — see examples/context7-with-mcpi/ for
+ * a 2-line integration with the high-level `McpServer` API.
  *
  * Demonstrates the MCP-I protocol:
  *   1. greet           — open tool with signed proof (via _meta)

--- a/examples/outbound-delegation/README.md
+++ b/examples/outbound-delegation/README.md
@@ -86,7 +86,7 @@ The demo:
 import {
   buildOutboundDelegationHeaders,
   CryptoProvider,
-} from '@mcpi/core';
+} from '@mcp-i/core';
 
 // When making an outbound request on behalf of an agent...
 const headers = await buildOutboundDelegationHeaders({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,33 @@
 {
-  "name": "@mcpi/core",
-  "version": "1.0.0",
+  "name": "@mcp-i/core",
+  "version": "1.1.0-canary.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mcpi/core",
-      "version": "1.0.0",
+      "name": "@mcp-i/core",
+      "version": "1.1.0-canary.2",
       "license": "MIT",
       "dependencies": {
+        "@mcp-i/core": "^1.1.0-canary.2",
         "jose": "^5.6.3",
         "json-canonicalize": "^2.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "@types/express": "^5.0.6",
         "@types/node": "^20.14.9",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
         "@vitest/coverage-v8": "^2.0.0",
+        "commander": "^14.0.3",
         "eslint": "^10.0.3",
+        "express": "^5.2.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.57.0",
-        "vitest": "^2.0.0"
+        "vitest": "^2.0.0",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": ">=1.0.0"
@@ -742,6 +747,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mcp-i/core": {
+      "version": "1.1.0-canary.2",
+      "resolved": "https://registry.npmjs.org/@mcp-i/core/-/core-1.1.0-canary.2.tgz",
+      "integrity": "sha512-56zUh0ZEGsVBi3OYLvVa1RktFGMxPzkC+6zGgGIQw1QGIljNZr1OLxZ32zITdgLbLKdWS+ZjdGLzAGrh+LFygA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-i/core": "^1.1.0-canary.1",
+        "jose": "^5.6.3",
+        "json-canonicalize": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
@@ -1154,6 +1178,27 @@
         "win32"
       ]
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1165,6 +1210,38 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1183,6 +1260,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1817,6 +1929,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -76,14 +76,18 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@types/express": "^5.0.6",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^2.0.0",
+    "commander": "^14.0.3",
     "eslint": "^10.0.3",
+    "express": "^5.2.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.57.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "zod": "^4.3.6"
   },
   "keywords": [
     "mcp-i",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mcpi/core",
-  "version": "1.0.0",
+  "name": "@mcp-i/core",
+  "version": "1.1.0-canary.2",
   "description": "MCP-I protocol reference implementation — delegation, proof, and session for Model Context Protocol Identity",
   "license": "MIT",
   "type": "module",
@@ -62,6 +62,7 @@
     "example:inspector": "npx @modelcontextprotocol/inspector npx tsx examples/node-server/server.ts --stdio"
   },
   "dependencies": {
+    "@mcp-i/core": "^1.1.0-canary.2",
     "jose": "^5.6.3",
     "json-canonicalize": "^2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mcp-i/core':
+        specifier: ^1.1.0-canary.2
+        version: 1.1.0-canary.2(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
       jose:
         specifier: ^5.6.3
         version: 5.10.0
@@ -303,6 +306,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mcp-i/core@1.1.0-canary.2':
+    resolution: {integrity: sha512-56zUh0ZEGsVBi3OYLvVa1RktFGMxPzkC+6zGgGIQw1QGIljNZr1OLxZ32zITdgLbLKdWS+ZjdGLzAGrh+LFygA==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -1632,6 +1643,13 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mcp-i/core@1.1.0-canary.2(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
+    dependencies:
+      jose: 5.10.0
+      json-canonicalize: 2.0.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.27.1(zod@4.3.6)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^20.14.9
         version: 20.19.37
@@ -33,9 +36,15 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9(@types/node@20.19.37))
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
       eslint:
         specifier: ^10.0.3
         version: 10.0.3
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       typescript:
         specifier: ^5.5.3
         version: 5.9.3
@@ -45,6 +54,9 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.37)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
 packages:
 
@@ -340,79 +352,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -444,17 +443,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -649,6 +675,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -1703,15 +1733,52 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.37
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.37
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.37
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.37
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
     dependencies:
@@ -1958,6 +2025,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@14.0.3: {}
 
   content-disposition@1.0.1: {}
 

--- a/src/__tests__/integration/mcp-enhance-server.test.ts
+++ b/src/__tests__/integration/mcp-enhance-server.test.ts
@@ -1,0 +1,311 @@
+/**
+ * withMCPI() Integration Tests
+ *
+ * Tests the dream API: `withMCPI(server, { crypto })` auto-registers
+ * the handshake tool and auto-attaches proofs to all tool responses.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { z } from 'zod';
+import { withMCPI, generateIdentity } from '../../middleware/with-mcpi-server.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function createTestPair(options?: {
+  proofAllTools?: boolean;
+  excludeTools?: string[];
+  autoSession?: boolean;
+  registerToolsBeforeWithMCPI?: boolean;
+}) {
+  const crypto = new NodeCryptoProvider();
+  const server = new McpServer(
+    { name: 'withMCPI-test', version: '1.0.0' },
+    { instructions: 'Test server for withMCPI integration' },
+  );
+
+  // Register tools BEFORE withMCPI to test pre-existing tool interception
+  if (options?.registerToolsBeforeWithMCPI) {
+    server.registerTool(
+      'greet',
+      {
+        description: 'Greet someone',
+        inputSchema: { name: z.string() },
+      },
+      async ({ name }) => ({
+        content: [{ type: 'text', text: `Hello, ${name}!` }],
+      }),
+    );
+  }
+
+  const mcpi = await withMCPI(server, {
+    crypto,
+    autoSession: options?.autoSession ?? true,
+    proofAllTools: options?.proofAllTools,
+    excludeTools: options?.excludeTools,
+  });
+
+  // Register tools AFTER withMCPI to test late registration
+  if (!options?.registerToolsBeforeWithMCPI) {
+    server.registerTool(
+      'greet',
+      {
+        description: 'Greet someone',
+        inputSchema: { name: z.string() },
+      },
+      async ({ name }) => ({
+        content: [{ type: 'text', text: `Hello, ${name}!` }],
+      }),
+    );
+  }
+
+  server.registerTool(
+    'add',
+    {
+      description: 'Add two numbers',
+      inputSchema: { a: z.number(), b: z.number() },
+    },
+    async ({ a, b }) => ({
+      content: [{ type: 'text', text: `${a + b}` }],
+    }),
+  );
+
+  const client = new Client(
+    { name: 'withMCPI-test-client', version: '1.0.0' },
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server, mcpi, crypto };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('withMCPI()', () => {
+  const pairs: Array<{ client: Client; server: McpServer }> = [];
+
+  afterEach(async () => {
+    for (const pair of pairs) {
+      await pair.client.close();
+      await pair.server.close();
+    }
+    pairs.length = 0;
+  });
+
+  async function create(options?: Parameters<typeof createTestPair>[0]) {
+    const pair = await createTestPair(options);
+    pairs.push(pair);
+    return pair;
+  }
+
+  it('auto-registers _mcpi_handshake tool', async () => {
+    const { client } = await create();
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toContain('_mcpi_handshake');
+  });
+
+  it('auto-proofs all registered tools', async () => {
+    const { client } = await create();
+
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'World' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, World!');
+
+    // Proof should be present via auto-session + auto-proof
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.did).toMatch(/^did:key:/);
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+  });
+
+  it('tools registered before withMCPI also get proofs', async () => {
+    const { client } = await create({ registerToolsBeforeWithMCPI: true });
+
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'Early Bird' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, Early Bird!');
+
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+  });
+
+  it('excludeTools skips proof for specified tools', async () => {
+    const { client } = await create({ excludeTools: ['greet'] });
+
+    // 'greet' should NOT have proof
+    const greetResult = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'No Proof' },
+    });
+
+    const greetContent = greetResult.content[0] as { type: string; text: string };
+    expect(greetContent.text).toBe('Hello, No Proof!');
+
+    // _meta may be undefined or proof should not be present
+    const greetProof = (greetResult._meta as Record<string, unknown> | undefined)?.proof;
+    expect(greetProof).toBeUndefined();
+
+    // 'add' should still have proof
+    const addResult = await client.callTool({
+      name: 'add',
+      arguments: { a: 2, b: 3 },
+    });
+
+    expect(addResult._meta).toBeDefined();
+    const addProof = (addResult._meta as Record<string, unknown>).proof as {
+      jws: string;
+    };
+    expect(addProof).toBeDefined();
+    expect(addProof.jws).toBeDefined();
+  });
+
+  it('proofAllTools: false disables auto-proofing', async () => {
+    const { client } = await create({ proofAllTools: false });
+
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'No Auto-Proof' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, No Auto-Proof!');
+
+    // No proof — auto-proofing is off
+    const proof = (result._meta as Record<string, unknown> | undefined)?.proof;
+    expect(proof).toBeUndefined();
+  });
+
+  it('handshake establishes session through withMCPI', async () => {
+    const { client, mcpi } = await create({ autoSession: false });
+
+    const result = await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `test-${Date.now()}`,
+        audience: mcpi.identity.did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    const parsed = JSON.parse(first.text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.sessionId).toMatch(/^mcpi_/);
+    expect(parsed.serverDid).toBe(mcpi.identity.did);
+  });
+
+  it('multiple tools share the same auto-session', async () => {
+    const { client } = await create();
+
+    const result1 = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'Alice' },
+    });
+    const result2 = await client.callTool({
+      name: 'add',
+      arguments: { a: 1, b: 2 },
+    });
+
+    const proof1 = (result1._meta as Record<string, unknown>).proof as {
+      meta: Record<string, unknown>;
+    };
+    const proof2 = (result2._meta as Record<string, unknown>).proof as {
+      meta: Record<string, unknown>;
+    };
+
+    expect(proof1.meta.sessionId).toBe(proof2.meta.sessionId);
+  });
+
+  it('wrapWithDelegation still works alongside withMCPI', async () => {
+    const crypto = new NodeCryptoProvider();
+    const server = new McpServer(
+      { name: 'delegation-test', version: '1.0.0' },
+    );
+
+    const mcpi = await withMCPI(server, { crypto, autoSession: true });
+
+    // Use wrapWithDelegation for a restricted tool
+    const restrictedHandler = mcpi.wrapWithDelegation(
+      'restricted-tool',
+      { scopeId: 'admin:write', consentUrl: 'https://example.com/consent' },
+      async (args) => ({
+        content: [{ type: 'text', text: `Restricted: ${(args as { data: string }).data}` }],
+      }),
+    );
+
+    server.registerTool(
+      'restricted-tool',
+      {
+        description: 'Requires delegation',
+        inputSchema: { data: z.string() },
+      },
+      async (args) => restrictedHandler(args as Record<string, unknown>),
+    );
+
+    const client = new Client({ name: 'delegation-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    pairs.push({ client, server });
+
+    // Call without delegation — should get needs_authorization
+    const result = await client.callTool({
+      name: 'restricted-tool',
+      arguments: { data: 'test' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    const parsed = JSON.parse(first.text);
+    expect(parsed.error).toBe('needs_authorization');
+    expect(parsed.authorizationUrl).toBe('https://example.com/consent');
+  });
+});
+
+describe('generateIdentity()', () => {
+  it('returns valid DID identity', async () => {
+    const crypto = new NodeCryptoProvider();
+    const identity = await generateIdentity(crypto);
+
+    expect(identity.did).toMatch(/^did:key:z6Mk/);
+    expect(identity.kid).toBe(`${identity.did}#keys-1`);
+    expect(identity.privateKey).toBeDefined();
+    expect(identity.publicKey).toBeDefined();
+    // Keys should be base64 strings
+    expect(() => atob(identity.privateKey)).not.toThrow();
+    expect(() => atob(identity.publicKey)).not.toThrow();
+  });
+
+  it('generates unique identities each call', async () => {
+    const crypto = new NodeCryptoProvider();
+    const id1 = await generateIdentity(crypto);
+    const id2 = await generateIdentity(crypto);
+
+    expect(id1.did).not.toBe(id2.did);
+    expect(id1.privateKey).not.toBe(id2.privateKey);
+  });
+});

--- a/src/__tests__/integration/mcp-transport-context7.test.ts
+++ b/src/__tests__/integration/mcp-transport-context7.test.ts
@@ -15,6 +15,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { z } from 'zod';
 import { createMCPIMiddleware } from '../../middleware/with-mcpi.js';
+import { withMCPI } from '../../middleware/with-mcpi-server.js';
 import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
 import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
 
@@ -269,5 +270,144 @@ describe('McpServer (High-Level API) + MCP-I Integration', () => {
 
     // Same session ID across tools
     expect(proof1.meta.sessionId).toBe(proof2.meta.sessionId);
+  });
+});
+
+// ── withMCPI() path — same tests, dream API ───────────────────
+
+describe('McpServer + withMCPI() (Dream API)', () => {
+  const pairs: Array<{ client: Client; server: McpServer }> = [];
+
+  afterEach(async () => {
+    for (const pair of pairs) {
+      await pair.client.close();
+      await pair.server.close();
+    }
+    pairs.length = 0;
+  });
+
+  async function createWithMCPIPair(options?: { autoSession?: boolean }) {
+    const crypto = new NodeCryptoProvider();
+    const server = new McpServer(
+      { name: 'mcpi-withmcpi-test', version: '1.0.0' },
+      { instructions: 'Test server for withMCPI integration' },
+    );
+
+    const mcpi = await withMCPI(server, {
+      crypto,
+      autoSession: options?.autoSession ?? true,
+    });
+
+    // Register tools AFTER withMCPI — they should still get proofs
+    server.registerTool(
+      'search',
+      {
+        description: 'Search for something',
+        inputSchema: { query: z.string().describe('Search query') },
+        annotations: { readOnlyHint: true },
+      },
+      async ({ query }) => ({
+        content: [{ type: 'text', text: `Found results for: ${query}` }],
+      }),
+    );
+
+    server.registerTool(
+      'fetch-docs',
+      {
+        description: 'Fetch documentation for a library',
+        inputSchema: {
+          libraryId: z.string().describe('Library identifier'),
+          query: z.string().describe('What to search for in docs'),
+        },
+      },
+      async ({ libraryId }) => ({
+        content: [{ type: 'text', text: `Docs for ${libraryId}: example content` }],
+      }),
+    );
+
+    const client = new Client(
+      { name: 'mcpi-withmcpi-test-client', version: '1.0.0' },
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    pairs.push({ client, server });
+    return { client, server, mcpi };
+  }
+
+  it('listTools returns handshake + registered tools (withMCPI)', async () => {
+    const { client } = await createWithMCPIPair();
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('search');
+    expect(toolNames).toContain('fetch-docs');
+  });
+
+  it('autoSession attaches proof without handshake (withMCPI)', async () => {
+    const { client } = await createWithMCPIPair();
+
+    const result = await client.callTool({
+      name: 'search',
+      arguments: { query: 'next.js routing' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Found results for: next.js routing');
+
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+  });
+
+  it('handshake works through withMCPI', async () => {
+    const { client, mcpi } = await createWithMCPIPair({ autoSession: false });
+
+    const result = await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `withmcpi-test-${Date.now()}`,
+        audience: mcpi.identity.did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    const parsed = JSON.parse(first.text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.sessionId).toMatch(/^mcpi_/);
+    expect(parsed.serverDid).toBe(mcpi.identity.did);
+  });
+
+  it('no per-tool wrapping needed — proofs are automatic (withMCPI)', async () => {
+    const { client } = await createWithMCPIPair();
+
+    // Both tools should get proofs without any manual wrapping
+    const searchResult = await client.callTool({
+      name: 'search',
+      arguments: { query: 'react hooks' },
+    });
+    const docsResult = await client.callTool({
+      name: 'fetch-docs',
+      arguments: { libraryId: '/vercel/next.js', query: 'app router' },
+    });
+
+    for (const result of [searchResult, docsResult]) {
+      expect(result._meta).toBeDefined();
+      const proof = (result._meta as Record<string, unknown>).proof as {
+        jws: string;
+      };
+      expect(proof).toBeDefined();
+      expect(proof.jws).toBeDefined();
+    }
   });
 });

--- a/src/__tests__/integration/mcp-transport-context7.test.ts
+++ b/src/__tests__/integration/mcp-transport-context7.test.ts
@@ -1,0 +1,273 @@
+/**
+ * McpServer (High-Level API) + MCP-I Integration Test
+ *
+ * Proves that MCP-I middleware works with the high-level McpServer API
+ * used by most real-world MCP servers (including Context7).
+ *
+ * This is distinct from mcp-transport.test.ts which uses the low-level
+ * Server API. The key difference: McpServer uses registerTool() with
+ * zod schemas, not setRequestHandler(CallToolRequestSchema, ...).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { z } from 'zod';
+import { createMCPIMiddleware } from '../../middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function setupMcpServerPair(options?: { autoSession?: boolean }) {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  const mcpi = createMCPIMiddleware(
+    {
+      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+      session: { sessionTtlMinutes: 60 },
+      autoSession: options?.autoSession,
+    },
+    crypto,
+  );
+
+  // ── McpServer (high-level API, same as Context7) ──
+
+  const server = new McpServer(
+    { name: 'mcpi-mcpserver-test', version: '1.0.0' },
+    { instructions: 'Test server for McpServer + MCP-I integration' },
+  );
+
+  // Register _mcpi_handshake tool (same pattern as Context7 integration)
+  server.registerTool(
+    '_mcpi_handshake',
+    {
+      description: 'MCP-I identity handshake',
+      inputSchema: {
+        nonce: z.string(),
+        audience: z.string(),
+        timestamp: z.number(),
+      },
+    },
+    async (args) => mcpi.handleHandshake(args as Record<string, unknown>),
+  );
+
+  // Wrap a test tool with proof (simulates Context7's resolve-library-id)
+  const searchHandler = mcpi.wrapWithProof(
+    'search',
+    async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Found results for: ${(args as { query: string }).query}`,
+      }],
+    }),
+  );
+
+  server.registerTool(
+    'search',
+    {
+      description: 'Search for something',
+      inputSchema: {
+        query: z.string().describe('Search query'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => searchHandler(args as Record<string, unknown>),
+  );
+
+  // Wrap a second tool (simulates Context7's query-docs)
+  const fetchHandler = mcpi.wrapWithProof(
+    'fetch-docs',
+    async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Docs for ${(args as { libraryId: string }).libraryId}: example content`,
+      }],
+    }),
+  );
+
+  server.registerTool(
+    'fetch-docs',
+    {
+      description: 'Fetch documentation for a library',
+      inputSchema: {
+        libraryId: z.string().describe('Library identifier'),
+        query: z.string().describe('What to search for in docs'),
+      },
+    },
+    async (args) => fetchHandler(args as Record<string, unknown>),
+  );
+
+  // ── Client + transport ──
+
+  const client = new Client(
+    { name: 'mcpi-mcpserver-test-client', version: '1.0.0' },
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server, did, kid, keyPair, crypto };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('McpServer (High-Level API) + MCP-I Integration', () => {
+  const pairs: Array<{ client: Client; server: McpServer }> = [];
+
+  afterEach(async () => {
+    for (const pair of pairs) {
+      await pair.client.close();
+      await pair.server.close();
+    }
+    pairs.length = 0;
+  });
+
+  async function createPair(options?: { autoSession?: boolean }) {
+    const pair = await setupMcpServerPair(options);
+    pairs.push(pair);
+    return pair;
+  }
+
+  it('listTools returns handshake + registered tools', async () => {
+    const { client } = await createPair();
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('search');
+    expect(toolNames).toContain('fetch-docs');
+  });
+
+  it('handshake establishes session via McpServer', async () => {
+    const { client, did } = await createPair();
+
+    const result = await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `mcpserver-test-${Date.now()}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    expect(result.content).toHaveLength(1);
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.type).toBe('text');
+
+    const parsed = JSON.parse(first.text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.sessionId).toMatch(/^mcpi_/);
+    expect(parsed.serverDid).toBe(did);
+  });
+
+  it('tool returns proof in _meta after handshake', async () => {
+    const { client, did } = await createPair();
+
+    // Handshake first
+    await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `mcpserver-test-${Date.now()}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    // Call search tool
+    const result = await client.callTool({
+      name: 'search',
+      arguments: { query: 'react hooks' },
+    });
+
+    // Verify tool output
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Found results for: react hooks');
+
+    // Verify proof in _meta
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.did).toMatch(/^did:key:/);
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+    expect(proof.meta.requestHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(proof.meta.responseHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('autoSession attaches proof without handshake (McpServer)', async () => {
+    const { client } = await createPair({ autoSession: true });
+
+    // Call tool directly — no handshake
+    const result = await client.callTool({
+      name: 'search',
+      arguments: { query: 'next.js routing' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Found results for: next.js routing');
+
+    // Proof should be present via auto-session
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+  });
+
+  it('second tool also gets proof (McpServer)', async () => {
+    const { client } = await createPair({ autoSession: true });
+
+    const result = await client.callTool({
+      name: 'fetch-docs',
+      arguments: { libraryId: '/vercel/next.js', query: 'app router' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Docs for /vercel/next.js: example content');
+
+    // Verify proof is attached
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+  });
+
+  it('multiple tools share the same session', async () => {
+    const { client } = await createPair({ autoSession: true });
+
+    const result1 = await client.callTool({
+      name: 'search',
+      arguments: { query: 'express middleware' },
+    });
+    const result2 = await client.callTool({
+      name: 'fetch-docs',
+      arguments: { libraryId: '/expressjs/express', query: 'middleware' },
+    });
+
+    const proof1 = (result1._meta as Record<string, unknown>).proof as {
+      meta: Record<string, unknown>;
+    };
+    const proof2 = (result2._meta as Record<string, unknown>).proof as {
+      meta: Record<string, unknown>;
+    };
+
+    // Same session ID across tools
+    expect(proof1.meta.sessionId).toBe(proof2.meta.sessionId);
+  });
+});

--- a/src/__tests__/integration/mcp-transport.test.ts
+++ b/src/__tests__/integration/mcp-transport.test.ts
@@ -1,0 +1,390 @@
+/**
+ * End-to-End MCP Transport Integration Test
+ *
+ * Exercises the MCP-I middleware through a real MCP SDK Client→Server
+ * transport (InMemoryTransport). Unlike unit tests that call handlers
+ * directly, these tests go through full JSON-RPC serialization and
+ * MCP protocol framing.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { createMCPIMiddleware } from '../../middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import { ProofVerifier } from '../../proof/verifier.js';
+import { MemoryNonceCacheProvider } from '../../providers/memory.js';
+import { ClockProvider, FetchProvider } from '../../providers/base.js';
+import {
+  createDidKeyResolver,
+  extractPublicKeyFromDidKey,
+  publicKeyToJwk,
+} from '../../delegation/did-key-resolver.js';
+import { base64urlEncodeFromBytes } from '../../utils/base64.js';
+import type {
+  DelegationCredential,
+  DIDDocument,
+  StatusList2021Credential,
+  DelegationRecord,
+  Proof,
+} from '../../types/protocol.js';
+
+// ── Test providers for ProofVerifier ──────────────────────────────
+
+class TestClockProvider extends ClockProvider {
+  now(): number { return Date.now(); }
+  isWithinSkew(timestampMs: number, skewSeconds: number): boolean {
+    return Math.abs(Date.now() - timestampMs) <= skewSeconds * 1000;
+  }
+  hasExpired(expiresAt: number): boolean { return Date.now() > expiresAt; }
+  calculateExpiry(ttlSeconds: number): number { return Date.now() + ttlSeconds * 1000; }
+  format(timestamp: number): string { return new Date(timestamp).toISOString(); }
+}
+
+class TestFetchProvider extends FetchProvider {
+  private didResolver = createDidKeyResolver();
+  async resolveDID(did: string): Promise<DIDDocument | null> {
+    return this.didResolver.resolve(did);
+  }
+  async fetchStatusList(): Promise<StatusList2021Credential | null> { return null; }
+  async fetchDelegationChain(): Promise<DelegationRecord[]> { return []; }
+  async fetch(): Promise<Response> { throw new Error('Not implemented'); }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function setupMcpPair(options?: { autoSession?: boolean }) {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  const mcpi = createMCPIMiddleware(
+    {
+      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+      session: { sessionTtlMinutes: 60 },
+      autoSession: options?.autoSession,
+    },
+    crypto,
+  );
+
+  // ── Tool handlers (mirrors examples/node-server/server.ts) ──
+
+  const greetHandler = mcpi.wrapWithProof('greet', async (args) => ({
+    content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}!` }],
+  }));
+
+  const restrictedGreetHandler = mcpi.wrapWithDelegation(
+    'restricted_greet',
+    {
+      scopeId: 'greeting:restricted',
+      consentUrl: 'https://example.com/consent?scope=greeting:restricted',
+    },
+    mcpi.wrapWithProof('restricted_greet', async (args) => ({
+      content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}! (delegation verified)` }],
+    })),
+  );
+
+  // ── MCP Server ──
+
+  const server = new Server(
+    { name: 'mcpi-transport-test', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      mcpi.handshakeTool,
+      {
+        name: 'greet',
+        description: 'Returns a greeting with proof',
+        inputSchema: {
+          type: 'object' as const,
+          properties: { name: { type: 'string' } },
+        },
+      },
+      {
+        name: 'restricted_greet',
+        description: 'Protected greeting requiring delegation',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            name: { type: 'string' },
+            _mcpi_delegation: { type: 'object' },
+          },
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+
+    if (name === '_mcpi_handshake') {
+      return mcpi.handleHandshake(args as Record<string, unknown>);
+    }
+    if (name === 'greet') {
+      return greetHandler(args as Record<string, unknown>);
+    }
+    if (name === 'restricted_greet') {
+      return restrictedGreetHandler(args as Record<string, unknown>);
+    }
+
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  });
+
+  // ── Client + transport ──
+
+  const client = new Client(
+    { name: 'mcpi-transport-test-client', version: '1.0.0' },
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server, did, kid, keyPair, crypto };
+}
+
+async function issueDelegationVC(scopes: string[]): Promise<DelegationCredential> {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  const signingFn = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kidArg: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, keyPair.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kidArg,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    { getDid: () => did, getKeyId: () => kid, getPrivateKey: () => keyPair.privateKey },
+    signingFn,
+  );
+
+  return issuer.createAndIssueDelegation({
+    id: `test-delegation-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    issuerDid: did,
+    subjectDid: did,
+    constraints: {
+      scopes,
+      notAfter: Math.floor(Date.now() / 1000) + 3600,
+    },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('MCP Transport Integration', () => {
+  const pairs: Array<{ client: Client; server: Server }> = [];
+
+  afterEach(async () => {
+    for (const pair of pairs) {
+      await pair.client.close();
+      await pair.server.close();
+    }
+    pairs.length = 0;
+  });
+
+  async function createPair(options?: { autoSession?: boolean }) {
+    const pair = await setupMcpPair(options);
+    pairs.push(pair);
+    return pair;
+  }
+
+  it('listTools returns handshake + app tools', async () => {
+    const { client } = await createPair();
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toHaveLength(3);
+    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('greet');
+    expect(toolNames).toContain('restricted_greet');
+  });
+
+  it('handshake establishes session via MCP transport', async () => {
+    const { client, did } = await createPair();
+
+    const result = await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `transport-test-${Date.now()}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    expect(result.content).toHaveLength(1);
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.type).toBe('text');
+
+    const parsed = JSON.parse(first.text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.sessionId).toMatch(/^mcpi_/);
+    expect(parsed.serverDid).toBe(did);
+  });
+
+  it('greet returns proof in _meta after handshake', async () => {
+    const { client, did } = await createPair();
+
+    // Handshake first
+    await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `transport-test-${Date.now()}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    // Call greet
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'MCP-I' },
+    });
+
+    // Verify tool output
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, MCP-I!');
+
+    // Verify proof in _meta (top-level on the result)
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.did).toMatch(/^did:key:/);
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+    expect(proof.meta.requestHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(proof.meta.responseHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('proof from greet verifies cryptographically', async () => {
+    const { client, did, kid } = await createPair();
+
+    // Handshake
+    await client.callTool({
+      name: '_mcpi_handshake',
+      arguments: {
+        nonce: `transport-test-${Date.now()}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    // Call greet
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'Verifier' },
+    });
+
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+
+    // Resolve server's public key from did:key
+    const publicKeyBytes = extractPublicKeyFromDidKey(did);
+    expect(publicKeyBytes).not.toBeNull();
+    const publicKeyJwk = publicKeyToJwk(publicKeyBytes!);
+
+    // Create verifier and verify
+    const crypto = new NodeCryptoProvider();
+    const verifier = new ProofVerifier({
+      cryptoProvider: crypto,
+      clockProvider: new TestClockProvider(),
+      nonceCacheProvider: new MemoryNonceCacheProvider(),
+      fetchProvider: new TestFetchProvider(),
+      timestampSkewSeconds: 300,
+    });
+
+    const jwkWithKid = { ...publicKeyJwk, kid };
+    const verificationResult = await verifier.verifyProof(proof as any, jwkWithKid as any);
+    expect(verificationResult.valid).toBe(true);
+  });
+
+  it('autoSession attaches proof without handshake', async () => {
+    const { client } = await createPair({ autoSession: true });
+
+    // Call greet directly — no handshake
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'Auto' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, Auto!');
+
+    // Proof should be present via auto-session
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
+  });
+
+  it('restricted_greet without delegation returns needs_authorization', async () => {
+    const { client } = await createPair();
+
+    const result = await client.callTool({
+      name: 'restricted_greet',
+      arguments: { name: 'Unauthorized' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    const parsed = JSON.parse(first.text);
+    expect(parsed.error).toBe('needs_authorization');
+    expect(parsed.authorizationUrl).toContain('consent');
+    expect(parsed.scopes).toContain('greeting:restricted');
+    expect(parsed.resumeToken).toBeDefined();
+  });
+
+  it('restricted_greet with valid delegation VC returns greeting with proof', async () => {
+    const { client, did } = await createPair({ autoSession: true });
+
+    const vc = await issueDelegationVC(['greeting:restricted']);
+
+    const result = await client.callTool({
+      name: 'restricted_greet',
+      arguments: { name: 'DIF', _mcpi_delegation: vc },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, DIF! (delegation verified)');
+
+    // Proof from inner wrapWithProof
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @mcpi/core — MCP-I Protocol Reference Implementation
+ * @mcp-i/core — MCP-I Protocol Reference Implementation
  *
  * Delegation, proof, and session for Model Context Protocol Identity.
  * This package is a DIF TAAWG protocol reference implementation.
@@ -235,6 +235,8 @@ export {
   MemoryNonceCacheProvider,
   MemoryIdentityProvider,
 } from './providers/memory.js';
+
+export { NodeCryptoProvider } from './providers/node-crypto.js';
 
 // Middleware
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,9 @@ export {
   type MCPIToolDefinition,
   type MCPIToolHandler,
   type MCPIServer,
+  withMCPI,
+  generateIdentity,
+  type WithMCPIOptions,
 } from './middleware/index.js';
 
 // Logging

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,7 +1,10 @@
 /**
  * MCP-I Middleware
  *
- * Provides identity-aware middleware for @modelcontextprotocol/sdk Server.
+ * Primary entry point: `withMCPI(server, { crypto })` — adds identity,
+ * handshake, and auto-proofs to any McpServer instance in one call.
+ *
+ * For the low-level `Server` API or custom patterns, use `createMCPIMiddleware` directly.
  */
 
 export {
@@ -14,3 +17,9 @@ export {
   type MCPIToolHandler,
   type MCPIServer,
 } from './with-mcpi.js';
+
+export {
+  withMCPI,
+  generateIdentity,
+  type WithMCPIOptions,
+} from './with-mcpi-server.js';

--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -125,8 +125,8 @@ export async function withMCPI(
 
   if (proofAllTools) {
     const lowLevel = server.server;
-    const handlers: Map<string, Function> =
-      lowLevel._requestHandlers;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    const handlers: Map<string, Function> = lowLevel._requestHandlers;
     const original = handlers.get("tools/call");
 
     if (original) {

--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -1,0 +1,185 @@
+/**
+ * McpServer Adapter for MCP-I
+ *
+ * Adds MCP-I identity, session management, and proof generation to a
+ * standard McpServer instance with a single function call.
+ *
+ * Usage:
+ *   import { withMCPI } from '@mcpi/core/middleware';
+ *   const mcpi = await withMCPI(server, { crypto: new NodeCryptoProvider() });
+ *   // All tools registered on `server` now get proofs automatically.
+ */
+
+import type { CryptoProvider } from "../providers/base.js";
+import { generateDidKeyFromBase64 } from "../utils/did-helpers.js";
+import {
+  createMCPIMiddleware,
+  type MCPIIdentityConfig,
+  type MCPIDelegationConfig,
+  type MCPIMiddleware,
+} from "./with-mcpi.js";
+import { z } from "zod";
+
+export interface WithMCPIOptions {
+  /** Platform-specific crypto implementation (required) */
+  crypto: CryptoProvider;
+  /** Identity config — auto-generated if omitted */
+  identity?: MCPIIdentityConfig;
+  /** Session configuration */
+  session?: { sessionTtlMinutes?: number };
+  /** Auto-create sessions for non-MCP-I clients (default: true) */
+  autoSession?: boolean;
+  /** Attach proofs to all tool responses (default: true) */
+  proofAllTools?: boolean;
+  /** Tools to skip proof generation for */
+  excludeTools?: string[];
+  /** Delegation verification config */
+  delegation?: MCPIDelegationConfig;
+}
+
+/**
+ * Generate a fresh Ed25519 identity for MCP-I.
+ *
+ * @param crypto - Platform-specific crypto provider
+ * @returns Identity config with DID, kid, and key material
+ */
+export async function generateIdentity(
+  crypto: CryptoProvider,
+): Promise<MCPIIdentityConfig> {
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  return {
+    did,
+    kid: `${did}#keys-1`,
+    privateKey: keyPair.privateKey,
+    publicKey: keyPair.publicKey,
+  };
+}
+
+/**
+ * McpServer type — minimal interface to avoid hard dependency on the SDK.
+ * Matches the public API of @modelcontextprotocol/sdk McpServer.
+ */
+interface McpServerLike {
+  server: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerTool(...args: any[]): void;
+}
+
+/**
+ * Add MCP-I to a McpServer instance.
+ *
+ * 1. Auto-generates Ed25519 identity (or uses provided one)
+ * 2. Registers `_mcpi_handshake` tool
+ * 3. Intercepts the `tools/call` request handler to auto-attach proofs
+ *
+ * @param server - McpServer instance
+ * @param options - Configuration
+ * @returns The MCPIMiddleware instance for advanced usage (wrapWithDelegation, etc.)
+ */
+export async function withMCPI(
+  server: McpServerLike,
+  options: WithMCPIOptions,
+): Promise<MCPIMiddleware> {
+  const identity =
+    options.identity ?? (await generateIdentity(options.crypto));
+
+  const mcpi = createMCPIMiddleware(
+    {
+      identity,
+      session: options.session,
+      delegation: options.delegation,
+      autoSession: options.autoSession ?? true,
+    },
+    options.crypto,
+  );
+
+  // Register _mcpi_handshake tool
+  server.registerTool(
+    "_mcpi_handshake",
+    {
+      description:
+        "MCP-I identity handshake — establishes a cryptographic session",
+      inputSchema: {
+        nonce: z.string().describe("Client-generated unique nonce"),
+        audience: z
+          .string()
+          .describe("Intended audience (server DID or URL)"),
+        timestamp: z.number().describe("Unix epoch seconds"),
+      },
+    },
+    async (args: unknown) => {
+      const result = await mcpi.handleHandshake(args as Record<string, unknown>);
+      return {
+        ...result,
+        content: result.content.map((c) => ({ ...c, type: "text" as const })),
+      };
+    },
+  );
+
+  // Auto-proof interception: wrap the tools/call handler
+  const proofAllTools = options.proofAllTools ?? true;
+
+  if (proofAllTools) {
+    const lowLevel = server.server;
+    const handlers: Map<string, Function> =
+      lowLevel._requestHandlers;
+    const original = handlers.get("tools/call");
+
+    if (original) {
+      handlers.set(
+        "tools/call",
+        async (request: Record<string, unknown>, extra: unknown) => {
+          const result = (await (
+            original as (
+              req: Record<string, unknown>,
+              ext: unknown,
+            ) => Promise<Record<string, unknown>>
+          )(request, extra)) as {
+            content?: Array<{
+              type: string;
+              text: string;
+              [key: string]: unknown;
+            }>;
+            isError?: boolean;
+            _meta?: Record<string, unknown>;
+            [key: string]: unknown;
+          };
+
+          const params = request.params as
+            | { name?: string; arguments?: Record<string, unknown> }
+            | undefined;
+          const toolName = params?.name;
+
+          if (
+            !toolName ||
+            toolName === "_mcpi_handshake" ||
+            result.isError
+          ) {
+            return result;
+          }
+
+          if (options.excludeTools?.includes(toolName)) {
+            return result;
+          }
+
+          // Use wrapWithProof to add proof — it handles session management
+          const addProof = mcpi.wrapWithProof(
+            toolName,
+            async () => result as {
+              content: Array<{ type: string; text: string; [key: string]: unknown }>;
+              isError?: boolean;
+              [key: string]: unknown;
+            },
+          );
+          return addProof(params?.arguments ?? {});
+        },
+      );
+    }
+  }
+
+  return mcpi;
+}

--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -5,7 +5,7 @@
  * standard McpServer instance with a single function call.
  *
  * Usage:
- *   import { withMCPI } from '@mcpi/core/middleware';
+ *   import { withMCPI } from '@mcp-i/core/middleware';
  *   const mcpi = await withMCPI(server, { crypto: new NodeCryptoProvider() });
  *   // All tools registered on `server` now get proofs automatically.
  */

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -1,13 +1,18 @@
 /**
- * MCP-I Middleware for @modelcontextprotocol/sdk Server
+ * MCP-I Middleware — Core Implementation
  *
- * Adds identity, session management, and proof generation to a standard
- * MCP SDK Server.
+ * Adds identity, session management, and proof generation to MCP servers.
  *
- * Usage:
- *   const { handshakeTool, registerToolWithProof } = createMCPIMiddleware(config, crypto);
- *   server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [handshakeTool, ...] }));
- *   registerToolWithProof(server, myToolDef, myHandler);
+ * For most use cases, prefer the high-level `withMCPI()` adapter from
+ * `./with-mcpi-server.ts` which auto-registers the handshake tool and
+ * auto-attaches proofs to all tool responses:
+ *
+ *   import { withMCPI } from '@mcpi/core';
+ *   await withMCPI(server, { crypto: new NodeCryptoProvider() });
+ *
+ * `createMCPIMiddleware()` in this file is the lower-level API used
+ * internally by `withMCPI()` and for advanced use cases like the
+ * low-level `Server` API or custom request handler patterns.
  */
 
 import {
@@ -115,9 +120,11 @@ export interface MCPIToolDefinition {
   };
 }
 
-export interface MCPIToolHandler {
+export interface MCPIToolHandler<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
   (
-    args: Record<string, unknown>,
+    args: T,
     sessionId?: string,
   ): Promise<{
     content: Array<{ type: string; text: string; [key: string]: unknown }>;
@@ -138,6 +145,9 @@ export interface MCPIServer {
 }
 
 export interface MCPIMiddleware {
+  /** The identity config used by this middleware instance */
+  identity: MCPIIdentityConfig;
+
   /** The SessionManager instance for manual session operations */
   sessionManager: SessionManager;
 
@@ -163,7 +173,10 @@ export interface MCPIMiddleware {
    * Wrap a tool handler to automatically generate proofs.
    * Returns a new handler that appends proof metadata to the response.
    */
-  wrapWithProof(toolName: string, handler: MCPIToolHandler): MCPIToolHandler;
+  wrapWithProof<T extends Record<string, unknown> = Record<string, unknown>>(
+    toolName: string,
+    handler: MCPIToolHandler<T>,
+  ): MCPIToolHandler;
 
   /**
    * Wrap a tool handler to require a valid W3C Delegation Credential.
@@ -252,6 +265,14 @@ function validateScopeAttenuation(
 
 /**
  * Create MCP-I middleware for a standard MCP SDK Server.
+ *
+ * For most use cases, prefer {@link withMCPI} from `./with-mcpi-server.ts`
+ * which wraps this function and auto-registers handshake + auto-attaches proofs.
+ *
+ * Use `createMCPIMiddleware` directly when:
+ * - You use the low-level `Server` API (not `McpServer`)
+ * - You need custom request handler patterns
+ * - You want per-tool control over proof/delegation wrapping
  *
  * @param config - Agent identity and session configuration
  * @param cryptoProvider - Platform-specific crypto implementation
@@ -756,6 +777,7 @@ export function createMCPIMiddleware(
   }
 
   return {
+    identity: config.identity,
     sessionManager,
     proofGenerator,
     handshakeTool,

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -7,7 +7,7 @@
  * `./with-mcpi-server.ts` which auto-registers the handshake tool and
  * auto-attaches proofs to all tool responses:
  *
- *   import { withMCPI } from '@mcpi/core';
+ *   import { withMCPI } from '@mcp-i/core';
  *   await withMCPI(server, { crypto: new NodeCryptoProvider() });
  *
  * `createMCPIMiddleware()` in this file is the lower-level API used
@@ -415,12 +415,12 @@ export function createMCPIMiddleware(
     return undefined;
   }
 
-  function wrapWithProof(
+  function wrapWithProof<T extends Record<string, unknown> = Record<string, unknown>>(
     toolName: string,
-    handler: MCPIToolHandler,
+    handler: MCPIToolHandler<T>,
   ): MCPIToolHandler {
     return async (args: Record<string, unknown>, sessionId?: string) => {
-      const result = await handler(args, sessionId);
+      const result = await handler(args as T, sessionId);
 
       if (result.isError) {
         return result;

--- a/src/proof/__tests__/proof-generator.test.ts
+++ b/src/proof/__tests__/proof-generator.test.ts
@@ -1,5 +1,5 @@
 /**
- * Proof Generator Tests — @mcpi/core
+ * Proof Generator Tests — @mcp-i/core
  *
  * Ported from packages/mcp-i-core/src/proof/__tests__/proof-generator.test.ts.
  * All test logic is identical — only import paths change.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -13,3 +13,5 @@ export {
   MemoryNonceCacheProvider,
   MemoryIdentityProvider,
 } from './memory.js';
+
+export { NodeCryptoProvider } from './node-crypto.js';

--- a/src/providers/node-crypto.ts
+++ b/src/providers/node-crypto.ts
@@ -1,0 +1,107 @@
+/**
+ * Node.js CryptoProvider
+ *
+ * Ed25519 crypto backed by Node.js built-in `node:crypto`.
+ * Use this on any Node.js 20+ server.
+ *
+ * @example
+ * ```typescript
+ * import { NodeCryptoProvider } from '@mcp-i/core/providers';
+ * import { withMCPI } from '@mcp-i/core/middleware';
+ *
+ * await withMCPI(server, { crypto: new NodeCryptoProvider() });
+ * ```
+ */
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign,
+  verify,
+  randomBytes,
+} from "node:crypto";
+import { CryptoProvider } from "./base.js";
+
+/** PKCS8 DER header for Ed25519 private keys (16 bytes) */
+const ED25519_PKCS8_PREFIX = Buffer.from(
+  "302e020100300506032b657004220420",
+  "hex",
+);
+
+/** SPKI DER header for Ed25519 public keys (12 bytes) */
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+export class NodeCryptoProvider extends CryptoProvider {
+  async sign(
+    data: Uint8Array,
+    privateKeyBase64: string,
+  ): Promise<Uint8Array> {
+    const privateKey = Buffer.from(privateKeyBase64, "base64");
+
+    // Handle both raw 32-byte and full 64-byte Ed25519 keys
+    const keyBytes =
+      privateKey.length === 64 ? privateKey.subarray(0, 32) : privateKey;
+
+    const keyObject = createPrivateKey({
+      key: Buffer.concat([ED25519_PKCS8_PREFIX, keyBytes]),
+      format: "der",
+      type: "pkcs8",
+    });
+
+    return new Uint8Array(sign(null, Buffer.from(data), keyObject));
+  }
+
+  async verify(
+    data: Uint8Array,
+    signature: Uint8Array,
+    publicKeyBase64: string,
+  ): Promise<boolean> {
+    try {
+      const keyObject = createPublicKey({
+        key: Buffer.concat([
+          ED25519_SPKI_PREFIX,
+          Buffer.from(publicKeyBase64, "base64"),
+        ]),
+        format: "der",
+        type: "spki",
+      });
+
+      return verify(
+        null,
+        Buffer.from(data),
+        keyObject,
+        Buffer.from(signature),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async generateKeyPair(): Promise<{
+    privateKey: string;
+    publicKey: string;
+  }> {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+      publicKeyEncoding: { type: "spki", format: "der" },
+      privateKeyEncoding: { type: "pkcs8", format: "der" },
+    });
+
+    return {
+      privateKey: (privateKey as Buffer).subarray(16, 48).toString("base64"),
+      publicKey: (publicKey as Buffer).subarray(12, 44).toString("base64"),
+    };
+  }
+
+  async hash(data: Uint8Array): Promise<string> {
+    const hex = createHash("sha256")
+      .update(Buffer.from(data))
+      .digest("hex");
+    return `sha256:${hex}`;
+  }
+
+  async randomBytes(length: number): Promise<Uint8Array> {
+    return new Uint8Array(randomBytes(length));
+  }
+}

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -1,5 +1,5 @@
 /**
- * Session Manager Tests — @mcpi/core
+ * Session Manager Tests — @mcp-i/core
  *
  * Verifies platform-agnostic SessionManager behaviour:
  * - Nonce format identical to existing implementation

--- a/src/utils/__tests__/did-helpers.test.ts
+++ b/src/utils/__tests__/did-helpers.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for DID Helper Utilities
  *
- * @package @mcpi/core/utils/__tests__
+ * @package @mcp-i/core/utils/__tests__
  */
 
 import { describe, it, expect } from "vitest";

--- a/src/utils/did-helpers.ts
+++ b/src/utils/did-helpers.ts
@@ -4,7 +4,7 @@
  * Centralized utilities for DID validation, normalization, and handling.
  * Promotes DRY principle and consistency across the codebase.
  *
- * @package @mcpi/core/utils
+ * @package @mcp-i/core/utils
  */
 
 import { base58Encode } from "./base58.js";


### PR DESCRIPTION
## Summary

- **`withMCPI(server, { crypto })`** — reduces MCP-I integration from ~40 lines to 2. Auto-registers handshake tool, auto-attaches proofs to all tool responses via `tools/call` interception. Works with tools registered before or after the call.
- **`generateIdentity(crypto)`** — one-liner identity generation (was 5 lines of boilerplate)
- **`NodeCryptoProvider`** — now shipped as a published export from `@mcp-i/core/providers`, no more copy-pasting
- **Generic `wrapWithProof<T>`** — typed args without casting for advanced users
- **Package renamed** `@mcpi/core` → `@mcp-i/core` across all docs and config
- **Brave Search example** — real-world integration with shared identity pattern for per-session server architectures
- **Context7 example** simplified from ~40 lines of MCP-I boilerplate to 2 lines

### Before / After

```typescript
// BEFORE: ~40 lines
const crypto = new NodeCryptoProvider();
const keyPair = await crypto.generateKeyPair();
const did = generateDidKeyFromBase64(keyPair.publicKey);
const kid = `${did}#keys-1`;
const mcpi = createMCPIMiddleware({ identity: { did, kid, ... }, ... }, crypto);
server.registerTool('_mcpi_handshake', { ... }, async (args) => mcpi.handleHandshake(...));
const handler = mcpi.wrapWithProof('my-tool', async (args) => { ... });
server.registerTool('my-tool', { ... }, async (args) => handler(args as Record<string, unknown>));

// AFTER: 2 lines
await withMCPI(server, { crypto: new NodeCryptoProvider() });
server.registerTool('my-tool', { ... }, async ({ query }) => { /* typed args, no casting */ });
```

## Test plan

- [x] 10 new integration tests for `withMCPI()` (auto-proof, excludeTools, proofAllTools, delegation, generateIdentity)
- [x] 4 new `withMCPI` tests added to existing McpServer test suite
- [x] All 625 existing tests pass — zero regressions
- [x] Published and tested as `@mcp-i/core@1.1.0-canary.2`
- [x] Brave Search example tested with MCP Inspector via HTTP transport
- [x] Context7 example verified with simplified integration