### PR TITLE
feat: consent-basic example with delegation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,413 +1,179 @@
 # @mcp-i/core
 
-**MCP-I protocol reference implementation** — delegation, proof, and session for the Model Context Protocol Identity (MCP-I) standard.
+**Identity, delegation, and proof for the Model Context Protocol.**
 
-> This package is a [DIF TAAWG](https://identity.foundation/working-groups/agent-and-authorization.html) protocol reference implementation donated to the Decentralized Identity Foundation.
+MCP-I answers three questions for every AI agent tool call: *who* is calling (DID), *are they allowed* (delegation VC), and *what happened* (signed proof). It uses W3C Verifiable Credentials, Ed25519 signatures, and Decentralized Identifiers — no central authority required.
 
----
-
-## What is MCP-I?
-
-MCP-I (Model Context Protocol Identity) is a protocol extension for the Model Context Protocol (MCP) that adds cryptographic identity, delegation chains, and non-repudiation proofs to AI agent interactions. It enables MCP servers to verify *who* is calling (agent DID), *on whose behalf* (user delegation), and *what* was done (signed proof). Delegations are issued as W3C Verifiable Credentials with Ed25519 signatures, revocation is tracked via StatusList2021, and every tool call produces a detached JWS proof for audit trails.
-
-Spec: [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.io)
+> [DIF TAAWG](https://identity.foundation/working-groups/agent-and-authorization.html) protocol reference implementation. Spec: [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.io)
 
 ---
 
-## What this package provides
+## Try It
 
-| Module | Description |
-|--------|-------------|
-| **delegation** | W3C VC delegation issuance (`DelegationCredentialIssuer`), verification (`DelegationCredentialVerifier`), graph management, StatusList2021 revocation, cascading revocation, outbound delegation propagation (`buildOutboundDelegationHeaders`), DID:key resolution (`createDidKeyResolver`), and DID:web resolution (`createDidWebResolver`) |
-| **proof** | Platform-agnostic proof generation (`ProofGenerator`) and server-side verification (`ProofVerifier`) — JCS canonicalization, SHA-256 hashing, Ed25519 JWS signing/verification |
-| **session** | Handshake validation and session management (`SessionManager`) with nonce replay prevention |
-| **auth** | Authorization handshake orchestration (`verifyOrHints`) — checks delegation and returns authorization hints |
-| **middleware** | MCP SDK integration — `withMCPI(server, { crypto })` adds identity, sessions, and auto-proof to any `McpServer` in one call. Lower-level `createMCPIMiddleware` available for the `Server` API. |
-| **providers** | Abstract base classes (`CryptoProvider`, `StorageProvider`, etc.) and in-memory implementations for testing |
-| **types** | Pure TypeScript interfaces for all protocol types — zero runtime dependencies |
-
----
-
-## Quick Start
-
-The fastest way to see MCP-I in action is the example server:
+See the consent flow in action — an agent calls a protected tool, a human approves, and the agent retries with a signed credential:
 
 ```bash
 git clone https://github.com/modelcontextprotocol-identity/mcp-i-core.git
 cd mcp-i-core
 pnpm install
-npx tsx examples/node-server/server.ts
+npx tsx examples/consent-basic/src/server.ts
 ```
 
-This starts an MCP server on stdio with identity handshake and proof generation. See [`examples/node-server/README.md`](./examples/node-server/README.md) for details.
+Then connect with [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
-For outbound delegation propagation (forwarding delegation context to downstream services), see [`examples/outbound-delegation/README.md`](./examples/outbound-delegation/README.md).
+```bash
+npx @modelcontextprotocol/inspector
+# → Connect to http://localhost:3002/sse
+```
+
+Call `checkout` — you'll get a consent link. Open it, approve, then retry the tool. [Full walkthrough →](./examples/consent-basic/README.md)
 
 ---
 
-## Installation
+## Add to Your Server
+
+One line to add identity, sessions, and proofs to any MCP server:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { withMCPI, NodeCryptoProvider } from '@mcp-i/core';
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+await withMCPI(server, { crypto: new NodeCryptoProvider() });
+
+// Register tools normally — proofs are attached automatically
+```
+
+Every tool response now includes a cryptographic proof. For protected tools that require human consent, add `wrapWithDelegation`:
+
+```typescript
+import { createMCPIMiddleware, generateIdentity, NodeCryptoProvider } from '@mcp-i/core';
+
+const crypto = new NodeCryptoProvider();
+const identity = await generateIdentity(crypto);
+const mcpi = createMCPIMiddleware({ identity, session: { sessionTtlMinutes: 60 } }, crypto);
+
+// Public tool — proof attached automatically
+const search = mcpi.wrapWithProof('search', async (args) => ({
+  content: [{ type: 'text', text: `Results for: ${args['query']}` }],
+}));
+
+// Protected tool — requires delegation with scope 'orders:write'
+const placeOrder = mcpi.wrapWithDelegation(
+  'place_order',
+  { scopeId: 'orders:write', consentUrl: 'https://example.com/consent' },
+  mcpi.wrapWithProof('place_order', async (args) => ({
+    content: [{ type: 'text', text: `Order placed: ${args['item']}` }],
+  })),
+);
+```
+
+---
+
+## Install
 
 ```bash
 npm install @mcp-i/core
 ```
 
+Requires Node.js 20+. Peer dependency on `@modelcontextprotocol/sdk` (optional — only needed for `withMCPI`).
+
 ---
 
-## Delegation Hardening Compatibility
+## Architecture
 
-MCP-I now enforces strict delegation-chain and status-list checks by default.
-
-- Credentials with `parentId` require `delegation.resolveDelegationChain`.
-- Credentials with `credentialStatus` require `delegation.statusListResolver`.
-
-For temporary migration support in legacy integrations, you can opt in to compatibility mode:
-
-```typescript
-await withMCPI(server, {
-  crypto: new NodeCryptoProvider(),
-  delegation: {
-    allowLegacyUnsafeDelegation: true, // temporary compatibility escape hatch
-  },
-});
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│   Agent      │────▶│  MCP Server  │────▶│  Downstream  │
+│  (did:key)   │     │  + MCP-I     │     │  Services    │
+└─────────────┘     └──────────────┘     └─────────────┘
+       │                    │                     │
+       │ handshake          │ verify delegation   │ outbound headers
+       │ (nonce+DID)        │ attach proof        │ (X-Agent-DID,
+       │                    │ check scopes        │  X-Delegation-Chain)
+       ▼                    ▼                     ▼
+   Session established   Tool executes        Context forwarded
+   with replay           with signed           to downstream
+   prevention            receipt               with delegation
 ```
 
-Compatibility mode weakens security guarantees and should only be used during migration.
+---
+
+## Modules
+
+| Module | What it does |
+|--------|-------------|
+| **middleware** | `withMCPI(server)` — one-call integration. `createMCPIMiddleware` for low-level control. |
+| **delegation** | Issue and verify W3C VCs. DID:key and DID:web resolution. StatusList2021 revocation. Cascading revocation. |
+| **proof** | Generate and verify detached JWS proofs with canonical hashing (JCS + SHA-256). |
+| **session** | Nonce-based handshake. Replay prevention. Session TTL management. |
+| **providers** | Abstract `CryptoProvider`, `IdentityProvider`, `StorageProvider`. Plug in your own KMS, HSM, or vault. |
+| **types** | Pure TypeScript interfaces. Zero runtime dependencies. |
+
+All modules available as subpath exports: `@mcp-i/core/delegation`, `@mcp-i/core/proof`, etc.
 
 ---
 
 ## Examples
 
-> Requires Node.js 20+. Save each block as `example.ts` and run with `npx tsx example.ts`.
+| Example | What it shows |
+|---------|--------------|
+| [**consent-basic**](./examples/consent-basic/) | Human-in-the-loop consent flow: `needs_authorization` → consent page → delegation VC → tool execution. SSE + Streamable HTTP transports. |
+| [**node-server**](./examples/node-server/) | Low-level Server API with handshake, proof, and restricted tools. |
+| [**brave-search-mcp-server**](./examples/brave-search-mcp-server/) | Real-world MCP server wrapping Brave Search with MCP-I identity and proofs. |
+| [**outbound-delegation**](./examples/outbound-delegation/) | Forwarding delegation context to downstream services (§7 gateway pattern). |
+| [**verify-proof**](./examples/verify-proof/) | Standalone proof verification with DID:key resolution. |
+| [**context7-with-mcpi**](./examples/context7-with-mcpi/) | Adding MCP-I to an existing MCP server with `withMCPI`. |
 
 ---
 
-## Example 1 — Issue a Delegation VC
+## Extension Points
+
+MCP-I is a protocol, not a platform. All cryptographic operations, storage, and identity management are abstracted behind interfaces you implement:
 
 ```typescript
-import {
-  createHash,
-  createPrivateKey,
-  generateKeyPairSync,
-  randomBytes,
-  sign as nodeSign,
-} from 'node:crypto';
-import {
-  CryptoProvider,
-  MemoryIdentityProvider,
-  DelegationCredentialIssuer,
-  type DelegationIdentityProvider,
-  type VCSigningFunction,
-} from '@mcp-i/core';
-
-// Minimal Node.js CryptoProvider backed by node:crypto
-class NodeCryptoProvider extends CryptoProvider {
-  async generateKeyPair() {
-    const { privateKey: pk, publicKey: pub } = generateKeyPairSync('ed25519', {
-      privateKeyEncoding: { type: 'pkcs8', format: 'der' },
-      publicKeyEncoding: { type: 'spki', format: 'der' },
-    });
-    // Ed25519 PKCS8 DER: 16-byte header + 32-byte seed
-    // Ed25519 SPKI DER:  12-byte header + 32-byte public key
-    return {
-      privateKey: (pk as Buffer).subarray(16).toString('base64'),
-      publicKey: (pub as Buffer).subarray(12).toString('base64'),
-    };
+// Use AWS KMS instead of local keys
+class KMSCryptoProvider extends CryptoProvider {
+  async sign(data: Uint8Array, keyArn: string) {
+    return kmsClient.sign({ KeyId: keyArn, Message: data });
   }
-  async hash(data: Uint8Array) {
-    return 'sha256:' + createHash('sha256').update(data).digest('hex');
-  }
-  async randomBytes(n: number) { return new Uint8Array(randomBytes(n)); }
-  async sign(data: Uint8Array, privateKeyBase64: string) {
-    const seed = Buffer.from(privateKeyBase64, 'base64').subarray(0, 32);
-    const hdr = Buffer.from([
-      0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05,
-      0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
-    ]);
-    const key = createPrivateKey({ key: Buffer.concat([hdr, seed]), format: 'der', type: 'pkcs8' });
-    return new Uint8Array(nodeSign(null, data, key));
-  }
-  async verify(): Promise<boolean> { throw new Error('unused'); }
 }
 
-const cryptoProvider = new NodeCryptoProvider();
-
-// MemoryIdentityProvider generates a real Ed25519 DID + key pair
-const identityProvider = new MemoryIdentityProvider(cryptoProvider);
-const agent = await identityProvider.getIdentity();
-
-// Adapt AgentIdentity to the DelegationIdentityProvider interface
-const identity: DelegationIdentityProvider = {
-  getDid: () => agent.did,
-  getKeyId: () => agent.kid,
-  getPrivateKey: () => agent.privateKey,
-};
-
-// Real Ed25519 signing function — delegates to NodeCryptoProvider
-const signingFunction: VCSigningFunction = async (canonicalVC, issuerDid) => {
-  const sig = await cryptoProvider.sign(
-    new TextEncoder().encode(canonicalVC),
-    agent.privateKey
-  );
-  return {
-    type: 'Ed25519Signature2020',
-    created: new Date().toISOString(),
-    verificationMethod: `${issuerDid}#key-1`,
-    proofPurpose: 'assertionMethod',
-    proofValue: Buffer.from(sig).toString('base64url'),
-  };
-};
-
-const issuer = new DelegationCredentialIssuer(identity, signingFunction);
-
-const vc = await issuer.createAndIssueDelegation({
-  id: 'delegation-001',
-  issuerDid: agent.did,
-  subjectDid: 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuias8sisDArDJF74t',
-  constraints: {
-    scopes: ['tool:execute', 'resource:read'],
-    notAfter: Math.floor(Date.now() / 1000) + 3600,
-  },
-});
-
-console.log('VC type:', vc.type);
-// ['VerifiableCredential', 'DelegationCredential']
-console.log('Scopes:', vc.credentialSubject.delegation.constraints.scopes);
-// ['tool:execute', 'resource:read']
-console.log('Proof type:', vc.proof?.type);
-// 'Ed25519Signature2020'
-```
-
----
-
-## Example 2 — Session Handshake
-
-```typescript
-import { randomBytes } from 'node:crypto';
-import {
-  CryptoProvider,
-  SessionManager,
-  MemoryNonceCacheProvider,
-  createHandshakeRequest,
-} from '@mcp-i/core';
-
-// SessionManager only needs randomBytes() for session ID generation
-class NodeCryptoProvider extends CryptoProvider {
-  async randomBytes(n: number) { return new Uint8Array(randomBytes(n)); }
-  async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> { throw new Error('unused'); }
-  async hash(_: Uint8Array): Promise<string> { throw new Error('unused'); }
-  async sign(_: Uint8Array, __: string): Promise<Uint8Array> { throw new Error('unused'); }
-  async verify(_: Uint8Array, __: Uint8Array, ___: string): Promise<boolean> { throw new Error('unused'); }
+// Use Redis instead of in-memory nonce cache
+class RedisNonceCacheProvider extends NonceCacheProvider {
+  async hasNonce(nonce: string) { return redis.exists(`nonce:${nonce}`); }
+  async addNonce(nonce: string, ttl: number) { redis.setex(`nonce:${nonce}`, ttl, '1'); }
 }
-
-const cryptoProvider = new NodeCryptoProvider();
-const nonceCache = new MemoryNonceCacheProvider();
-
-const sessionManager = new SessionManager(cryptoProvider, {
-  nonceCache,
-  sessionTtlMinutes: 30,
-  timestampSkewSeconds: 120,
-  serverDid: 'did:web:my-mcp-server.example.com',
-});
-
-// Client: build handshake request (uses globalThis.crypto, built into Node 20+)
-const request = createHandshakeRequest('did:web:my-mcp-server.example.com');
-request.agentDid = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
-
-// Server: validate it
-const result = await sessionManager.validateHandshake(request);
-
-if (result.success && result.session) {
-  console.log('Session ID:', result.session.sessionId);
-  // e.g. 'mcpi_4f3e2a1b-c7d2-4e5f-b6a3-...'
-  console.log('Audience:', result.session.audience);
-  // 'did:web:my-mcp-server.example.com'
-  console.log('Agent DID:', result.session.agentDid);
-  // 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
-}
-console.log('Stats:', sessionManager.getStats());
-// { activeSessions: 1, config: { sessionTtlMinutes: 30, ... } }
 ```
+
+Supported DID methods: `did:key` (built-in, self-resolving), `did:web` (built-in, HTTP resolution), or any custom method via `DIDResolver`.
 
 ---
 
-## Example 3 — Generate a Tool Call Proof
+## Conformance
 
-```typescript
-import {
-  createHash,
-  createPrivateKey,
-  generateKeyPairSync,
-  randomBytes,
-  sign as nodeSign,
-} from 'node:crypto';
-import {
-  CryptoProvider,
-  MemoryIdentityProvider,
-  ProofGenerator,
-  SessionManager,
-} from '@mcp-i/core';
+Three levels defined in [CONFORMANCE.md](./CONFORMANCE.md):
 
-class NodeCryptoProvider extends CryptoProvider {
-  async generateKeyPair() {
-    const { privateKey: pk, publicKey: pub } = generateKeyPairSync('ed25519', {
-      privateKeyEncoding: { type: 'pkcs8', format: 'der' },
-      publicKeyEncoding: { type: 'spki', format: 'der' },
-    });
-    return {
-      privateKey: (pk as Buffer).subarray(16).toString('base64'),
-      publicKey: (pub as Buffer).subarray(12).toString('base64'),
-    };
-  }
-  async hash(data: Uint8Array) {
-    return 'sha256:' + createHash('sha256').update(data).digest('hex');
-  }
-  async randomBytes(n: number) { return new Uint8Array(randomBytes(n)); }
-  async sign(data: Uint8Array, privateKeyBase64: string) {
-    const seed = Buffer.from(privateKeyBase64, 'base64').subarray(0, 32);
-    const hdr = Buffer.from([
-      0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05,
-      0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
-    ]);
-    const key = createPrivateKey({ key: Buffer.concat([hdr, seed]), format: 'der', type: 'pkcs8' });
-    return new Uint8Array(nodeSign(null, data, key));
-  }
-  async verify(): Promise<boolean> { throw new Error('unused'); }
-}
-
-const cryptoProvider = new NodeCryptoProvider();
-
-// MemoryIdentityProvider generates a fresh DID + Ed25519 key pair
-const identityProvider = new MemoryIdentityProvider(cryptoProvider);
-const agent = await identityProvider.getIdentity();
-
-// ProofGenerator signs tool call request+response pairs with the agent's key
-const generator = new ProofGenerator(agent, cryptoProvider);
-
-const request = {
-  method: 'tools/call',
-  params: { name: 'read_file', arguments: { path: '/etc/hosts' } },
-};
-const response = { data: { content: '127.0.0.1 localhost' } };
-
-// SessionContext — in production this comes from SessionManager.validateHandshake()
-const session = {
-  sessionId: 'mcpi_demo-session',
-  audience: 'did:web:my-mcp-server.example.com',
-  nonce: SessionManager.generateNonce(),
-  timestamp: Math.floor(Date.now() / 1000),
-  createdAt: Math.floor(Date.now() / 1000),
-  lastActivity: Math.floor(Date.now() / 1000),
-  ttlMinutes: 30,
-  identityState: 'anonymous' as const,
-};
-
-const proof = await generator.generateProof(request, response, session);
-
-console.log('JWS (first 40 chars):', proof.jws.slice(0, 40) + '...');
-// 'eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk...'
-console.log('Request hash:', proof.meta.requestHash);
-// 'sha256:e3b0...'
-console.log('Agent DID:', proof.meta.did);
-// 'did:key:z...'
-```
+| Level | Requirements |
+|-------|-------------|
+| **Level 1** — Core Crypto | Ed25519 signatures, DID:key resolution, JCS canonicalization |
+| **Level 2** — Full Session | Nonce-based handshake, session management, replay prevention |
+| **Level 3** — Full Delegation | W3C VC issuance/verification, scope attenuation, StatusList2021, cascading revocation |
 
 ---
 
-## Example 4 — MCP Server with Middleware (`withMCPI`)
+## Contributing
 
-The recommended way to add MCP-I to any `McpServer`-based server:
+See [CONTRIBUTING.md](./CONTRIBUTING.md). DCO sign-off required. All PRs must pass CI (type check, lint, test across Node 20/22 on Linux/macOS/Windows).
 
-```typescript
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { withMCPI, CryptoProvider } from '@mcp-i/core';
-import { z } from 'zod';
+## Governance
 
-// ... (NodeCryptoProvider as above)
+See [GOVERNANCE.md](./GOVERNANCE.md). Lazy consensus for non-breaking changes. Explicit vote for breaking changes.
 
-const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+## Security
 
-// One call: auto-generates identity, registers handshake, auto-proofs all tools
-await withMCPI(server, { crypto: new NodeCryptoProvider() });
-
-// Register tools normally — proofs are attached automatically
-server.registerTool(
-  'echo',
-  { description: 'Echo a message', inputSchema: { message: z.string() } },
-  async ({ message }) => ({ content: [{ type: 'text' as const, text: `Echo: ${message}` }] }),
-);
-
-await server.connect(new StdioServerTransport());
-```
-
-<details>
-<summary>Low-level Server API (advanced)</summary>
-
-For the low-level `Server` API with manual request handlers, use `createMCPIMiddleware` directly:
-
-```typescript
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { createMCPIMiddleware, generateIdentity } from '@mcp-i/core';
-
-const crypto = new NodeCryptoProvider();
-const identity = await generateIdentity(crypto);
-
-const mcpi = createMCPIMiddleware({ identity, session: { sessionTtlMinutes: 60 } }, crypto);
-
-const echo = mcpi.wrapWithProof('echo', async (args) => ({
-  content: [{ type: 'text', text: `Echo: ${args['message']}` }],
-}));
-
-const server = new Server({ name: 'my-server', version: '1.0.0' }, { capabilities: { tools: {} } });
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [mcpi.handshakeTool, { name: 'echo', inputSchema: { type: 'object' } }],
-}));
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  if (req.params.name === '_mcpi_handshake') return mcpi.handleHandshake(req.params.arguments ?? {});
-  if (req.params.name === 'echo') return echo(req.params.arguments ?? {});
-  return { content: [{ type: 'text', text: 'Unknown tool' }], isError: true };
-});
-
-await server.connect(new StdioServerTransport());
-```
-
-</details>
-
----
-
-## Example 5 — Verify a Proof with DID:key Resolution
-
-```typescript
-import { ProofVerifier, createDidKeyResolver, CryptoProvider } from '@mcp-i/core';
-
-// ... (NodeCryptoProvider with verify + hash)
-
-const crypto = new NodeCryptoProvider();
-const didResolver = createDidKeyResolver();
-
-const verifier = new ProofVerifier({
-  cryptoProvider: crypto,
-  fetchPublicKeyFromDID: async (did) => {
-    const result = didResolver(did);
-    return result?.publicKeyJwk ?? null;
-  },
-  timestampSkewSeconds: 120,
-});
-
-const result = await verifier.verifyProofDetached(proof);
-console.log('Valid:', result.valid);
-```
-
----
+See [SECURITY.md](./SECURITY.md). 48-hour acknowledgement. 90-day coordinated disclosure.
 
 ## License
 
 MIT — see [LICENSE](./LICENSE)
-
----
-
-*This package is a DIF TAAWG protocol reference implementation.*
-*Spec: [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.io)*

--- a/examples/consent-basic/.gitignore
+++ b/examples/consent-basic/.gitignore
@@ -1,0 +1,4 @@
+# Private key material — never commit
+.mcpi/
+node_modules/
+dist/

--- a/examples/consent-basic/README.md
+++ b/examples/consent-basic/README.md
@@ -1,0 +1,57 @@
+# consent-basic
+
+Human-in-the-loop consent flow for MCP-I. An AI agent calls a protected tool, the human approves via a consent page, and the agent retries with a signed delegation credential.
+
+```
+Agent calls checkout → needs_authorization → Human approves → Agent retries with VC → Tool executes
+```
+
+## Quick Start
+
+```bash
+# 1. Generate a persistent identity (optional — ephemeral if skipped)
+npm run generate-identity
+
+# 2. Start the server (MCP + consent server, shared identity)
+npm start
+
+# 3. Connect via MCP Inspector
+npx @modelcontextprotocol/inspector
+# → Connect to http://localhost:3002/sse
+```
+
+## What's Inside
+
+| File | Purpose |
+|------|---------|
+| `src/server.ts` | MCP server with `browse` (public) and `checkout` (protected) tools |
+| `src/consent-server.ts` | HTTP consent page + VC issuance endpoint |
+| `src/delegation-issuer.ts` | Shared factory for creating a `DelegationCredentialIssuer` from identity config |
+| `scripts/generate-identity.ts` | Persist a DID to `.mcpi/identity.json` so it survives restarts |
+| `public/consent.html` | Consent UI served during the authorization flow |
+
+## Testing the Consent Flow
+
+1. **Call `browse`** with `{ "category": "electronics" }` — works immediately, proof attached
+2. **Call `checkout`** with `{ "item": "laptop" }` — returns `needs_authorization` with a consent link
+3. **Open the consent URL** in your browser and click **Approve**
+4. **Retry `checkout`** with the same arguments — the delegation is applied automatically
+5. Order confirmed — proof attached to response
+
+## Spec Coverage
+
+| Section | What's demonstrated |
+|---------|-------------------|
+| §4 Delegation | W3C VC issuance, scope constraints, expiry |
+| §5 Proof | Detached JWS proof on every tool response |
+| §6 Authorization | `needs_authorization` → consent → delegation verification |
+
+## Persistent Identity
+
+This example generates ephemeral keys by default. To persist across restarts:
+
+```bash
+npm run generate-identity
+```
+
+This writes a `did:key` identity to `.mcpi/identity.json`. The server loads it automatically on startup.

--- a/examples/consent-basic/__tests__/consent-server.test.ts
+++ b/examples/consent-basic/__tests__/consent-server.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration Tests: consent-server.ts
+ *
+ * Validates the HTTP consent server serves the consent page and issues
+ * spec-compliant W3C Delegation Credentials on approval.
+ *
+ * Spec coverage: §3.1 (VC structure), §4.1 (DelegationRecord),
+ *                §4.2 (DelegationConstraints)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
+import type { DelegationCredential } from '../../../src/types/protocol.js';
+
+let server: ConsentServer;
+
+function request(path: string, options?: RequestInit): Promise<Response> {
+  return fetch(`${server.url}${path}`, options);
+}
+
+describe('Consent HTTP Server', () => {
+  beforeAll(async () => {
+    server = await startConsentServer({ port: 0 });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  // GET /consent — page serving
+  it('should serve consent.html with query params injected', async () => {
+    const res = await request(
+      '/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+
+    const body = await res.text();
+    expect(body).toContain('checkout');
+    expect(body).toContain('cart:write');
+    expect(body).toContain('did:key:z6MkTest');
+  });
+
+  it('should handle missing query params gracefully', async () => {
+    const res = await request('/consent');
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('unknown');
+  });
+
+  // POST /approve — §3.1 compliant VC
+  it('should issue a valid delegation VC on approval', async () => {
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write',
+        agentDid: 'did:key:z6MkTestAgent',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    expect(data.delegationToken).toBeDefined();
+
+    const vc = data.delegationToken;
+    expect(vc.type).toContain('DelegationCredential');
+    expect(vc.credentialSubject.delegation.constraints.scopes).toContain('cart:write');
+    expect(vc.proof).toBeDefined();
+    expect(vc.proof!.type).toBe('Ed25519Signature2020');
+  });
+
+  // §4.1 — subjectDid set to requesting agent
+  it('should set subjectDid to the requesting agent DID', async () => {
+    const agentDid = 'did:key:z6MkSpecificAgent';
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write',
+        agentDid,
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    expect(vc.credentialSubject.delegation.subjectDid).toBe(agentDid);
+  });
+
+  // §4.2 — 1 hour expiry
+  it('should set notAfter to approximately 1 hour from now', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write',
+        agentDid: 'did:key:z6MkExpiryTest',
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    const notAfter = vc.credentialSubject.delegation.constraints.notAfter!;
+
+    // Within 5s tolerance
+    expect(notAfter).toBeGreaterThanOrEqual(nowSeconds + 3595);
+    expect(notAfter).toBeLessThanOrEqual(nowSeconds + 3605);
+  });
+
+  // CORS
+  it('should include Access-Control-Allow-Origin header', async () => {
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write',
+        agentDid: 'did:key:z6MkCorsTest',
+      }),
+    });
+
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  // 404
+  it('should return 404 for unknown routes', async () => {
+    const res = await request('/unknown');
+    expect(res.status).toBe(404);
+  });
+
+  // Multiple scopes
+  it('should handle comma-separated scopes', async () => {
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write,cart:read',
+        agentDid: 'did:key:z6MkMultiScope',
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    expect(vc.credentialSubject.delegation.constraints.scopes).toEqual(['cart:write', 'cart:read']);
+  });
+
+  // Error: malformed JSON
+  it('should return 400 for malformed JSON body', async () => {
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('invalid_request');
+  });
+
+  // Error: missing required fields
+  it('should return 400 when required fields are missing', async () => {
+    const res = await request('/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: 'checkout' }),
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('missing_fields');
+  });
+});

--- a/examples/consent-basic/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-basic/__tests__/delegation-issuer.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit Tests: delegation-issuer.ts
+ *
+ * Validates the factory for creating DelegationCredentialIssuers
+ * from identity config. Covers VC structure, proof, and constraints.
+ *
+ * Spec coverage: §3.1 (VC structure), §4.1 (DelegationRecord), §4.2 (constraints)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createDelegationIssuerFromIdentity, type DelegationIssuerFactory } from '../src/delegation-issuer.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import type { DelegationCredential } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+
+let factory: DelegationIssuerFactory;
+let vc: DelegationCredential;
+
+describe('createDelegationIssuerFromIdentity', () => {
+  beforeAll(async () => {
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+
+    factory = createDelegationIssuerFromIdentity(crypto, {
+      did,
+      kid,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+    });
+
+    vc = await factory.issuer.createAndIssueDelegation({
+      id: 'test-delegation-001',
+      issuerDid: did,
+      subjectDid: 'did:key:z6MkTestSubject',
+      constraints: {
+        scopes: ['cart:write', 'cart:read'],
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+  });
+
+  // §3.1 — VC structure
+  it('should produce a VC with correct type array', () => {
+    expect(vc.type).toContain('VerifiableCredential');
+    expect(vc.type).toContain('DelegationCredential');
+  });
+
+  it('should include W3C context', () => {
+    expect(vc['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+  });
+
+  it('should have an issuer matching the identity DID', () => {
+    expect(vc.issuer).toBe(factory.identity.did);
+  });
+
+  it('should set credentialSubject.id to the subject DID', () => {
+    expect(vc.credentialSubject.id).toBe('did:key:z6MkTestSubject');
+  });
+
+  // §3.1 — Proof
+  it('should include an Ed25519Signature2020 proof', () => {
+    expect(vc.proof).toBeDefined();
+    expect(vc.proof!.type).toBe('Ed25519Signature2020');
+  });
+
+  it('should have proofValue in the proof', () => {
+    expect(vc.proof!['proofValue']).toBeDefined();
+    expect(typeof vc.proof!['proofValue']).toBe('string');
+  });
+
+  it('should set verificationMethod to the kid', () => {
+    expect(vc.proof!['verificationMethod']).toBe(factory.identity.kid);
+  });
+
+  it('should set proofPurpose to assertionMethod', () => {
+    expect(vc.proof!.proofPurpose).toBe('assertionMethod');
+  });
+
+  // §4.1 — DelegationRecord
+  it('should embed the delegation record in credentialSubject', () => {
+    const delegation = vc.credentialSubject.delegation;
+    expect(delegation).toBeDefined();
+    expect(delegation.id).toBe('test-delegation-001');
+    expect(delegation.issuerDid).toBe(factory.identity.did);
+    expect(delegation.subjectDid).toBe('did:key:z6MkTestSubject');
+  });
+
+  // §4.2 — Constraints
+  it('should include scopes in constraints', () => {
+    const scopes = vc.credentialSubject.delegation.constraints.scopes;
+    expect(scopes).toEqual(['cart:write', 'cart:read']);
+  });
+
+  it('should include notAfter in constraints', () => {
+    const notAfter = vc.credentialSubject.delegation.constraints.notAfter;
+    expect(notAfter).toBeDefined();
+    expect(notAfter).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  // Factory identity
+  it('should return the identity in the factory', () => {
+    expect(factory.identity.did).toBeDefined();
+    expect(factory.identity.did.startsWith('did:key:')).toBe(true);
+    expect(factory.identity.kid).toContain('#keys-1');
+  });
+});

--- a/examples/consent-basic/__tests__/e2e.test.ts
+++ b/examples/consent-basic/__tests__/e2e.test.ts
@@ -1,0 +1,162 @@
+/**
+ * E2E Tests: Full consent → delegation → execution cycle
+ *
+ * Validates the complete MCP-I consent flow as a user would experience it:
+ * tool call → needs_authorization → consent page → approve → delegation → retry → success.
+ *
+ * Spec coverage: §4.1 (delegation chain), §5.1 (proof), §6.1 (needs_authorization),
+ *                §6.2 (delegation verification)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
+import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
+import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+
+interface ToolResult {
+  content: Array<{ type: string; text: string; [key: string]: unknown }>;
+  isError?: boolean;
+  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  [key: string]: unknown;
+}
+
+let consentServer: ConsentServer;
+let mcpi: MCPIMiddleware;
+let browseHandler: (args: Record<string, unknown>) => Promise<ToolResult>;
+let checkoutHandler: (args: Record<string, unknown>) => Promise<ToolResult>;
+
+describe('E2E: consent -> delegation -> execution', () => {
+  beforeAll(async () => {
+    // 1. Create MCP middleware with fresh identity
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+
+    mcpi = createMCPIMiddleware(
+      {
+        identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    // 2. Start consent server with the MCP server's identity (shared trust domain)
+    const factory = createDelegationIssuerFromIdentity(crypto, {
+      did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey,
+    });
+    consentServer = await startConsentServer({ port: 0, factory });
+
+    browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+      content: [{ type: 'text', text: `Browsing: ${args['category'] ?? 'all'}` }],
+    })) as typeof browseHandler;
+
+    checkoutHandler = mcpi.wrapWithDelegation(
+      'checkout',
+      {
+        scopeId: 'cart:write',
+        consentUrl: `${consentServer.url}/consent?tool=checkout&scopes=cart:write&agent_did=${encodeURIComponent(did)}`,
+      },
+      mcpi.wrapWithProof('checkout', async (args) => ({
+        content: [{ type: 'text', text: `Order confirmed: ${args['item']}` }],
+      })),
+    ) as typeof checkoutHandler;
+  });
+
+  afterAll(async () => {
+    await consentServer.close();
+  });
+
+  // Full cycle: §6.1 → §4.1 → §6.2 → §5.1
+  it('should complete the full consent flow', async () => {
+    // 3. Call checkout → get needs_authorization
+    const firstAttempt = await checkoutHandler({ item: 'laptop' });
+    const authError = JSON.parse(firstAttempt.content[0]!.text) as NeedsAuthorizationError;
+    expect(authError.error).toBe('needs_authorization');
+    expect(authError.scopes).toContain('cart:write');
+
+    // 4. Parse authorizationUrl
+    const authUrl = new URL(authError.authorizationUrl);
+    const tool = authUrl.searchParams.get('tool');
+    const scopes = authUrl.searchParams.get('scopes');
+    const agentDid = authUrl.searchParams.get('agent_did');
+
+    // 5. POST /approve to consent server
+    const approveRes = await fetch(`${consentServer.url}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool, scopes, agentDid }),
+    });
+    expect(approveRes.status).toBe(200);
+
+    // 6. Parse the delegation token (returned as object, not string)
+    const approveData = (await approveRes.json()) as { delegationToken: DelegationCredential };
+    expect(approveData.delegationToken).toBeDefined();
+    const vc = approveData.delegationToken;
+    expect(vc.type).toContain('DelegationCredential');
+
+    // 7. Retry checkout with the consent server's VC directly.
+    //    This works because both servers share the same identity.
+    const retryResult = await checkoutHandler({
+      item: 'laptop',
+      _mcpi_delegation: vc,
+    });
+
+    // 8. Tool executes successfully
+    expect(retryResult.isError).toBeUndefined();
+    expect(retryResult.content[0]!.text).toContain('Order confirmed');
+    expect(retryResult.content[0]!.text).toContain('laptop');
+
+    // 9. Response includes proof
+    expect(retryResult._meta).toBeDefined();
+    expect(retryResult._meta!.proof).toBeDefined();
+    expect(retryResult._meta!.proof!.jws).toBeDefined();
+  });
+
+  // §4.3 — scope mismatch across tools
+  it('should not allow reuse of delegation for different tools', async () => {
+    // A delegation for cart:write should not work for a tool requiring admin:write
+    const factory = createDelegationIssuerFromIdentity(crypto, {
+      did: mcpi.identity.did,
+      kid: mcpi.identity.kid,
+      privateKey: mcpi.identity.privateKey,
+      publicKey: mcpi.identity.publicKey,
+    });
+
+    const vc = await factory.issuer.createAndIssueDelegation({
+      id: `wrong-scope-${Date.now()}`,
+      issuerDid: mcpi.identity.did,
+      subjectDid: mcpi.identity.did,
+      constraints: {
+        scopes: ['admin:write'],
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+
+    const result = await checkoutHandler({ item: 'laptop', _mcpi_delegation: vc });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_scope_missing');
+  });
+
+  // Deny flow
+  it('should handle denial gracefully — no delegation issued', async () => {
+    // Without approving, subsequent calls still return needs_authorization
+    const result = await checkoutHandler({ item: 'laptop' });
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+    expect(parsed.error).toBe('needs_authorization');
+  });
+
+  // Browse still works without any delegation
+  it('should execute browse with proof but no delegation', async () => {
+    const result = await browseHandler({ category: 'electronics' });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('electronics');
+    expect(result._meta?.proof).toBeDefined();
+  });
+});

--- a/examples/consent-basic/__tests__/server.test.ts
+++ b/examples/consent-basic/__tests__/server.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration Tests: server.ts — MCP Server with consent-based delegation
+ *
+ * Validates tool protection (needs_authorization flow), delegation
+ * verification, proof generation, and argument stripping.
+ *
+ * Spec coverage: §4.3 (scope attenuation), §5.1 (DetachedProof),
+ *                §5.2 (canonical hashing), §6.1 (needs_authorization),
+ *                §6.2 (delegation verification)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
+import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+const CONSENT_URL = 'http://localhost:9999/consent';
+
+interface ToolResult {
+  content: Array<{ type: string; text: string; [key: string]: unknown }>;
+  isError?: boolean;
+  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  [key: string]: unknown;
+}
+
+let mcpi: MCPIMiddleware;
+let browseHandler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>;
+let checkoutHandler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>;
+let serverDid: string;
+
+async function issueTestDelegation(
+  subjectDid: string,
+  scopes: string[],
+  notAfterOffset = 3600,
+): Promise<DelegationCredential> {
+  const factory = createDelegationIssuerFromIdentity(crypto, {
+    did: mcpi.identity.did,
+    kid: mcpi.identity.kid,
+    privateKey: mcpi.identity.privateKey,
+    publicKey: mcpi.identity.publicKey,
+  });
+
+  return factory.issuer.createAndIssueDelegation({
+    id: `delegation-test-${Date.now()}`,
+    issuerDid: mcpi.identity.did,
+    subjectDid,
+    constraints: {
+      scopes,
+      notAfter: Math.floor(Date.now() / 1000) + notAfterOffset,
+    },
+  });
+}
+
+describe('MCP Server with consent-basic', () => {
+  beforeAll(async () => {
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+    serverDid = did;
+
+    mcpi = createMCPIMiddleware(
+      {
+        identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Browsing category: ${args['category'] ?? 'all'}. Found 3 items.`,
+      }],
+    })) as typeof browseHandler;
+
+    checkoutHandler = mcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      mcpi.wrapWithProof('checkout', async (args) => ({
+        content: [{
+          type: 'text',
+          text: `Order confirmed for item: ${args['item'] ?? 'unknown'}. Thank you!`,
+        }],
+      })),
+    ) as typeof checkoutHandler;
+  });
+
+  // Public tool — no delegation needed
+  it('should execute browse tool without delegation', async () => {
+    const result = await browseHandler({ category: 'electronics' });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('electronics');
+  });
+
+  // §6.1 — needs_authorization
+  it('should return needs_authorization for checkout without delegation', async () => {
+    const result = await checkoutHandler({ item: 'widget' });
+
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+    expect(parsed.error).toBe('needs_authorization');
+    expect(parsed.authorizationUrl).toBe(CONSENT_URL);
+    expect(parsed.scopes).toContain('cart:write');
+    expect(parsed.resumeToken).toBeDefined();
+    expect(typeof parsed.resumeToken).toBe('string');
+    expect(parsed.resumeToken.length).toBeGreaterThan(0);
+    expect(parsed.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  // §6.1 — resume token format (UUID-like: 8-4-4-4-12 hex chars)
+  it('should include resumeToken in UUID-like format', async () => {
+    const result = await checkoutHandler({ item: 'widget' });
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+
+    expect(parsed.resumeToken).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  // §6.2 — Delegation verification (valid VC)
+  it('should execute checkout with a valid delegation VC', async () => {
+    const vc = await issueTestDelegation(serverDid, ['cart:write']);
+    const result = await checkoutHandler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('Order confirmed');
+    expect(result.content[0]!.text).toContain('widget');
+  });
+
+  // §4.3 — Wrong scope
+  it('should reject a delegation VC with wrong scope', async () => {
+    const vc = await issueTestDelegation(serverDid, ['cart:read']);
+    const result = await checkoutHandler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_scope_missing');
+  });
+
+  // §4.2 — Expired delegation
+  it('should reject an expired delegation VC', async () => {
+    // Use a dedicated middleware instance to avoid shared state interference
+    const expiredMcpi = createMCPIMiddleware(
+      {
+        identity: mcpi.identity,
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    const expiredCheckout = expiredMcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      async (args) => ({
+        content: [{ type: 'text', text: `Order: ${args['item']}` }],
+      }),
+    );
+
+    const vc = await issueTestDelegation(serverDid, ['cart:write'], -3600);
+    const result = await expiredCheckout({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_invalid');
+  });
+
+  // §5.1 — Detached proof on browse
+  it('should attach a detached proof to browse tool response', async () => {
+    const result = await browseHandler({ category: 'books' });
+
+    expect(result._meta).toBeDefined();
+    expect(result._meta!.proof).toBeDefined();
+
+    const proof = result._meta!.proof!;
+    // JWS: 3 dot-separated base64url parts
+    expect(proof.jws).toBeDefined();
+    expect(proof.jws.split('.').length).toBe(3);
+    // Meta fields
+    expect(proof.meta.did).toBeDefined();
+    expect((proof.meta.did as string).startsWith('did:key:')).toBe(true);
+    expect((proof.meta.requestHash as string).startsWith('sha256:')).toBe(true);
+    expect((proof.meta.responseHash as string).startsWith('sha256:')).toBe(true);
+  });
+
+  // §5.2 — Deterministic hashing
+  it('should produce deterministic hashes for identical requests', async () => {
+    const result1 = await browseHandler({ category: 'books' });
+    const result2 = await browseHandler({ category: 'books' });
+
+    expect(result1._meta!.proof!.meta.requestHash).toBe(
+      result2._meta!.proof!.meta.requestHash,
+    );
+  });
+
+  // §4.3 — _mcpi_delegation stripping
+  it('should not pass _mcpi_delegation to the tool handler', async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const testMcpi = createMCPIMiddleware(
+      {
+        identity: mcpi.identity,
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    const handler = testMcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      async (args) => {
+        capturedArgs = args;
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const vc = await issueTestDelegation(serverDid, ['cart:write']);
+    await handler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(capturedArgs).toBeDefined();
+    expect(capturedArgs!['item']).toBe('widget');
+    expect(capturedArgs!['_mcpi_delegation']).toBeUndefined();
+  });
+});

--- a/examples/consent-basic/package.json
+++ b/examples/consent-basic/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@mcp-i/example-consent-basic",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP-I consent flow example — demonstrates needs_authorization → consent page → delegation VC → tool execution",
+  "scripts": {
+    "start": "npx tsx src/server.ts",
+    "start:consent": "npx tsx src/consent-server.ts",
+    "generate-identity": "npx tsx scripts/generate-identity.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/examples/consent-basic/public/consent.html
+++ b/examples/consent-basic/public/consent.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MCP-I Consent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e1e4e8;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #1c1f26;
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      padding: 2rem;
+      max-width: 480px;
+      width: 100%;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    }
+    h1 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-bottom: 1.5rem;
+      color: #f0f6fc;
+    }
+    .field { margin-bottom: 1rem; }
+    .field .label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #8b949e;
+      margin-bottom: 0.25rem;
+    }
+    .field .value {
+      font-size: 0.95rem;
+      color: #c9d1d9;
+      word-break: break-all;
+      padding: 0.5rem 0.75rem;
+      background: #161b22;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+    }
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+    button {
+      flex: 1;
+      padding: 0.625rem 1rem;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    button:hover { opacity: 0.9; }
+    button:focus-visible {
+      outline: 2px solid #58a6ff;
+      outline-offset: 2px;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-approve { background: #238636; color: #fff; }
+    .btn-deny { background: #da3633; color: #fff; }
+    #status {
+      margin-top: 1rem;
+      padding: 0.75rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      display: none;
+    }
+    #status.success { display: block; background: #0d1117; border: 1px solid #238636; color: #3fb950; }
+    #status.error { display: block; background: #0d1117; border: 1px solid #da3633; color: #f85149; }
+    #status.denied { display: block; background: #0d1117; border: 1px solid #d29922; color: #e3b341; }
+    #delegation-output {
+      display: none;
+      margin-top: 1rem;
+    }
+    #delegation-output textarea {
+      width: 100%;
+      min-height: 120px;
+      background: #161b22;
+      color: #c9d1d9;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      padding: 0.5rem;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.75rem;
+      resize: vertical;
+    }
+    .btn-copy {
+      background: #388bfd;
+      color: #fff;
+      margin-top: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="card" role="dialog" aria-labelledby="consent-title">
+    <h1 id="consent-title">Agent Consent Request</h1>
+
+    <div class="field">
+      <span class="label" id="label-tool">Tool</span>
+      <div class="value" id="field-tool" aria-labelledby="label-tool">{{tool}}</div>
+    </div>
+
+    <div class="field">
+      <span class="label" id="label-scopes">Requested Scopes</span>
+      <div class="value" id="field-scopes" aria-labelledby="label-scopes">{{scopes}}</div>
+    </div>
+
+    <div class="field">
+      <span class="label" id="label-agent">Agent DID</span>
+      <div class="value" id="field-agent" aria-labelledby="label-agent">{{agentDid}}</div>
+    </div>
+
+    <div class="actions">
+      <button
+        class="btn-approve"
+        id="btn-approve"
+        type="button"
+        aria-label="Approve delegation for this tool"
+      >Approve</button>
+      <button
+        class="btn-deny"
+        id="btn-deny"
+        type="button"
+        aria-label="Deny delegation request"
+      >Deny</button>
+    </div>
+
+    <div id="status" role="alert" aria-live="polite"></div>
+
+    <div id="delegation-output">
+      <span class="label">Delegation Token</span>
+      <textarea id="delegation-json" readonly aria-label="Delegation token JSON"></textarea>
+      <button class="btn-copy" id="btn-copy" type="button">Copy to Clipboard</button>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      var tool = document.getElementById('field-tool').textContent;
+      var scopes = document.getElementById('field-scopes').textContent;
+      var agentDid = document.getElementById('field-agent').textContent;
+      var resumeToken = new URLSearchParams(window.location.search).get('resume_token') || '';
+      var statusEl = document.getElementById('status');
+      var approveBtn = document.getElementById('btn-approve');
+      var denyBtn = document.getElementById('btn-deny');
+
+      function setStatus(msg, cls) {
+        statusEl.textContent = msg;
+        statusEl.className = cls;
+      }
+
+      approveBtn.addEventListener('click', function () {
+        approveBtn.disabled = true;
+        denyBtn.disabled = true;
+        setStatus('Issuing delegation...', '');
+
+        fetch('/approve', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tool: tool, scopes: scopes, agentDid: agentDid, resumeToken: resumeToken }),
+        })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            if (data.delegationToken) {
+              setStatus('Delegation approved. You can now retry the tool call — the credential will be applied automatically.', 'success');
+              var outputEl = document.getElementById('delegation-output');
+              var jsonEl = document.getElementById('delegation-json');
+              jsonEl.value = JSON.stringify(data.delegationToken, null, 2);
+              outputEl.style.display = 'block';
+              document.getElementById('btn-copy').addEventListener('click', function () {
+                jsonEl.select();
+                navigator.clipboard.writeText(jsonEl.value).then(function () {
+                  setStatus('Copied to clipboard!', 'success');
+                });
+              });
+            } else {
+              setStatus('Error: ' + (data.message || 'Unknown error'), 'error');
+              approveBtn.disabled = false;
+              denyBtn.disabled = false;
+            }
+          })
+          .catch(function (err) {
+            setStatus('Network error: ' + err.message, 'error');
+            approveBtn.disabled = false;
+            denyBtn.disabled = false;
+          });
+      });
+
+      denyBtn.addEventListener('click', function () {
+        approveBtn.disabled = true;
+        denyBtn.disabled = true;
+        setStatus('Delegation denied. No credentials were issued.', 'denied');
+      });
+
+      // Focus management: auto-focus the approve button
+      approveBtn.focus();
+    })();
+  </script>
+</body>
+</html>

--- a/examples/consent-basic/scripts/generate-identity.ts
+++ b/examples/consent-basic/scripts/generate-identity.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env npx tsx
+/**
+ * Generate Identity
+ *
+ * Creates a persistent Ed25519 DID identity and saves it to .mcpi/identity.json.
+ * If an identity already exists, prints it without overwriting.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-identity.ts
+ *   npx tsx scripts/generate-identity.ts --force   # overwrite existing
+ *
+ * The server reads this file on startup so the DID survives restarts.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_DIR = path.resolve(__dirname, '..', '.mcpi');
+const IDENTITY_PATH = path.join(IDENTITY_DIR, 'identity.json');
+
+interface PersistedIdentity {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+  createdAt: string;
+}
+
+async function main() {
+  const force = process.argv.includes('--force');
+
+  // Check for existing identity
+  if (fs.existsSync(IDENTITY_PATH) && !force) {
+    const existing = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as PersistedIdentity;
+    process.stderr.write(`Identity already exists (use --force to regenerate)\n`);
+    process.stderr.write(`  DID: ${existing.did}\n`);
+    process.stderr.write(`  Created: ${existing.createdAt}\n`);
+    process.stderr.write(`  Path: ${IDENTITY_PATH}\n`);
+    return;
+  }
+
+  // Generate new identity
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  const identity: PersistedIdentity = {
+    did,
+    kid,
+    privateKey: keyPair.privateKey,
+    publicKey: keyPair.publicKey,
+    createdAt: new Date().toISOString(),
+  };
+
+  // Write to disk
+  fs.mkdirSync(IDENTITY_DIR, { recursive: true });
+  fs.writeFileSync(IDENTITY_PATH, JSON.stringify(identity, null, 2) + '\n');
+
+  process.stderr.write(`Identity generated\n`);
+  process.stderr.write(`  DID: ${did}\n`);
+  process.stderr.write(`  Path: ${IDENTITY_PATH}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-basic/src/consent-server.ts
+++ b/examples/consent-basic/src/consent-server.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env npx tsx
+/**
+ * Consent HTTP Server
+ *
+ * Serves a consent page and issues W3C Delegation Credentials on approval.
+ * This is the authorization endpoint in the MCP-I consent flow.
+ *
+ * Routes:
+ *   GET  /consent  — Consent page with tool/scopes/agentDid injected
+ *   POST /approve  — Issues a delegation VC and returns { delegationToken }
+ *
+ * Related Spec: MCP-I §4 (Delegation), §6 (Authorization)
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import {
+  createDelegationIssuerFromIdentity,
+  type AgentIdentityConfig,
+  type DelegationIssuerFactory,
+} from './delegation-issuer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface DelegationStoreWriter {
+  set(resumeToken: string, vc: unknown, ttlSeconds?: number): void;
+}
+
+export interface ConsentServerConfig {
+  port: number;
+  factory?: DelegationIssuerFactory;
+  delegationStore?: DelegationStoreWriter;
+}
+
+export interface ConsentServer {
+  server: http.Server;
+  port: number;
+  url: string;
+  factory: DelegationIssuerFactory;
+  close: () => Promise<void>;
+}
+
+/**
+ * Create and start a consent HTTP server.
+ *
+ * @param config - Server configuration (port, optional pre-built factory)
+ * @returns Running server with address info and cleanup handle
+ */
+export async function startConsentServer(
+  config: ConsentServerConfig,
+): Promise<ConsentServer> {
+  let factory: DelegationIssuerFactory;
+
+  if (config.factory) {
+    factory = config.factory;
+  } else {
+    const crypto = new NodeCryptoProvider();
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const identity: AgentIdentityConfig = {
+      did,
+      kid: `${did}#keys-1`,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+    };
+    factory = createDelegationIssuerFromIdentity(crypto, identity);
+  }
+
+  const consentHtmlPath = path.resolve(__dirname, '..', 'public', 'consent.html');
+  const consentTemplate = fs.readFileSync(consentHtmlPath, 'utf-8');
+
+  const httpServer = http.createServer(async (req, res) => {
+    // CORS headers for all responses
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${config.port}`);
+
+    // GET /consent — serve consent page with query params injected
+    if (url.pathname === '/consent' && req.method === 'GET') {
+      const tool = url.searchParams.get('tool') ?? 'unknown';
+      const scopes = url.searchParams.get('scopes') ?? 'unknown';
+      const agentDid = url.searchParams.get('agent_did') ?? 'unknown';
+      const sessionId = url.searchParams.get('session_id') ?? '';
+
+      const html = consentTemplate
+        .replaceAll('{{tool}}', escapeHtml(tool))
+        .replaceAll('{{scopes}}', escapeHtml(scopes))
+        .replaceAll('{{agentDid}}', escapeHtml(agentDid))
+        .replaceAll('{{sessionId}}', escapeHtml(sessionId));
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    // POST /approve — issue delegation VC
+    if (url.pathname === '/approve' && req.method === 'POST') {
+      try {
+        const body = await readBody(req);
+        const { tool, scopes, agentDid, resumeToken } = JSON.parse(body) as {
+          tool?: string;
+          scopes?: string;
+          agentDid?: string;
+          resumeToken?: string;
+        };
+
+        if (!tool || !scopes || !agentDid) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'missing_fields',
+            message: 'tool, scopes, and agentDid are required',
+          }));
+          return;
+        }
+
+        const scopeList = scopes.split(',').map((s) => s.trim()).filter(Boolean);
+        const subjectDid = agentDid;
+        const delegationId = `delegation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const nowSeconds = Math.floor(Date.now() / 1000);
+
+        const vc = await factory.issuer.createAndIssueDelegation({
+          id: delegationId,
+          issuerDid: factory.identity.did,
+          subjectDid,
+          constraints: {
+            scopes: scopeList,
+            notAfter: nowSeconds + 3600, // 1 hour expiry
+          },
+          metadata: { tool, approvedAt: new Date().toISOString() },
+        });
+
+        // Store VC in delegation store so MCP server can auto-apply on retry
+        if (resumeToken && config.delegationStore) {
+          config.delegationStore.set(resumeToken, vc);
+          process.stderr.write(`[consent] Stored delegation for resume_token: ${resumeToken}\n`);
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ delegationToken: vc }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          error: 'invalid_request',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        }));
+      }
+      return;
+    }
+
+    // 404 for everything else
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(config.port, () => {
+      const addr = httpServer.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : config.port;
+      const serverUrl = `http://localhost:${actualPort}`;
+
+      process.stderr.write(`[consent] Consent server: ${serverUrl}\n`);
+      process.stderr.write(`[consent] Issuer DID: ${factory.identity.did}\n`);
+
+      resolve({
+        server: httpServer,
+        port: actualPort,
+        url: serverUrl,
+        factory,
+        close: () => new Promise<void>((res) => httpServer.close(() => res())),
+      });
+    });
+  });
+}
+
+function readBody(req: http.IncomingMessage, maxBytes = 1_048_576): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    req.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > maxBytes) {
+        req.destroy();
+        reject(new Error('Request body too large'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// Run standalone when executed directly
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const port = parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
+  startConsentServer({ port }).catch((err) => {
+    process.stderr.write(`Fatal: ${err}\n`);
+    process.exit(1);
+  });
+}

--- a/examples/consent-basic/src/delegation-issuer.ts
+++ b/examples/consent-basic/src/delegation-issuer.ts
@@ -1,0 +1,59 @@
+/**
+ * Delegation Issuer Factory
+ *
+ * Creates a DelegationCredentialIssuer from an identity config.
+ * Used by both consent-server.ts and tests.
+ *
+ * Related Spec: MCP-I §3.1 (VC structure), §4.1 (DelegationRecord)
+ */
+
+import { DelegationCredentialIssuer } from '../../../src/delegation/vc-issuer.js';
+import type { VCSigningFunction } from '../../../src/delegation/vc-issuer.js';
+import type { Proof } from '../../../src/types/protocol.js';
+import type { CryptoProvider } from '../../../src/providers/base.js';
+import { base64urlEncodeFromBytes } from '../../../src/utils/base64.js';
+
+export interface AgentIdentityConfig {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+export interface DelegationIssuerFactory {
+  issuer: DelegationCredentialIssuer;
+  identity: AgentIdentityConfig;
+}
+
+export function createDelegationIssuerFromIdentity(
+  crypto: CryptoProvider,
+  identity: AgentIdentityConfig,
+): DelegationIssuerFactory {
+  const signingFunction: VCSigningFunction = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kid: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, identity.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => identity.did,
+      getKeyId: () => identity.kid,
+      getPrivateKey: () => identity.privateKey,
+    },
+    signingFunction,
+  );
+
+  return { issuer, identity };
+}

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -1,0 +1,402 @@
+#!/usr/bin/env npx tsx
+/**
+ * MCP Server with Consent-Based Delegation
+ *
+ * Demonstrates two tools:
+ *   - browse   (public)    — executes without delegation, proof attached
+ *   - checkout (protected) — requires a W3C Delegation Credential with scope cart:write
+ *
+ * Transports (selected via --transport flag):
+ *   - stdio (default) — for MCP Inspector CLI integration
+ *   - sse             — legacy SSE transport on /sse + /messages
+ *   - mcp             — Streamable HTTP transport on /mcp (recommended for HTTP)
+ *
+ * Related Spec: MCP-I §4 (Delegation), §5 (Proof), §6 (Authorization)
+ */
+
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { startConsentServer } from './consent-server.js';
+import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_PATH = path.resolve(__dirname, '..', '.mcpi', 'identity.json');
+
+export interface ServerConfig {
+  consentUrl: string;
+  delegationStore?: DelegationStore;
+}
+
+/**
+ * In-memory store mapping resume_token → approved delegation VC.
+ *
+ * When a user approves on the consent page, the VC is stored here keyed
+ * by resume_token. On the next tool call, the server checks this store
+ * and automatically injects the delegation.
+ */
+export class DelegationStore {
+  private store = new Map<string, { vc: unknown; expiresAt: number }>();
+
+  set(resumeToken: string, vc: unknown, ttlSeconds = 300): void {
+    this.store.set(resumeToken, { vc, expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
+
+  get(resumeToken: string): unknown | undefined {
+    const entry = this.store.get(resumeToken);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(resumeToken);
+      return undefined;
+    }
+    return entry.vc;
+  }
+
+  /** Find any pending delegation for a given tool (checks all entries). */
+  findByTool(toolName: string): { resumeToken: string; vc: unknown } | undefined {
+    for (const [token, entry] of this.store) {
+      if (Date.now() > entry.expiresAt) {
+        this.store.delete(token);
+        continue;
+      }
+      const vc = entry.vc as Record<string, unknown> | undefined;
+      const metadata = (vc?.credentialSubject as Record<string, unknown>)
+        ?.delegation as Record<string, unknown> | undefined;
+      if (metadata?.metadata && (metadata.metadata as Record<string, unknown>).tool === toolName) {
+        this.store.delete(token); // consume it
+        return { resumeToken: token, vc: entry.vc };
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Intercept needs_authorization responses and reformat as a clickable
+ * consent link with URL params (tool, scopes, agent_did, resume_token).
+ *
+ * Also checks the DelegationStore for previously approved delegations
+ * and auto-injects them on retry.
+ */
+function formatAsConsentLink(
+  toolName: string,
+  consentBaseUrl: string,
+  agentDid: string,
+  delegationStore: DelegationStore | undefined,
+  handler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
+): (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult> {
+  return async (args, sessionId) => {
+    // Check the delegation store for a previously approved VC (resume token flow).
+    if (!args['_mcpi_delegation'] && delegationStore) {
+      const pending = delegationStore.findByTool(toolName);
+      if (pending) {
+        process.stderr.write(`[server] Auto-applying delegation from consent approval (token: ${pending.resumeToken})\n`);
+        return handler({ ...args, _mcpi_delegation: pending.vc }, sessionId);
+      }
+    }
+
+    const result = await handler(args, sessionId);
+
+    // Intercept needs_authorization JSON and reformat as markdown link
+    const text = result.content?.[0]?.text;
+    if (text && !result.isError) {
+      try {
+        const parsed = JSON.parse(text) as {
+          error?: string;
+          scopes?: string[];
+          resumeToken?: string;
+        };
+        if (parsed.error === 'needs_authorization') {
+          const url = new URL(consentBaseUrl);
+          url.searchParams.set('tool', toolName);
+          url.searchParams.set('scopes', (parsed.scopes ?? []).join(','));
+          url.searchParams.set('agent_did', agentDid);
+          if (parsed.resumeToken) {
+            url.searchParams.set('resume_token', parsed.resumeToken);
+          }
+
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Authorization required.\n\n[Authorize ${toolName}](${url.toString()})\n\nRetry after authorizing.`,
+            }],
+            isError: false,
+          };
+        }
+      } catch {
+        // Not JSON — pass through
+      }
+    }
+
+    return result;
+  };
+}
+
+interface ToolResult {
+  content: Array<{ type: string; text: string; [key: string]: unknown }>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export function createConsentMcpServer(
+  mcpi: MCPIMiddleware,
+  config: ServerConfig,
+) {
+  const server = new Server(
+    { name: 'consent-basic-example', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  // browse: public tool — proof attached via wrapWithProof
+  const browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+    content: [{
+      type: 'text',
+      text: `Browsing category: ${args['category'] ?? 'all'}. Found 3 items.`,
+    }],
+  }));
+
+  // checkout: protected tool — requires delegation with scope cart:write
+  const rawCheckoutHandler = mcpi.wrapWithDelegation(
+    'checkout',
+    { scopeId: 'cart:write', consentUrl: config.consentUrl },
+    mcpi.wrapWithProof('checkout', async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Order confirmed for item: ${args['item'] ?? 'unknown'}. Thank you!`,
+      }],
+    })),
+  );
+  const checkoutHandler = formatAsConsentLink(
+    'checkout',
+    config.consentUrl,
+    mcpi.identity.did,
+    config.delegationStore,
+    rawCheckoutHandler as (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'browse',
+        description: 'Browse product categories (public — no delegation required)',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            category: { type: 'string', description: 'Product category to browse' },
+          },
+        },
+      },
+      {
+        name: 'checkout',
+        description: 'Complete a purchase (requires delegation with scope: cart:write)',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            item: { type: 'string', description: 'Item to purchase' },
+          },
+          required: ['item'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+
+    if (name === '_mcpi_handshake') {
+      return mcpi.handleHandshake(args as Record<string, unknown>);
+    }
+
+    if (name === 'browse') {
+      return browseHandler(args as Record<string, unknown>);
+    }
+
+    if (name === 'checkout') {
+      return checkoutHandler(args as Record<string, unknown>);
+    }
+
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  });
+
+  return server;
+}
+
+/**
+ * Load identity from .mcpi/identity.json if it exists,
+ * otherwise generate an ephemeral one.
+ */
+export async function createMcpiMiddleware() {
+  const crypto = new NodeCryptoProvider();
+  let did: string;
+  let kid: string;
+  let privateKey: string;
+  let publicKey: string;
+
+  if (fs.existsSync(IDENTITY_PATH)) {
+    const stored = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as {
+      did: string; kid: string; privateKey: string; publicKey: string;
+    };
+    did = stored.did;
+    kid = stored.kid;
+    privateKey = stored.privateKey;
+    publicKey = stored.publicKey;
+    process.stderr.write(`[server] Loaded identity from ${IDENTITY_PATH}\n`);
+  } else {
+    const keyPair = await crypto.generateKeyPair();
+    did = generateDidKeyFromBase64(keyPair.publicKey);
+    kid = `${did}#keys-1`;
+    privateKey = keyPair.privateKey;
+    publicKey = keyPair.publicKey;
+    process.stderr.write(`[server] Generated ephemeral identity (run 'npm run generate-identity' to persist)\n`);
+  }
+
+  return createMCPIMiddleware(
+    {
+      identity: { did, kid, privateKey, publicKey },
+      session: { sessionTtlMinutes: 60 },
+      autoSession: true,
+    },
+    crypto,
+  );
+}
+
+function setCorsHeaders(res: http.ServerResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, MCP-Session-Id');
+  res.setHeader('Access-Control-Expose-Headers', 'MCP-Session-Id');
+}
+
+/**
+ * Start the MCP server with SSE + Streamable HTTP transports.
+ */
+async function startHttpServer(mcpi: MCPIMiddleware, consentUrl: string, port: number, delegationStore?: DelegationStore) {
+  let sseTransport: SSEServerTransport | null = null;
+
+  const httpServer = http.createServer(async (req, res) => {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+
+    // ── SSE transport: GET /sse + POST /messages ──────────────────
+    if (url.pathname === '/sse' && req.method === 'GET') {
+      const server = createConsentMcpServer(mcpi, { consentUrl, delegationStore });
+      sseTransport = new SSEServerTransport('/messages', res);
+      await server.connect(sseTransport);
+      process.stderr.write('[server] SSE client connected\n');
+      return;
+    }
+
+    if (url.pathname === '/messages' && req.method === 'POST') {
+      if (!sseTransport) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'No SSE connection. Connect to /sse first.' }));
+        return;
+      }
+      await sseTransport.handlePostMessage(req, res);
+      return;
+    }
+
+    // ── Streamable HTTP transport: POST /mcp ─────────────────────
+    if (url.pathname === '/mcp' && req.method === 'POST') {
+      const server = createConsentMcpServer(mcpi, { consentUrl, delegationStore });
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      res.on('close', () => transport.close());
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    // ── Info endpoint ────────────────────────────────────────────
+    if (url.pathname === '/' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        name: 'consent-basic-example',
+        did: mcpi.identity.did,
+        transports: {
+          sse: `http://localhost:${port}/sse`,
+          mcp: `http://localhost:${port}/mcp`,
+        },
+      }));
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  httpServer.listen(port, () => {
+    process.stderr.write(`[server] HTTP server: http://localhost:${port}\n`);
+    process.stderr.write(`[server]   SSE:  http://localhost:${port}/sse\n`);
+    process.stderr.write(`[server]   MCP:  http://localhost:${port}/mcp\n`);
+    process.stderr.write(`[server] Agent DID: ${mcpi.identity.did}\n`);
+  });
+}
+
+// Run standalone
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const transport = process.argv.includes('--stdio') ? 'stdio'
+    : process.argv.includes('--sse') ? 'sse'
+    : process.argv.includes('--mcp') ? 'mcp'
+    : 'sse'; // default to HTTP (SSE + /mcp) for Inspector compatibility
+
+  const port = parseInt(process.env['PORT'] ?? '3002', 10);
+  // In stdio mode, use ephemeral port (0) to avoid conflicts
+  const consentPort = transport === 'stdio'
+    ? 0
+    : parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
+
+  createMcpiMiddleware().then(async (mcpi) => {
+    // Start consent server with the MCP server's identity so VCs are
+    // issued by the same DID that verifies them (single trust domain).
+    const cryptoProvider = new NodeCryptoProvider();
+    const factory = createDelegationIssuerFromIdentity(cryptoProvider, {
+      did: mcpi.identity.did,
+      kid: mcpi.identity.kid,
+      privateKey: mcpi.identity.privateKey,
+      publicKey: mcpi.identity.publicKey,
+    });
+    // Shared delegation store — consent server writes, MCP server reads
+    const delegationStore = new DelegationStore();
+    const consentServer = await startConsentServer({ port: consentPort, factory, delegationStore });
+    const consentUrl = `${consentServer.url}/consent`;
+
+    if (transport === 'stdio') {
+      process.stderr.write(`[server] Agent DID: ${mcpi.identity.did}\n`);
+      const server = createConsentMcpServer(mcpi, { consentUrl, delegationStore });
+      await server.connect(new StdioServerTransport());
+      process.stderr.write('[server] MCP server running on stdio\n');
+    } else {
+      await startHttpServer(mcpi, consentUrl, port, delegationStore);
+    }
+  }).catch((err) => {
+    process.stderr.write(`Fatal: ${err}\n`);
+    process.exit(1);
+  });
+}

--- a/examples/consent-basic/tsconfig.json
+++ b/examples/consent-basic/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/consent-basic/` — complete human-in-the-loop consent flow demonstrating `needs_authorization` → consent page → W3C delegation VC → tool execution
- MCP server with two tools: `browse` (public, proof-only) and `checkout` (protected, requires `cart:write` delegation)
- Consent HTTP server with consent UI and W3C VC issuance endpoint
- Resume-token-based `DelegationStore` auto-applies approved delegations on retry
- `generate-identity` script for persistent DIDs across restarts (`.mcpi/identity.json`)
- Supports stdio, SSE, and Streamable HTTP transports
- 35 tests across 4 suites: delegation issuer, consent server, server integration, and E2E
- Streamlines root README — replaces inline code examples with links to runnable examples

## Files

| File | Purpose |
|------|---------|
| `src/server.ts` | MCP server with browse/checkout tools, DelegationStore, consent link formatting |
| `src/consent-server.ts` | HTTP consent page + VC issuance endpoint with resume token storage |
| `src/delegation-issuer.ts` | Shared factory for creating `DelegationCredentialIssuer` from identity config |
| `scripts/generate-identity.ts` | Persist a `did:key` identity to `.mcpi/identity.json` |
| `public/consent.html` | Consent UI served during the authorization flow |
| `__tests__/*.test.ts` | 35 tests covering delegation, proof, consent server, and full E2E cycle |
| `README.md` (root) | Streamlined for onboarding |

## Spec Coverage

| Section | What's demonstrated |
|---------|-------------------|
| §4 Delegation | W3C VC issuance, scope constraints, expiry, resume tokens |
| §5 Proof | Detached JWS proof on every tool response, deterministic hashing |
| §6 Authorization | `needs_authorization` → consent → delegation verification |

## Test plan

- [x] `npx vitest run examples/consent-basic` — all 35 tests pass
- [x] Start server (`npx tsx examples/consent-basic/src/server.ts`), connect Inspector to `/sse`, call `browse` (succeeds with proof), call `checkout` (returns consent link), approve in browser, retry `checkout` (succeeds with auto-applied delegation)
- [x] Verify `npm run generate-identity` creates `.mcpi/identity.json` and server loads it on restart