### PR TITLE
feat(examples): consent-full — @kya-os/consent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ All modules available as subpath exports: `@mcp-i/core/delegation`, `@mcp-i/core
 | Example | What it shows |
 |---------|--------------|
 | [**consent-basic**](./examples/consent-basic/) | Human-in-the-loop consent flow: `needs_authorization` → consent page → delegation VC → tool execution. SSE + Streamable HTTP transports. |
+| [**consent-full**](./examples/consent-full/) | Same consent flow as consent-basic, powered by [`@kya-os/consent`](https://www.npmjs.com/package/@kya-os/consent) — multi-mode auth, configurable branding, and production-grade consent UI. |
 | [**node-server**](./examples/node-server/) | Low-level Server API with handshake, proof, and restricted tools. |
 | [**brave-search-mcp-server**](./examples/brave-search-mcp-server/) | Real-world MCP server wrapping Brave Search with MCP-I identity and proofs. |
 | [**outbound-delegation**](./examples/outbound-delegation/) | Forwarding delegation context to downstream services (§7 gateway pattern). |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ await withMCPI(server, { crypto: new NodeCryptoProvider() });
 // Register tools normally — proofs are attached automatically
 ```
 
+Default behavior is compatibility-first:
+- `withMCPI` auto-registers `_mcpi`, so it appears in MCP Inspector and tool lists.
+- Handshake is not tied to MCP `initialize`; a client/runtime must call it (or use `autoSession`).
+
+If your runtime has a native connection/auth handshake hook, disable tool exposure and call middleware directly:
+
+```typescript
+const mcpi = await withMCPI(server, {
+  crypto: new NodeCryptoProvider(),
+  handshakeExposure: 'none',
+  autoSession: false,
+});
+
+// In your runtime's connection handshake hook:
+await mcpi.handleMCPI({
+  action: 'handshake',
+  nonce: 'client-generated-nonce',
+  audience: mcpi.identity.did,
+  timestamp: Math.floor(Date.now() / 1000),
+  agentDid: 'did:key:...optional...',
+});
+```
+
 Every tool response now includes a cryptographic proof. For protected tools that require human consent, add `wrapWithDelegation`:
 
 ```typescript

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -195,6 +195,7 @@ export function createConsentMcpServer(
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
+      mcpi.mcpiTool,
       {
         name: 'browse',
         description: 'Browse product categories (public — no delegation required)',
@@ -222,8 +223,8 @@ export function createConsentMcpServer(
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
 
-    if (name === '_mcpi_handshake') {
-      return mcpi.handleHandshake(args as Record<string, unknown>);
+    if (name === '_mcpi') {
+      return mcpi.handleMCPI(args as Record<string, unknown>);
     }
 
     if (name === 'browse') {

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -6,10 +6,16 @@
  *   - browse   (public)    — executes without delegation, proof attached
  *   - checkout (protected) — requires a W3C Delegation Credential with scope cart:write
  *
- * Transports (selected via --transport flag):
- *   - stdio (default) — for MCP Inspector CLI integration
- *   - sse             — legacy SSE transport on /sse + /messages
- *   - mcp             — Streamable HTTP transport on /mcp (recommended for HTTP)
+ * Architecture note:
+ *   This example uses the low-level SDK `Server` API with `createMCPIMiddleware`
+ *   instead of the 2-line `withMCPI(server, { crypto })` pattern (see examples/
+ *   context7-with-mcpi for that). The reason: delegation-protected tools receive
+ *   `_mcpi_delegation` as a tool argument. McpServer.registerTool validates args
+ *   against zod schemas and strips unknown keys — so the delegation VC would be
+ *   silently dropped before the handler sees it. The low-level Server API passes
+ *   args through without schema validation, which delegation requires.
+ *
+ * Transports: stdio (default), sse, mcp (Streamable HTTP)
  *
  * Related Spec: MCP-I §4 (Delegation), §5 (Proof), §6 (Authorization)
  */

--- a/examples/consent-full/.gitignore
+++ b/examples/consent-full/.gitignore
@@ -1,0 +1,4 @@
+# Private key material — never commit
+.mcpi/
+node_modules/
+dist/

--- a/examples/consent-full/README.md
+++ b/examples/consent-full/README.md
@@ -22,6 +22,23 @@ npx @modelcontextprotocol/inspector
 3. Approve — delegation issued, stored via resume_token
 4. Retry `checkout` — delegation auto-applied, tool executes
 
+## Architecture
+
+This example runs **two servers**:
+
+| Server | Port | Purpose |
+|--------|------|---------|
+| MCP server (`server.ts`) | 3002 | Hosts tools, verifies delegations, attaches proofs |
+| Consent server (`consent-server.ts`) | 3001 | Renders consent UI via `@kya-os/consent`, issues VCs |
+
+**`consent-server.ts` is the showcase** — it demonstrates `@kya-os/consent`'s template system, auth modes, and branding. `server.ts` is MCP infrastructure, identical in structure to consent-basic.
+
+### Why the low-level Server API?
+
+This example uses `createMCPIMiddleware` with the SDK's low-level `Server` class instead of the 2-line `withMCPI(server, { crypto })` pattern ([see context7-with-mcpi](../context7-with-mcpi/) for that). The reason: delegation-protected tools receive `_mcpi_delegation` as a tool argument. `McpServer.registerTool` validates args against zod schemas and strips unknown keys — so the delegation VC is silently dropped before the handler sees it. The low-level `Server` API passes args through without schema validation, which delegation requires.
+
+If your server doesn't need delegation (just proofs + handshake), use `withMCPI` — it's 2 lines.
+
 ## What's Different from consent-basic?
 
 | | consent-basic | consent-full |
@@ -59,8 +76,8 @@ The consent page shows a username/password form. Demo credentials: `demo` / `dem
 
 | File | Purpose |
 |------|---------|
-| `src/server.ts` | MCP server with browse/checkout tools, SSE + HTTP transports |
-| `src/consent-server.ts` | Consent page via `@kya-os/consent`, VC issuance on approval |
+| `src/consent-server.ts` | **The showcase** — consent page via `@kya-os/consent`, VC issuance |
+| `src/server.ts` | MCP server infrastructure — tools, delegation, transports |
 | `src/delegation-issuer.ts` | DelegationCredentialIssuer factory |
 | `scripts/generate-identity.ts` | Persistent Ed25519 DID identity |
 

--- a/examples/consent-full/README.md
+++ b/examples/consent-full/README.md
@@ -1,0 +1,82 @@
+# consent-full
+
+Same MCP-I consent flow as [consent-basic](../consent-basic/) — but the consent page is rendered by [`@kya-os/consent`](https://www.npmjs.com/package/@kya-os/consent). One `generateConsentShell()` call replaces 200+ lines of hand-rolled HTML with a production-grade consent UI: multi-mode auth, configurable branding, loading skeleton, and no-JS fallback.
+
+## Quick Start
+
+```bash
+# From the repo root
+pnpm install
+npx tsx examples/consent-full/src/server.ts
+```
+
+Then connect with [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector
+# → Connect to http://localhost:3002/sse
+```
+
+1. Call `checkout` — get a consent link
+2. Open the link — see the `<mcp-consent>` UI
+3. Approve — delegation issued, stored via resume_token
+4. Retry `checkout` — delegation auto-applied, tool executes
+
+## What's Different from consent-basic?
+
+| | consent-basic | consent-full |
+|---|---|---|
+| **Consent UI** | Hand-rolled HTML + vanilla JS | `@kya-os/consent` web component |
+| **Auth modes** | Consent-only | Consent-only (default) + credentials via `AUTH_MODE` |
+| **Branding** | Hardcoded dark theme | Configurable via `BRAND_COLOR` / `COMPANY_NAME` |
+| **Loading UX** | None | Skeleton loader + no-JS fallback |
+| **Approval format** | JSON POST to `/approve` | FormData POST to `/consent/approve` |
+| **HTML template** | `public/consent.html` (215 lines) | `generateConsentShell()` (zero template files) |
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `AUTH_MODE` | `consent-only` | Auth mode: `consent-only` or `credentials` |
+| `BRAND_COLOR` | `#2563EB` | Primary brand color (hex) |
+| `COMPANY_NAME` | `MCP-I Demo` | Company name shown on consent page |
+| `PORT` | `3002` | MCP server HTTP port |
+| `CONSENT_PORT` | `3001` | Consent server HTTP port |
+
+### Credentials mode
+
+```bash
+AUTH_MODE=credentials npx tsx examples/consent-full/src/server.ts
+```
+
+The consent page shows a username/password form. Demo credentials: `demo` / `demo123`.
+
+### OAuth (production)
+
+`@kya-os/consent` supports 8 auth modes including OAuth, magic-link, OTP, passkey, and IDV. This example demonstrates consent-only and credentials. For OAuth integration in production, see the [`@kya-os/consent` documentation](https://www.npmjs.com/package/@kya-os/consent).
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `src/server.ts` | MCP server with browse/checkout tools, SSE + HTTP transports |
+| `src/consent-server.ts` | Consent page via `@kya-os/consent`, VC issuance on approval |
+| `src/delegation-issuer.ts` | DelegationCredentialIssuer factory |
+| `scripts/generate-identity.ts` | Persistent Ed25519 DID identity |
+
+## Persistent Identity
+
+```bash
+npx tsx examples/consent-full/scripts/generate-identity.ts
+```
+
+Generates `.mcpi/identity.json` — the DID survives server restarts. Without it, the server creates an ephemeral identity on each start.
+
+## Tests
+
+```bash
+cd examples/consent-full
+npx vitest run
+```
+
+Coverage: delegation issuance, consent page rendering, VC structure, scope enforcement, proof generation, and full E2E consent flow.

--- a/examples/consent-full/__tests__/consent-server.test.ts
+++ b/examples/consent-full/__tests__/consent-server.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Integration Tests: consent-server.ts (powered by @kya-os/consent)
+ *
+ * Validates the HTTP consent server serves rendered consent pages from
+ * @kya-os/consent and issues spec-compliant W3C Delegation Credentials
+ * on approval via the /consent/approve endpoint.
+ *
+ * Spec coverage: §3.1 (VC structure), §4.1 (DelegationRecord),
+ *                §4.2 (DelegationConstraints)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
+import type { DelegationCredential } from '../../../src/types/protocol.js';
+
+let server: ConsentServer;
+
+function request(path: string, options?: RequestInit): Promise<Response> {
+  return fetch(`${server.url}${path}`, options);
+}
+
+describe('Consent HTTP Server (@kya-os/consent)', () => {
+  beforeAll(async () => {
+    server = await startConsentServer({ port: 0 });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  // GET /consent — page serving via @kya-os/consent
+  it('should serve a consent page with <mcp-consent> component', async () => {
+    const res = await request(
+      '/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+
+    const body = await res.text();
+    // @kya-os/consent generates HTML with <mcp-consent> web component
+    expect(body).toContain('<mcp-consent');
+    expect(body).toContain('checkout');
+    expect(body).toContain('cart:write');
+    expect(body).toContain('did:key:z6MkTest');
+  });
+
+  it('should include loading skeleton for perceived performance', async () => {
+    const res = await request('/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest');
+    const body = await res.text();
+    expect(body).toContain('loading-skeleton');
+  });
+
+  it('should include no-JS fallback form', async () => {
+    const res = await request('/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest');
+    const body = await res.text();
+    expect(body).toContain('<noscript>');
+    expect(body).toContain('consent/approve');
+  });
+
+  // GET /consent.js — bundle serving
+  it('should serve the consent component bundle', async () => {
+    const res = await request('/consent.js');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/javascript');
+    expect(res.headers.get('cache-control')).toContain('public');
+
+    const body = await res.text();
+    expect(body.length).toBeGreaterThan(1000); // Bundle should be substantial
+  });
+
+  // POST /consent/approve — §3.1 compliant VC (JSON body)
+  it('should issue a valid delegation VC on approval', async () => {
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: 'did:key:z6MkTestAgent',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as {
+      success: boolean;
+      delegation_id: string;
+      delegationToken: DelegationCredential;
+    };
+    expect(data.success).toBe(true);
+    expect(data.delegation_id).toBeDefined();
+    expect(data.delegationToken).toBeDefined();
+
+    const vc = data.delegationToken;
+    expect(vc.type).toContain('DelegationCredential');
+    expect(vc.credentialSubject.delegation.constraints.scopes).toContain('cart:write');
+    expect(vc.proof).toBeDefined();
+    expect(vc.proof!.type).toBe('Ed25519Signature2020');
+  });
+
+  // §4.1 — subjectDid set to requesting agent
+  it('should set subjectDid to the requesting agent DID', async () => {
+    const agentDid = 'did:key:z6MkSpecificAgent';
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: agentDid,
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    expect(vc.credentialSubject.delegation.subjectDid).toBe(agentDid);
+  });
+
+  // §4.2 — 1 hour expiry
+  it('should set notAfter to approximately 1 hour from now', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: 'did:key:z6MkExpiryTest',
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    const notAfter = vc.credentialSubject.delegation.constraints.notAfter!;
+
+    expect(notAfter).toBeGreaterThanOrEqual(nowSeconds + 3595);
+    expect(notAfter).toBeLessThanOrEqual(nowSeconds + 3605);
+  });
+
+  // Comma-separated scopes (backward compat)
+  it('should handle comma-separated scopes', async () => {
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: 'cart:write,cart:read',
+        agent_did: 'did:key:z6MkMultiScope',
+      }),
+    });
+
+    const data = (await res.json()) as { delegationToken: DelegationCredential };
+    const vc = data.delegationToken;
+    expect(vc.credentialSubject.delegation.constraints.scopes).toEqual(['cart:write', 'cart:read']);
+  });
+
+  // CORS
+  it('should include Access-Control-Allow-Origin header', async () => {
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: 'did:key:z6MkCorsTest',
+      }),
+    });
+
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  // 404
+  it('should return 404 for unknown routes', async () => {
+    const res = await request('/unknown');
+    expect(res.status).toBe(404);
+  });
+
+  // Error: missing required fields
+  it('should return 400 when required fields are missing', async () => {
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: 'checkout' }),
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('missing_fields');
+  });
+
+  // Error: malformed JSON — server-side parse failure
+  it('should return 500 for malformed JSON body', async () => {
+    const res = await request('/consent/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+
+    expect(res.status).toBe(500);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('internal_error');
+  });
+});
+
+describe('Consent HTTP Server — credentials mode', () => {
+  let credServer: ConsentServer;
+
+  beforeAll(async () => {
+    credServer = await startConsentServer({ port: 0, authMode: 'credentials' });
+  });
+
+  afterAll(async () => {
+    await credServer.close();
+  });
+
+  it('should serve consent page with auth-mode="credentials"', async () => {
+    const res = await fetch(
+      `${credServer.url}/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest`,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('auth-mode="credentials"');
+  });
+
+  it('should reject invalid credentials', async () => {
+    const res = await fetch(`${credServer.url}/consent/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: 'did:key:z6MkTest',
+        auth_mode: 'credentials',
+        username: 'wrong',
+        password: 'wrong',
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('invalid_credentials');
+  });
+
+  it('should issue delegation with valid credentials', async () => {
+    const res = await fetch(`${credServer.url}/consent/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: '["cart:write"]',
+        agent_did: 'did:key:z6MkTest',
+        auth_mode: 'credentials',
+        username: 'demo',
+        password: 'demo123',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      success: boolean;
+      delegationToken: DelegationCredential;
+    };
+    expect(data.success).toBe(true);
+    expect(data.delegationToken.type).toContain('DelegationCredential');
+  });
+});

--- a/examples/consent-full/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-full/__tests__/delegation-issuer.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit Tests: delegation-issuer.ts
+ *
+ * Validates the factory for creating DelegationCredentialIssuers
+ * from identity config. Covers VC structure, proof, and constraints.
+ *
+ * Spec coverage: §3.1 (VC structure), §4.1 (DelegationRecord), §4.2 (constraints)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createDelegationIssuerFromIdentity, type DelegationIssuerFactory } from '../src/delegation-issuer.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import type { DelegationCredential } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+
+let factory: DelegationIssuerFactory;
+let vc: DelegationCredential;
+
+describe('createDelegationIssuerFromIdentity', () => {
+  beforeAll(async () => {
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+
+    factory = createDelegationIssuerFromIdentity(crypto, {
+      did,
+      kid,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+    });
+
+    vc = await factory.issuer.createAndIssueDelegation({
+      id: 'test-delegation-001',
+      issuerDid: did,
+      subjectDid: 'did:key:z6MkTestSubject',
+      constraints: {
+        scopes: ['cart:write', 'cart:read'],
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+  });
+
+  // §3.1 — VC structure
+  it('should produce a VC with correct type array', () => {
+    expect(vc.type).toContain('VerifiableCredential');
+    expect(vc.type).toContain('DelegationCredential');
+  });
+
+  it('should include W3C context', () => {
+    expect(vc['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+  });
+
+  it('should have an issuer matching the identity DID', () => {
+    expect(vc.issuer).toBe(factory.identity.did);
+  });
+
+  it('should set credentialSubject.id to the subject DID', () => {
+    expect(vc.credentialSubject.id).toBe('did:key:z6MkTestSubject');
+  });
+
+  // §3.1 — Proof
+  it('should include an Ed25519Signature2020 proof', () => {
+    expect(vc.proof).toBeDefined();
+    expect(vc.proof!.type).toBe('Ed25519Signature2020');
+  });
+
+  it('should have proofValue in the proof', () => {
+    expect(vc.proof!['proofValue']).toBeDefined();
+    expect(typeof vc.proof!['proofValue']).toBe('string');
+  });
+
+  it('should set verificationMethod to the kid', () => {
+    expect(vc.proof!['verificationMethod']).toBe(factory.identity.kid);
+  });
+
+  it('should set proofPurpose to assertionMethod', () => {
+    expect(vc.proof!.proofPurpose).toBe('assertionMethod');
+  });
+
+  // §4.1 — DelegationRecord
+  it('should embed the delegation record in credentialSubject', () => {
+    const delegation = vc.credentialSubject.delegation;
+    expect(delegation).toBeDefined();
+    expect(delegation.id).toBe('test-delegation-001');
+    expect(delegation.issuerDid).toBe(factory.identity.did);
+    expect(delegation.subjectDid).toBe('did:key:z6MkTestSubject');
+  });
+
+  // §4.2 — Constraints
+  it('should include scopes in constraints', () => {
+    const scopes = vc.credentialSubject.delegation.constraints.scopes;
+    expect(scopes).toEqual(['cart:write', 'cart:read']);
+  });
+
+  it('should include notAfter in constraints', () => {
+    const notAfter = vc.credentialSubject.delegation.constraints.notAfter;
+    expect(notAfter).toBeDefined();
+    expect(notAfter).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  // Factory identity
+  it('should return the identity in the factory', () => {
+    expect(factory.identity.did).toBeDefined();
+    expect(factory.identity.did.startsWith('did:key:')).toBe(true);
+    expect(factory.identity.kid).toContain('#keys-1');
+  });
+});

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -1,0 +1,173 @@
+/**
+ * E2E Tests: Full consent -> delegation -> execution cycle
+ *
+ * Validates the complete MCP-I consent flow using @kya-os/consent:
+ * tool call -> needs_authorization -> consent page -> approve -> delegation -> retry -> success.
+ *
+ * Spec coverage: §4.1 (delegation chain), §5.1 (proof), §6.1 (needs_authorization),
+ *                §6.2 (delegation verification)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
+import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
+import type { ToolResult } from '../src/server.js';
+import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+
+let consentServer: ConsentServer;
+let mcpi: MCPIMiddleware;
+let browseHandler: (args: Record<string, unknown>) => Promise<ToolResult>;
+let checkoutHandler: (args: Record<string, unknown>) => Promise<ToolResult>;
+
+describe('E2E: consent -> delegation -> execution', () => {
+  beforeAll(async () => {
+    // 1. Create MCP middleware with fresh identity
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+
+    mcpi = createMCPIMiddleware(
+      {
+        identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    // 2. Start consent server with the MCP server's identity (shared trust domain)
+    const factory = createDelegationIssuerFromIdentity(crypto, {
+      did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey,
+    });
+    consentServer = await startConsentServer({ port: 0, factory });
+
+    browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+      content: [{ type: 'text', text: `Browsing: ${args['category'] ?? 'all'}` }],
+    })) as typeof browseHandler;
+
+    checkoutHandler = mcpi.wrapWithDelegation(
+      'checkout',
+      {
+        scopeId: 'cart:write',
+        consentUrl: `${consentServer.url}/consent?tool=checkout&scopes=cart:write&agent_did=${encodeURIComponent(did)}`,
+      },
+      mcpi.wrapWithProof('checkout', async (args) => ({
+        content: [{ type: 'text', text: `Order confirmed: ${args['item']}` }],
+      })),
+    ) as typeof checkoutHandler;
+  });
+
+  afterAll(async () => {
+    await consentServer.close();
+  });
+
+  // Full cycle: §6.1 -> §4.1 -> §6.2 -> §5.1
+  it('should complete the full consent flow', async () => {
+    // 3. Call checkout -> get needs_authorization
+    const firstAttempt = await checkoutHandler({ item: 'laptop' });
+    const authError = JSON.parse(firstAttempt.content[0]!.text) as NeedsAuthorizationError;
+    expect(authError.error).toBe('needs_authorization');
+    expect(authError.scopes).toContain('cart:write');
+
+    // 4. Parse authorizationUrl
+    const authUrl = new URL(authError.authorizationUrl);
+    const tool = authUrl.searchParams.get('tool');
+    const scopes = authUrl.searchParams.get('scopes');
+    const agentDid = authUrl.searchParams.get('agent_did');
+
+    // 5. POST /consent/approve to consent server (JSON — simulating approval)
+    const approveRes = await fetch(`${consentServer.url}/consent/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool,
+        scopes: scopes ? `["${scopes}"]` : '[]',
+        agent_did: agentDid,
+      }),
+    });
+    expect(approveRes.status).toBe(200);
+
+    // 6. Parse the delegation token
+    const approveData = (await approveRes.json()) as {
+      success: boolean;
+      delegationToken: DelegationCredential;
+    };
+    expect(approveData.success).toBe(true);
+    expect(approveData.delegationToken).toBeDefined();
+    const vc = approveData.delegationToken;
+    expect(vc.type).toContain('DelegationCredential');
+
+    // 7. Retry checkout with the VC
+    const retryResult = await checkoutHandler({
+      item: 'laptop',
+      _mcpi_delegation: vc,
+    });
+
+    // 8. Tool executes successfully
+    expect(retryResult.isError).toBeUndefined();
+    expect(retryResult.content[0]!.text).toContain('Order confirmed');
+    expect(retryResult.content[0]!.text).toContain('laptop');
+
+    // 9. Response includes proof
+    expect(retryResult._meta).toBeDefined();
+    expect(retryResult._meta!.proof).toBeDefined();
+    expect(retryResult._meta!.proof!.jws).toBeDefined();
+  });
+
+  // §4.3 — scope mismatch across tools
+  it('should not allow reuse of delegation for different tools', async () => {
+    const factory = createDelegationIssuerFromIdentity(crypto, {
+      did: mcpi.identity.did,
+      kid: mcpi.identity.kid,
+      privateKey: mcpi.identity.privateKey,
+      publicKey: mcpi.identity.publicKey,
+    });
+
+    const vc = await factory.issuer.createAndIssueDelegation({
+      id: `wrong-scope-${Date.now()}`,
+      issuerDid: mcpi.identity.did,
+      subjectDid: mcpi.identity.did,
+      constraints: {
+        scopes: ['admin:write'],
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+
+    const result = await checkoutHandler({ item: 'laptop', _mcpi_delegation: vc });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_scope_missing');
+  });
+
+  // Deny flow
+  it('should handle denial gracefully — no delegation issued', async () => {
+    const result = await checkoutHandler({ item: 'laptop' });
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+    expect(parsed.error).toBe('needs_authorization');
+  });
+
+  // Browse still works without any delegation
+  it('should execute browse with proof but no delegation', async () => {
+    const result = await browseHandler({ category: 'electronics' });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('electronics');
+    expect(result._meta?.proof).toBeDefined();
+  });
+
+  // Consent page rendered by @kya-os/consent
+  it('should serve a consent page with <mcp-consent> web component', async () => {
+    const res = await fetch(
+      `${consentServer.url}/consent?tool=checkout&scopes=cart:write&agent_did=did:key:z6MkTest`,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('<mcp-consent');
+    expect(body).toContain('checkout');
+  });
+});

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/index.js';
 import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
 import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/index.js';
 import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
 import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Integration Tests: server.ts — MCP Server with consent-based delegation
+ *
+ * Validates tool protection (needs_authorization flow), delegation
+ * verification, proof generation, and argument stripping.
+ *
+ * Spec coverage: §4.3 (scope attenuation), §5.1 (DetachedProof),
+ *                §5.2 (canonical hashing), §6.1 (needs_authorization),
+ *                §6.2 (delegation verification)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
+import type { ToolResult } from '../src/server.js';
+import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
+
+const crypto = new NodeCryptoProvider();
+const CONSENT_URL = 'http://localhost:9999/consent';
+
+let mcpi: MCPIMiddleware;
+let browseHandler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>;
+let checkoutHandler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>;
+let serverDid: string;
+
+async function issueTestDelegation(
+  subjectDid: string,
+  scopes: string[],
+  notAfterOffset = 3600,
+): Promise<DelegationCredential> {
+  const factory = createDelegationIssuerFromIdentity(crypto, {
+    did: mcpi.identity.did,
+    kid: mcpi.identity.kid,
+    privateKey: mcpi.identity.privateKey,
+    publicKey: mcpi.identity.publicKey,
+  });
+
+  return factory.issuer.createAndIssueDelegation({
+    id: `delegation-test-${Date.now()}`,
+    issuerDid: mcpi.identity.did,
+    subjectDid,
+    constraints: {
+      scopes,
+      notAfter: Math.floor(Date.now() / 1000) + notAfterOffset,
+    },
+  });
+}
+
+describe('MCP Server with consent-full', () => {
+  beforeAll(async () => {
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#keys-1`;
+    serverDid = did;
+
+    mcpi = createMCPIMiddleware(
+      {
+        identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Browsing category: ${args['category'] ?? 'all'}. Found 3 items.`,
+      }],
+    })) as typeof browseHandler;
+
+    checkoutHandler = mcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      mcpi.wrapWithProof('checkout', async (args) => ({
+        content: [{
+          type: 'text',
+          text: `Order confirmed for item: ${args['item'] ?? 'unknown'}. Thank you!`,
+        }],
+      })),
+    ) as typeof checkoutHandler;
+  });
+
+  // Public tool — no delegation needed
+  it('should execute browse tool without delegation', async () => {
+    const result = await browseHandler({ category: 'electronics' });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('electronics');
+  });
+
+  // §6.1 — needs_authorization
+  it('should return needs_authorization for checkout without delegation', async () => {
+    const result = await checkoutHandler({ item: 'widget' });
+
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+    expect(parsed.error).toBe('needs_authorization');
+    expect(parsed.authorizationUrl).toBe(CONSENT_URL);
+    expect(parsed.scopes).toContain('cart:write');
+    expect(parsed.resumeToken).toBeDefined();
+    expect(typeof parsed.resumeToken).toBe('string');
+    expect(parsed.resumeToken.length).toBeGreaterThan(0);
+    expect(parsed.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  // §6.1 — resume token format (UUID-like: 8-4-4-4-12 hex chars)
+  it('should include resumeToken in UUID-like format', async () => {
+    const result = await checkoutHandler({ item: 'widget' });
+    const parsed = JSON.parse(result.content[0]!.text) as NeedsAuthorizationError;
+
+    expect(parsed.resumeToken).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  // §6.2 — Delegation verification (valid VC)
+  it('should execute checkout with a valid delegation VC', async () => {
+    const vc = await issueTestDelegation(serverDid, ['cart:write']);
+    const result = await checkoutHandler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('Order confirmed');
+    expect(result.content[0]!.text).toContain('widget');
+  });
+
+  // §4.3 — Wrong scope
+  it('should reject a delegation VC with wrong scope', async () => {
+    const vc = await issueTestDelegation(serverDid, ['cart:read']);
+    const result = await checkoutHandler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_scope_missing');
+  });
+
+  // §4.2 — Expired delegation
+  it('should reject an expired delegation VC', async () => {
+    const expiredMcpi = createMCPIMiddleware(
+      {
+        identity: mcpi.identity,
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    const expiredCheckout = expiredMcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      async (args) => ({
+        content: [{ type: 'text', text: `Order: ${args['item']}` }],
+      }),
+    );
+
+    const vc = await issueTestDelegation(serverDid, ['cart:write'], -3600);
+    const result = await expiredCheckout({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe('delegation_invalid');
+  });
+
+  // §5.1 — Detached proof on browse
+  it('should attach a detached proof to browse tool response', async () => {
+    const result = await browseHandler({ category: 'books' });
+
+    expect(result._meta).toBeDefined();
+    expect(result._meta!.proof).toBeDefined();
+
+    const proof = result._meta!.proof!;
+    // JWS: 3 dot-separated base64url parts
+    expect(proof.jws).toBeDefined();
+    expect(proof.jws.split('.').length).toBe(3);
+    // Meta fields
+    expect(proof.meta.did).toBeDefined();
+    expect((proof.meta.did as string).startsWith('did:key:')).toBe(true);
+    expect((proof.meta.requestHash as string).startsWith('sha256:')).toBe(true);
+    expect((proof.meta.responseHash as string).startsWith('sha256:')).toBe(true);
+  });
+
+  // §5.2 — Deterministic hashing
+  it('should produce deterministic hashes for identical requests', async () => {
+    const result1 = await browseHandler({ category: 'books' });
+    const result2 = await browseHandler({ category: 'books' });
+
+    expect(result1._meta!.proof!.meta.requestHash).toBe(
+      result2._meta!.proof!.meta.requestHash,
+    );
+  });
+
+  // §4.3 — _mcpi_delegation stripping
+  it('should not pass _mcpi_delegation to the tool handler', async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const testMcpi = createMCPIMiddleware(
+      {
+        identity: mcpi.identity,
+        session: { sessionTtlMinutes: 60 },
+        autoSession: true,
+      },
+      crypto,
+    );
+
+    const handler = testMcpi.wrapWithDelegation(
+      'checkout',
+      { scopeId: 'cart:write', consentUrl: CONSENT_URL },
+      async (args) => {
+        capturedArgs = args;
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const vc = await issueTestDelegation(serverDid, ['cart:write']);
+    await handler({ item: 'widget', _mcpi_delegation: vc });
+
+    expect(capturedArgs).toBeDefined();
+    expect(capturedArgs!['item']).toBe('widget');
+    expect(capturedArgs!['_mcpi_delegation']).toBeUndefined();
+  });
+});

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -10,11 +10,13 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/index.js';
 import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
 import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
-import type { ToolResult } from '../src/server.js';
+import { createConsentFullMcpServer, type ToolResult } from '../src/server.js';
 import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
 
 const crypto = new NodeCryptoProvider();
@@ -89,6 +91,37 @@ describe('MCP Server with consent-full', () => {
 
     expect(result.isError).toBeUndefined();
     expect(result.content[0]!.text).toContain('electronics');
+  });
+
+  it('should route _mcpi with action: "handshake" and return a valid session', async () => {
+    const server = createConsentFullMcpServer(mcpi, { consentUrl: CONSENT_URL });
+    const client = new Client({ name: 'consent-full-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const result = await client.callTool({
+      name: '_mcpi',
+      arguments: {
+        action: 'handshake',
+        nonce: `consent-full-test-${Date.now()}`,
+        audience: serverDid,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      success: boolean;
+      sessionId: string;
+      serverDid: string;
+    };
+    expect(parsed.success).toBe(true);
+    expect(parsed.sessionId).toMatch(/^mcpi_/);
+    expect(parsed.serverDid).toBe(serverDid);
+
+    await client.close();
+    await server.close();
   });
 
   // §6.1 — needs_authorization

--- a/examples/consent-full/package.json
+++ b/examples/consent-full/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@mcp-i/example-consent-full",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP-I consent flow with @kya-os/consent — multi-mode auth, configurable branding, and production-grade consent UI",
+  "scripts": {
+    "start": "npx tsx src/server.ts",
+    "start:consent": "npx tsx src/consent-server.ts",
+    "generate-identity": "npx tsx scripts/generate-identity.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@kya-os/consent": "^0.1.37"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/examples/consent-full/scripts/generate-identity.ts
+++ b/examples/consent-full/scripts/generate-identity.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env npx tsx
+/**
+ * Generate Identity
+ *
+ * Creates a persistent Ed25519 DID identity and saves it to .mcpi/identity.json.
+ * If an identity already exists, prints it without overwriting.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-identity.ts
+ *   npx tsx scripts/generate-identity.ts --force   # overwrite existing
+ *
+ * The server reads this file on startup so the DID survives restarts.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_DIR = path.resolve(__dirname, '..', '.mcpi');
+const IDENTITY_PATH = path.join(IDENTITY_DIR, 'identity.json');
+
+interface PersistedIdentity {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+  createdAt: string;
+}
+
+async function main() {
+  const force = process.argv.includes('--force');
+
+  // Check for existing identity
+  if (fs.existsSync(IDENTITY_PATH) && !force) {
+    const existing = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as PersistedIdentity;
+    process.stderr.write(`Identity already exists (use --force to regenerate)\n`);
+    process.stderr.write(`  DID: ${existing.did}\n`);
+    process.stderr.write(`  Created: ${existing.createdAt}\n`);
+    process.stderr.write(`  Path: ${IDENTITY_PATH}\n`);
+    return;
+  }
+
+  // Generate new identity
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#keys-1`;
+
+  const identity: PersistedIdentity = {
+    did,
+    kid,
+    privateKey: keyPair.privateKey,
+    publicKey: keyPair.publicKey,
+    createdAt: new Date().toISOString(),
+  };
+
+  // Write to disk
+  fs.mkdirSync(IDENTITY_DIR, { recursive: true });
+  fs.writeFileSync(IDENTITY_PATH, JSON.stringify(identity, null, 2) + '\n');
+
+  process.stderr.write(`Identity generated\n`);
+  process.stderr.write(`  DID: ${did}\n`);
+  process.stderr.write(`  Path: ${IDENTITY_PATH}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-full/src/consent-server.ts
+++ b/examples/consent-full/src/consent-server.ts
@@ -2,9 +2,9 @@
 /**
  * Consent HTTP Server (powered by @kya-os/consent)
  *
- * Serves a consent page rendered by @kya-os/consent and issues W3C Delegation
- * Credentials on approval. Replaces hand-rolled HTML with a single
- * generateConsentShell() call — multi-mode auth, loading skeleton, and no-JS
+ * This is the core differentiator from consent-basic. It replaces 200+ lines
+ * of hand-rolled HTML with a single generateConsentShell() call from
+ * @kya-os/consent — multi-mode auth, loading skeleton, branding, and no-JS
  * fallback included.
  *
  * Routes:

--- a/examples/consent-full/src/consent-server.ts
+++ b/examples/consent-full/src/consent-server.ts
@@ -1,0 +1,307 @@
+#!/usr/bin/env npx tsx
+/**
+ * Consent HTTP Server (powered by @kya-os/consent)
+ *
+ * Serves a consent page rendered by @kya-os/consent and issues W3C Delegation
+ * Credentials on approval. Replaces hand-rolled HTML with a single
+ * generateConsentShell() call — multi-mode auth, loading skeleton, and no-JS
+ * fallback included.
+ *
+ * Routes:
+ *   GET  /consent          — Consent page via @kya-os/consent
+ *   GET  /consent.js       — Consent component bundle
+ *   POST /consent/approve  — Issues a delegation VC (accepts FormData or JSON)
+ *
+ * Auth modes (AUTH_MODE env var):
+ *   consent-only  (default) — Approve/deny only. Zero config.
+ *   credentials             — Username/password + approve. Demo credentials: demo / demo123
+ *
+ * Related Spec: MCP-I §4 (Delegation), §6 (Authorization)
+ */
+
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateConsentShell } from '@kya-os/consent/bundle/shell';
+import { CONSENT_BUNDLE } from '@kya-os/consent/bundle/inline';
+import type { ConsentConfig } from '@kya-os/consent/types';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import {
+  createDelegationIssuerFromIdentity,
+  type AgentIdentityConfig,
+  type DelegationIssuerFactory,
+} from './delegation-issuer.js';
+
+export type AuthMode = 'consent-only' | 'credentials';
+
+/** Delegation VC time-to-live in seconds (1 hour). */
+const DELEGATION_TTL_SECONDS = 3600;
+
+export interface DelegationStoreWriter {
+  set(resumeToken: string, vc: unknown, ttlSeconds?: number): void;
+}
+
+export interface ConsentServerConfig {
+  port: number;
+  factory?: DelegationIssuerFactory;
+  delegationStore?: DelegationStoreWriter;
+  authMode?: AuthMode;
+  branding?: { primaryColor?: string; companyName?: string };
+}
+
+export interface ConsentServer {
+  server: http.Server;
+  port: number;
+  url: string;
+  factory: DelegationIssuerFactory;
+  close: () => Promise<void>;
+}
+
+/**
+ * Create and start a consent HTTP server powered by @kya-os/consent.
+ */
+export async function startConsentServer(
+  config: ConsentServerConfig,
+): Promise<ConsentServer> {
+  const authMode: AuthMode = config.authMode
+    ?? (process.env['AUTH_MODE'] as AuthMode | undefined)
+    ?? 'consent-only';
+
+  let factory: DelegationIssuerFactory;
+  if (config.factory) {
+    factory = config.factory;
+  } else {
+    const crypto = new NodeCryptoProvider();
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const identity: AgentIdentityConfig = {
+      did,
+      kid: `${did}#keys-1`,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+    };
+    factory = createDelegationIssuerFromIdentity(crypto, identity);
+  }
+
+  const consentConfig: ConsentConfig = {
+    branding: {
+      primaryColor: config.branding?.primaryColor ?? process.env['BRAND_COLOR'] ?? '#2563EB',
+      companyName: config.branding?.companyName ?? process.env['COMPANY_NAME'] ?? 'MCP-I Demo',
+    },
+    ui: {
+      title: 'Permission Request',
+      description: '[AI Agent] is requesting access to resources on your behalf.',
+      theme: 'auto',
+    },
+    terms: { required: false },
+    expirationDays: 1,
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    // EXAMPLE ONLY — restrict to your consent page origin in production
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const addr = httpServer.address();
+    const actualPort = typeof addr === 'object' && addr ? addr.port : config.port;
+    const url = new URL(req.url ?? '/', `http://localhost:${actualPort}`);
+
+    // GET /consent — consent page via @kya-os/consent
+    if (url.pathname === '/consent' && req.method === 'GET') {
+      const tool = url.searchParams.get('tool') ?? 'unknown';
+      const scopesRaw = url.searchParams.get('scopes') ?? '';
+      const agentDid = url.searchParams.get('agent_did') ?? 'unknown';
+      const resumeToken = url.searchParams.get('resume_token') ?? '';
+      const scopes = scopesRaw.split(',').map(s => s.trim()).filter(Boolean);
+
+      const html = generateConsentShell({
+        config: consentConfig,
+        tool,
+        scopes,
+        agentDid,
+        // @kya-os/consent uses session_id internally; maps 1:1 with MCP-I resume_token
+        sessionId: resumeToken,
+        projectId: 'consent-full-example',
+        serverUrl: `http://localhost:${actualPort}`,
+        authMode,
+      });
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    // GET /consent.js — serve the @kya-os/consent component bundle
+    if (url.pathname === '/consent.js' && req.method === 'GET') {
+      res.writeHead(200, {
+        'Content-Type': 'application/javascript; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+      });
+      res.end(CONSENT_BUNDLE);
+      return;
+    }
+
+    // POST /consent/approve — issue delegation VC
+    if (url.pathname === '/consent/approve' && req.method === 'POST') {
+      try {
+        const fields = await parseApprovalBody(req);
+        const tool = fields['tool'];
+        const scopesRaw = fields['scopes'];
+        const agentDid = fields['agent_did'];
+        const sessionId = fields['session_id'] ?? ''; // This is the resume_token
+        const requestAuthMode = fields['auth_mode'] ?? 'consent-only';
+
+        if (typeof tool !== 'string' || typeof scopesRaw !== 'string' || typeof agentDid !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'missing_fields',
+            message: 'tool, scopes, and agent_did are required',
+          }));
+          return;
+        }
+
+        // EXAMPLE ONLY — replace with real credential validation in production
+        if (requestAuthMode === 'credentials') {
+          const username = fields['username'] ?? '';
+          const password = fields['password'] ?? '';
+          if (username !== 'demo' || password !== 'demo123') {
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              error: 'invalid_credentials',
+              message: 'Invalid username or password',
+            }));
+            return;
+          }
+        }
+
+        // Parse scopes — FormData sends as JSON string, plain strings also accepted
+        let scopeList: string[];
+        try {
+          scopeList = JSON.parse(scopesRaw) as string[];
+        } catch {
+          scopeList = scopesRaw.split(',').map(s => s.trim()).filter(Boolean);
+        }
+
+        const delegationId = `delegation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const nowSeconds = Math.floor(Date.now() / 1000);
+
+        const vc = await factory.issuer.createAndIssueDelegation({
+          id: delegationId,
+          issuerDid: factory.identity.did,
+          subjectDid: agentDid,
+          constraints: {
+            scopes: scopeList,
+            notAfter: nowSeconds + DELEGATION_TTL_SECONDS,
+          },
+          metadata: { tool, approvedAt: new Date().toISOString() },
+        });
+
+        // Store VC in delegation store for auto-apply on retry
+        if (sessionId && config.delegationStore) {
+          config.delegationStore.set(sessionId, vc);
+          process.stderr.write(`[consent] Stored delegation for resume_token: ${sessionId}\n`);
+        }
+
+        // Response includes delegation_id for the <mcp-consent> component's
+        // success event (ConsentApproveDetail) and delegationToken for API clients.
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          success: true,
+          delegation_id: delegationId,
+          delegationToken: vc,
+        }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          error: 'internal_error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        }));
+      }
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(config.port, () => {
+      const addr = httpServer.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : config.port;
+      const serverUrl = `http://localhost:${actualPort}`;
+
+      process.stderr.write(`[consent] Consent server: ${serverUrl}\n`);
+      process.stderr.write(`[consent] Auth mode: ${authMode}\n`);
+      process.stderr.write(`[consent] Issuer DID: ${factory.identity.did}\n`);
+
+      resolve({
+        server: httpServer,
+        port: actualPort,
+        url: serverUrl,
+        factory,
+        close: () => new Promise<void>((res) => httpServer.close(() => res())),
+      });
+    });
+  });
+}
+
+/**
+ * Parse approval body — supports both FormData (from <mcp-consent>)
+ * and JSON (from API clients/tests).
+ */
+async function parseApprovalBody(req: http.IncomingMessage): Promise<Record<string, string>> {
+  const contentType = req.headers['content-type'] ?? '';
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of req) {
+    totalBytes += (chunk as Buffer).length;
+    if (totalBytes > 1_048_576) throw new Error('Request body too large');
+    chunks.push(chunk as Buffer);
+  }
+
+  const rawBody = Buffer.concat(chunks);
+
+  // JSON bodies (from tests, API clients)
+  if (contentType.includes('application/json')) {
+    return JSON.parse(rawBody.toString('utf-8')) as Record<string, string>;
+  }
+
+  // FormData bodies (from <mcp-consent> web component) — use Web Request API
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === 'string') headers[key] = value;
+  }
+
+  const webReq = new Request(`http://localhost${req.url}`, {
+    method: 'POST',
+    headers,
+    body: rawBody,
+  });
+
+  const formData = await webReq.formData();
+  const result: Record<string, string> = {};
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'string') result[key] = value;
+  }
+  return result;
+}
+
+// Run standalone when executed directly
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const port = parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
+  startConsentServer({ port }).catch((err) => {
+    process.stderr.write(`Fatal: ${err}\n`);
+    process.exit(1);
+  });
+}

--- a/examples/consent-full/src/delegation-issuer.ts
+++ b/examples/consent-full/src/delegation-issuer.ts
@@ -1,0 +1,59 @@
+/**
+ * Delegation Issuer Factory
+ *
+ * Creates a DelegationCredentialIssuer from an identity config.
+ * Used by both consent-server.ts and tests.
+ *
+ * Related Spec: MCP-I §3.1 (VC structure), §4.1 (DelegationRecord)
+ */
+
+import { DelegationCredentialIssuer } from '../../../src/delegation/vc-issuer.js';
+import type { VCSigningFunction } from '../../../src/delegation/vc-issuer.js';
+import type { Proof } from '../../../src/types/protocol.js';
+import type { CryptoProvider } from '../../../src/providers/base.js';
+import { base64urlEncodeFromBytes } from '../../../src/utils/base64.js';
+
+export interface AgentIdentityConfig {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+export interface DelegationIssuerFactory {
+  issuer: DelegationCredentialIssuer;
+  identity: AgentIdentityConfig;
+}
+
+export function createDelegationIssuerFromIdentity(
+  crypto: CryptoProvider,
+  identity: AgentIdentityConfig,
+): DelegationIssuerFactory {
+  const signingFunction: VCSigningFunction = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kid: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, identity.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => identity.did,
+      getKeyId: () => identity.kid,
+      getPrivateKey: () => identity.privateKey,
+    },
+    signingFunction,
+  );
+
+  return { issuer, identity };
+}

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -1,0 +1,400 @@
+#!/usr/bin/env npx tsx
+/**
+ * MCP Server with Full Consent Flow (powered by @kya-os/consent)
+ *
+ * Same protocol flow as consent-basic — browse (public) and checkout (protected)
+ * tools — but the consent page is rendered by @kya-os/consent with multi-mode
+ * auth, configurable branding, loading skeleton, and no-JS fallback.
+ *
+ * Transports (selected via --transport flag):
+ *   - stdio (default) — for MCP Inspector CLI integration
+ *   - sse             — legacy SSE transport on /sse + /messages
+ *   - mcp             — Streamable HTTP transport on /mcp (recommended for HTTP)
+ *
+ * Related Spec: MCP-I §4 (Delegation), §5 (Proof), §6 (Authorization)
+ */
+
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { startConsentServer } from './consent-server.js';
+import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_PATH = path.resolve(__dirname, '..', '.mcpi', 'identity.json');
+
+export interface ServerConfig {
+  consentUrl: string;
+  delegationStore?: DelegationStore;
+}
+
+/**
+ * In-memory store mapping resume_token -> approved delegation VC.
+ *
+ * When a user approves on the consent page, the VC is stored here keyed
+ * by resume_token. On the next tool call, the server checks this store
+ * and automatically injects the delegation.
+ */
+export class DelegationStore {
+  private store = new Map<string, { vc: unknown; expiresAt: number }>();
+
+  set(resumeToken: string, vc: unknown, ttlSeconds = 300): void {
+    this.store.set(resumeToken, { vc, expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
+
+  get(resumeToken: string): unknown | undefined {
+    const entry = this.store.get(resumeToken);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(resumeToken);
+      return undefined;
+    }
+    return entry.vc;
+  }
+
+  /** Find any pending delegation for a given tool (checks all entries). */
+  findByTool(toolName: string): { resumeToken: string; vc: unknown } | undefined {
+    for (const [token, entry] of this.store) {
+      if (Date.now() > entry.expiresAt) {
+        this.store.delete(token);
+        continue;
+      }
+      const vc = entry.vc as Record<string, unknown> | undefined;
+      const metadata = (vc?.credentialSubject as Record<string, unknown>)
+        ?.delegation as Record<string, unknown> | undefined;
+      if (metadata?.metadata && (metadata.metadata as Record<string, unknown>).tool === toolName) {
+        this.store.delete(token); // consume it
+        return { resumeToken: token, vc: entry.vc };
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Intercept needs_authorization responses and reformat as a clickable
+ * consent link with URL params (tool, scopes, agent_did, resume_token).
+ *
+ * Also checks the DelegationStore for previously approved delegations
+ * and auto-injects them on retry.
+ */
+function formatAsConsentLink(
+  toolName: string,
+  consentBaseUrl: string,
+  agentDid: string,
+  delegationStore: DelegationStore | undefined,
+  handler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
+): (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult> {
+  return async (args, sessionId) => {
+    // Check the delegation store for a previously approved VC (resume token flow).
+    if (!args['_mcpi_delegation'] && delegationStore) {
+      const pending = delegationStore.findByTool(toolName);
+      if (pending) {
+        process.stderr.write(`[server] Auto-applying delegation from consent approval (token: ${pending.resumeToken})\n`);
+        return handler({ ...args, _mcpi_delegation: pending.vc }, sessionId);
+      }
+    }
+
+    const result = await handler(args, sessionId);
+
+    // Intercept needs_authorization JSON and reformat as markdown link
+    const text = result.content?.[0]?.text;
+    if (text && !result.isError) {
+      try {
+        const parsed = JSON.parse(text) as {
+          error?: string;
+          scopes?: string[];
+          resumeToken?: string;
+        };
+        if (parsed.error === 'needs_authorization') {
+          const url = new URL(consentBaseUrl);
+          url.searchParams.set('tool', toolName);
+          url.searchParams.set('scopes', (parsed.scopes ?? []).join(','));
+          url.searchParams.set('agent_did', agentDid);
+          if (parsed.resumeToken) {
+            url.searchParams.set('resume_token', parsed.resumeToken);
+          }
+
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Authorization required.\n\n[Authorize ${toolName}](${url.toString()})\n\nRetry after authorizing.`,
+            }],
+            isError: false,
+          };
+        }
+      } catch {
+        // Not JSON — pass through
+      }
+    }
+
+    return result;
+  };
+}
+
+export interface ToolResult {
+  content: Array<{ type: string; text: string; [key: string]: unknown }>;
+  isError?: boolean;
+  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  [key: string]: unknown;
+}
+
+export function createConsentFullMcpServer(
+  mcpi: MCPIMiddleware,
+  config: ServerConfig,
+) {
+  const server = new Server(
+    { name: 'consent-full-example', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  // browse: public tool — proof attached via wrapWithProof
+  const browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
+    content: [{
+      type: 'text',
+      text: `Browsing category: ${args['category'] ?? 'all'}. Found 3 items.`,
+    }],
+  }));
+
+  // checkout: protected tool — requires delegation with scope cart:write
+  const rawCheckoutHandler = mcpi.wrapWithDelegation(
+    'checkout',
+    { scopeId: 'cart:write', consentUrl: config.consentUrl },
+    mcpi.wrapWithProof('checkout', async (args) => ({
+      content: [{
+        type: 'text',
+        text: `Order confirmed for item: ${args['item'] ?? 'unknown'}. Thank you!`,
+      }],
+    })),
+  );
+  const checkoutHandler = formatAsConsentLink(
+    'checkout',
+    config.consentUrl,
+    mcpi.identity.did,
+    config.delegationStore,
+    rawCheckoutHandler as (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'browse',
+        description: 'Browse product categories (public — no delegation required)',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            category: { type: 'string', description: 'Product category to browse' },
+          },
+        },
+      },
+      {
+        name: 'checkout',
+        description: 'Complete a purchase (requires delegation with scope: cart:write)',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            item: { type: 'string', description: 'Item to purchase' },
+          },
+          required: ['item'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+
+    if (name === '_mcpi_handshake') {
+      return mcpi.handleHandshake(args as Record<string, unknown>);
+    }
+
+    if (name === 'browse') {
+      return browseHandler(args as Record<string, unknown>);
+    }
+
+    if (name === 'checkout') {
+      return checkoutHandler(args as Record<string, unknown>);
+    }
+
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  });
+
+  return server;
+}
+
+/**
+ * Load identity from .mcpi/identity.json if it exists,
+ * otherwise generate an ephemeral one.
+ */
+export async function createMcpiMiddleware() {
+  const crypto = new NodeCryptoProvider();
+  let did: string;
+  let kid: string;
+  let privateKey: string;
+  let publicKey: string;
+
+  if (fs.existsSync(IDENTITY_PATH)) {
+    const stored = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as {
+      did: string; kid: string; privateKey: string; publicKey: string;
+    };
+    did = stored.did;
+    kid = stored.kid;
+    privateKey = stored.privateKey;
+    publicKey = stored.publicKey;
+    process.stderr.write(`[server] Loaded identity from ${IDENTITY_PATH}\n`);
+  } else {
+    const keyPair = await crypto.generateKeyPair();
+    did = generateDidKeyFromBase64(keyPair.publicKey);
+    kid = `${did}#keys-1`;
+    privateKey = keyPair.privateKey;
+    publicKey = keyPair.publicKey;
+    process.stderr.write(`[server] Generated ephemeral identity (run 'npm run generate-identity' to persist)\n`);
+  }
+
+  return createMCPIMiddleware(
+    {
+      identity: { did, kid, privateKey, publicKey },
+      session: { sessionTtlMinutes: 60 },
+      autoSession: true,
+    },
+    crypto,
+  );
+}
+
+function setCorsHeaders(res: http.ServerResponse) {
+  // EXAMPLE ONLY — restrict to your application origin in production
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, MCP-Session-Id');
+  res.setHeader('Access-Control-Expose-Headers', 'MCP-Session-Id');
+}
+
+/**
+ * Start the MCP server with SSE + Streamable HTTP transports.
+ */
+async function startHttpServer(mcpi: MCPIMiddleware, consentUrl: string, port: number, delegationStore?: DelegationStore) {
+  let sseTransport: SSEServerTransport | null = null;
+
+  const httpServer = http.createServer(async (req, res) => {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+
+    // SSE transport: GET /sse + POST /messages
+    if (url.pathname === '/sse' && req.method === 'GET') {
+      const server = createConsentFullMcpServer(mcpi, { consentUrl, delegationStore });
+      sseTransport = new SSEServerTransport('/messages', res);
+      await server.connect(sseTransport);
+      process.stderr.write('[server] SSE client connected\n');
+      return;
+    }
+
+    if (url.pathname === '/messages' && req.method === 'POST') {
+      if (!sseTransport) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'No SSE connection. Connect to /sse first.' }));
+        return;
+      }
+      await sseTransport.handlePostMessage(req, res);
+      return;
+    }
+
+    // Streamable HTTP transport: POST /mcp
+    if (url.pathname === '/mcp' && req.method === 'POST') {
+      const server = createConsentFullMcpServer(mcpi, { consentUrl, delegationStore });
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      res.on('close', () => transport.close());
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    // Info endpoint
+    if (url.pathname === '/' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        name: 'consent-full-example',
+        did: mcpi.identity.did,
+        transports: {
+          sse: `http://localhost:${port}/sse`,
+          mcp: `http://localhost:${port}/mcp`,
+        },
+      }));
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  httpServer.listen(port, () => {
+    process.stderr.write(`[server] HTTP server: http://localhost:${port}\n`);
+    process.stderr.write(`[server]   SSE:  http://localhost:${port}/sse\n`);
+    process.stderr.write(`[server]   MCP:  http://localhost:${port}/mcp\n`);
+    process.stderr.write(`[server] Agent DID: ${mcpi.identity.did}\n`);
+  });
+}
+
+// Run standalone
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const transport = process.argv.includes('--stdio') ? 'stdio'
+    : process.argv.includes('--sse') ? 'sse'
+    : process.argv.includes('--mcp') ? 'mcp'
+    : 'sse'; // default to HTTP (SSE + /mcp) for Inspector compatibility
+
+  const port = parseInt(process.env['PORT'] ?? '3002', 10);
+  const consentPort = transport === 'stdio'
+    ? 0
+    : parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
+
+  createMcpiMiddleware().then(async (mcpi) => {
+    const cryptoProvider = new NodeCryptoProvider();
+    const factory = createDelegationIssuerFromIdentity(cryptoProvider, {
+      did: mcpi.identity.did,
+      kid: mcpi.identity.kid,
+      privateKey: mcpi.identity.privateKey,
+      publicKey: mcpi.identity.publicKey,
+    });
+    // Shared delegation store — consent server writes, MCP server reads
+    const delegationStore = new DelegationStore();
+    const consentServer = await startConsentServer({ port: consentPort, factory, delegationStore });
+    const consentUrl = `${consentServer.url}/consent`;
+
+    if (transport === 'stdio') {
+      process.stderr.write(`[server] Agent DID: ${mcpi.identity.did}\n`);
+      const server = createConsentFullMcpServer(mcpi, { consentUrl, delegationStore });
+      await server.connect(new StdioServerTransport());
+      process.stderr.write('[server] MCP server running on stdio\n');
+    } else {
+      await startHttpServer(mcpi, consentUrl, port, delegationStore);
+    }
+  }).catch((err) => {
+    process.stderr.write(`Fatal: ${err}\n`);
+    process.exit(1);
+  });
+}

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -212,6 +212,7 @@ export function createConsentFullMcpServer(
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
+      mcpi.mcpiTool,
       {
         name: 'browse',
         description: 'Browse product categories (public — no delegation required)',
@@ -239,8 +240,8 @@ export function createConsentFullMcpServer(
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
 
-    if (name === '_mcpi_handshake') {
-      return mcpi.handleHandshake(args as Record<string, unknown>);
+    if (name === '_mcpi') {
+      return mcpi.handleMCPI(args as Record<string, unknown>);
     }
 
     if (name === 'browse') {

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -1,15 +1,24 @@
 #!/usr/bin/env npx tsx
 /**
- * MCP Server with Full Consent Flow (powered by @kya-os/consent)
+ * MCP Server with Consent-Based Delegation
  *
- * Same protocol flow as consent-basic — browse (public) and checkout (protected)
- * tools — but the consent page is rendered by @kya-os/consent with multi-mode
- * auth, configurable branding, loading skeleton, and no-JS fallback.
+ * Demonstrates two tools:
+ *   - browse   (public)    — executes freely, proof attached
+ *   - checkout (protected) — requires a W3C Delegation Credential with scope cart:write
  *
- * Transports (selected via --transport flag):
- *   - stdio (default) — for MCP Inspector CLI integration
- *   - sse             — legacy SSE transport on /sse + /messages
- *   - mcp             — Streamable HTTP transport on /mcp (recommended for HTTP)
+ * The consent UI is served by consent-server.ts (the @kya-os/consent showcase).
+ * This file is MCP server infrastructure — identical in structure to consent-basic.
+ *
+ * Architecture note:
+ *   This example uses the low-level SDK `Server` API with `createMCPIMiddleware`
+ *   instead of the 2-line `withMCPI(server, { crypto })` pattern (see examples/
+ *   context7-with-mcpi for that). The reason: delegation-protected tools receive
+ *   `_mcpi_delegation` as a tool argument. McpServer.registerTool validates args
+ *   against zod schemas and strips unknown keys — so the delegation VC would be
+ *   silently dropped before the handler sees it. The low-level Server API passes
+ *   args through without schema validation, which delegation requires.
+ *
+ * Transports: stdio (default), sse, mcp (Streamable HTTP)
  *
  * Related Spec: MCP-I §4 (Delegation), §5 (Proof), §6 (Authorization)
  */
@@ -26,14 +35,22 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { createMCPIMiddleware, type MCPIMiddleware } from '../../../src/middleware/with-mcpi.js';
+import {
+  createMCPIMiddleware,
+  generateIdentity,
+  type MCPIMiddleware,
+  type MCPIIdentityConfig,
+} from '../../../src/middleware/index.js';
 import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
 import { startConsentServer } from './consent-server.js';
 import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const IDENTITY_PATH = path.resolve(__dirname, '..', '.mcpi', 'identity.json');
+
+// ── Application-Level Types ─────────────────────────────────────────
+// These are example-specific patterns for the resume_token consent flow,
+// not part of the MCP-I protocol itself.
 
 export interface ServerConfig {
   consentUrl: string;
@@ -151,6 +168,11 @@ export interface ToolResult {
   [key: string]: unknown;
 }
 
+// ── MCP Server Factory ──────────────────────────────────────────────
+// Protocol integration: createMCPIMiddleware provides wrapWithProof (§5)
+// and wrapWithDelegation (§4). We use the low-level Server API because
+// delegation requires raw args — see architecture note at top of file.
+
 export function createConsentFullMcpServer(
   mcpi: MCPIMiddleware,
   config: ServerConfig,
@@ -160,7 +182,7 @@ export function createConsentFullMcpServer(
     { capabilities: { tools: {} } },
   );
 
-  // browse: public tool — proof attached via wrapWithProof
+  // browse: public tool — §5 proof attached via wrapWithProof
   const browseHandler = mcpi.wrapWithProof('browse', async (args) => ({
     content: [{
       type: 'text',
@@ -168,7 +190,8 @@ export function createConsentFullMcpServer(
     }],
   }));
 
-  // checkout: protected tool — requires delegation with scope cart:write
+  // checkout: protected tool — §4 delegation with scope cart:write
+  // wrapWithDelegation checks _mcpi_delegation in args (why we need raw args)
   const rawCheckoutHandler = mcpi.wrapWithDelegation(
     'checkout',
     { scopeId: 'cart:write', consentUrl: config.consentUrl },
@@ -237,44 +260,32 @@ export function createConsentFullMcpServer(
   return server;
 }
 
+// ── Identity + Middleware Setup ──────────────────────────────────────
+
 /**
- * Load identity from .mcpi/identity.json if it exists,
- * otherwise generate an ephemeral one.
+ * Load identity from .mcpi/identity.json or generate an ephemeral one,
+ * then create MCP-I middleware with session + proof + delegation support.
  */
 export async function createMcpiMiddleware() {
   const crypto = new NodeCryptoProvider();
-  let did: string;
-  let kid: string;
-  let privateKey: string;
-  let publicKey: string;
 
+  let identity: MCPIIdentityConfig;
   if (fs.existsSync(IDENTITY_PATH)) {
-    const stored = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as {
-      did: string; kid: string; privateKey: string; publicKey: string;
-    };
-    did = stored.did;
-    kid = stored.kid;
-    privateKey = stored.privateKey;
-    publicKey = stored.publicKey;
+    identity = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as MCPIIdentityConfig;
     process.stderr.write(`[server] Loaded identity from ${IDENTITY_PATH}\n`);
   } else {
-    const keyPair = await crypto.generateKeyPair();
-    did = generateDidKeyFromBase64(keyPair.publicKey);
-    kid = `${did}#keys-1`;
-    privateKey = keyPair.privateKey;
-    publicKey = keyPair.publicKey;
+    identity = await generateIdentity(crypto);
     process.stderr.write(`[server] Generated ephemeral identity (run 'npm run generate-identity' to persist)\n`);
   }
 
   return createMCPIMiddleware(
-    {
-      identity: { did, kid, privateKey, publicKey },
-      session: { sessionTtlMinutes: 60 },
-      autoSession: true,
-    },
+    { identity, session: { sessionTtlMinutes: 60 }, autoSession: true },
     crypto,
   );
 }
+
+// ── HTTP Transport Boilerplate ───────────────────────────────────────
+// Standard MCP transport setup — not specific to consent or delegation.
 
 function setCorsHeaders(res: http.ServerResponse) {
   // EXAMPLE ONLY — restrict to your application origin in production
@@ -284,9 +295,7 @@ function setCorsHeaders(res: http.ServerResponse) {
   res.setHeader('Access-Control-Expose-Headers', 'MCP-Session-Id');
 }
 
-/**
- * Start the MCP server with SSE + Streamable HTTP transports.
- */
+/** Start the MCP server with SSE + Streamable HTTP transports. */
 async function startHttpServer(mcpi: MCPIMiddleware, consentUrl: string, port: number, delegationStore?: DelegationStore) {
   let sseTransport: SSEServerTransport | null = null;
 
@@ -359,7 +368,8 @@ async function startHttpServer(mcpi: MCPIMiddleware, consentUrl: string, port: n
   });
 }
 
-// Run standalone
+// ── Entrypoint ──────────────────────────────────────────────────────
+
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
   const transport = process.argv.includes('--stdio') ? 'stdio'

--- a/examples/consent-full/tsconfig.json
+++ b/examples/consent-full/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"]
+}

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -64,6 +64,7 @@ function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
+      mcpi.mcpiTool,
       {
         name: 'greet',
         description: 'Returns a greeting with a signed Ed25519 proof',
@@ -94,9 +95,9 @@ function createMcpServer(mcpi: ReturnType<typeof createMCPIMiddleware>) {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
 
-    // ── Handshake (still available for MCP-I-aware clients) ─────
-    if (name === '_mcpi_handshake') {
-      return mcpi.handleHandshake(args as Record<string, unknown>);
+    // ── MCP-I protocol operations ────────────────────────────────
+    if (name === '_mcpi') {
+      return mcpi.handleMCPI(args as Record<string, unknown>);
     }
 
     // ── Open tools ──────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@kya-os/consent": "^0.1.37",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@types/express": "^5.0.6",
     "@types/node": "^20.14.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3)
+      '@kya-os/consent':
+        specifier: ^0.1.37
+        version: 0.1.37(@types/react@19.2.14)
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.27.1(zod@4.3.6)
@@ -307,6 +310,20 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kya-os/consent@0.1.37':
+    resolution: {integrity: sha512-BiPwSv8wimsEPF50XOBOyAN4iQDr3lIRkz7k3aQ8aWKnBkQnLqkIRrZ2noK/H9c7fJdte8D67EQdRjwWVa9GbA==}
+
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/react@1.0.8':
+    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
+    peerDependencies:
+      '@types/react': 17 || 18 || 19
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
   '@mcp-i/core@1.1.0-canary.2':
     resolution: {integrity: sha512-56zUh0ZEGsVBi3OYLvVa1RktFGMxPzkC+6zGgGIQw1QGIljNZr1OLxZ32zITdgLbLKdWS+ZjdGLzAGrh+LFygA==}
     peerDependencies:
@@ -487,11 +504,17 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -714,6 +737,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1051,6 +1077,15 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.2:
+    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@3.3.2:
+    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1476,6 +1511,9 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -1644,6 +1682,24 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kya-os/consent@0.1.37(@types/react@19.2.14)':
+    dependencies:
+      '@lit/react': 1.0.8(@types/react@19.2.14)
+      lit: 3.3.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/react@1.0.8(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+
   '@mcp-i/core@1.1.0-canary.2(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
     dependencies:
       jose: 5.10.0
@@ -1789,6 +1845,10 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 20.19.37
@@ -1797,6 +1857,8 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.37
+
+  '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
     dependencies:
@@ -2064,6 +2126,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2432,6 +2496,22 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.2
+
+  lit-html@3.3.2:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.2:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
 
   locate-path@6.0.0:
     dependencies:
@@ -2863,5 +2943,7 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/src/__tests__/integration/mcp-enhance-server.test.ts
+++ b/src/__tests__/integration/mcp-enhance-server.test.ts
@@ -2,7 +2,7 @@
  * withMCPI() Integration Tests
  *
  * Tests the dream API: `withMCPI(server, { crypto })` auto-registers
- * the handshake tool and auto-attaches proofs to all tool responses.
+ * the `_mcpi` protocol tool and auto-attaches proofs to all tool responses.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -20,6 +20,7 @@ async function createTestPair(options?: {
   excludeTools?: string[];
   autoSession?: boolean;
   registerToolsBeforeWithMCPI?: boolean;
+  handshakeExposure?: 'tool' | 'none';
 }) {
   const crypto = new NodeCryptoProvider();
   const server = new McpServer(
@@ -46,6 +47,7 @@ async function createTestPair(options?: {
     autoSession: options?.autoSession ?? true,
     proofAllTools: options?.proofAllTools,
     excludeTools: options?.excludeTools,
+    handshakeExposure: options?.handshakeExposure,
   });
 
   // Register tools AFTER withMCPI to test late registration
@@ -103,13 +105,23 @@ describe('withMCPI()', () => {
     return pair;
   }
 
-  it('auto-registers _mcpi_handshake tool', async () => {
+  it('auto-registers _mcpi tool', async () => {
     const { client } = await create();
 
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name);
 
-    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('_mcpi');
+  });
+
+  it('handshakeExposure: none does not auto-register _mcpi', async () => {
+    const { client } = await create({ handshakeExposure: 'none' });
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).not.toContain('_mcpi');
+    expect(toolNames).toContain('greet');
   });
 
   it('auto-proofs all registered tools', async () => {
@@ -204,8 +216,9 @@ describe('withMCPI()', () => {
     const { client, mcpi } = await create({ autoSession: false });
 
     const result = await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `test-${Date.now()}`,
         audience: mcpi.identity.did,
         timestamp: Math.floor(Date.now() / 1000),
@@ -217,6 +230,36 @@ describe('withMCPI()', () => {
     expect(parsed.success).toBe(true);
     expect(parsed.sessionId).toMatch(/^mcpi_/);
     expect(parsed.serverDid).toBe(mcpi.identity.did);
+  });
+
+  it('manual handshake API works when handshake tool is not exposed', async () => {
+    const { client, mcpi } = await create({
+      autoSession: false,
+      handshakeExposure: 'none',
+    });
+
+    await mcpi.handleHandshake({
+      nonce: `manual-${Date.now()}`,
+      audience: mcpi.identity.did,
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: { name: 'Manual Handshake' },
+    });
+
+    const first = result.content[0] as { type: string; text: string };
+    expect(first.text).toBe('Hello, Manual Handshake!');
+
+    expect(result._meta).toBeDefined();
+    const proof = (result._meta as Record<string, unknown>).proof as {
+      jws: string;
+      meta: Record<string, unknown>;
+    };
+    expect(proof).toBeDefined();
+    expect(proof.jws).toBeDefined();
+    expect(proof.meta.sessionId).toMatch(/^mcpi_/);
   });
 
   it('multiple tools share the same auto-session', async () => {

--- a/src/__tests__/integration/mcp-transport-context7.test.ts
+++ b/src/__tests__/integration/mcp-transport-context7.test.ts
@@ -43,18 +43,19 @@ async function setupMcpServerPair(options?: { autoSession?: boolean }) {
     { instructions: 'Test server for McpServer + MCP-I integration' },
   );
 
-  // Register _mcpi_handshake tool (same pattern as Context7 integration)
+  // Register unified _mcpi tool (same pattern as Context7 integration)
   server.registerTool(
-    '_mcpi_handshake',
+    '_mcpi',
     {
-      description: 'MCP-I identity handshake',
+      description: 'MCP-I protocol',
       inputSchema: {
-        nonce: z.string(),
-        audience: z.string(),
-        timestamp: z.number(),
+        action: z.enum(['handshake', 'identity', 'reputation']),
+        nonce: z.string().optional(),
+        audience: z.string().optional(),
+        timestamp: z.number().optional(),
       },
     },
-    async (args) => mcpi.handleHandshake(args as Record<string, unknown>),
+    async (args) => mcpi.handleMCPI(args as Record<string, unknown>),
   );
 
   // Wrap a test tool with proof (simulates Context7's resolve-library-id)
@@ -135,13 +136,13 @@ describe('McpServer (High-Level API) + MCP-I Integration', () => {
     return pair;
   }
 
-  it('listTools returns handshake + registered tools', async () => {
+  it('listTools returns _mcpi + registered tools', async () => {
     const { client } = await createPair();
 
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name);
 
-    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('_mcpi');
     expect(toolNames).toContain('search');
     expect(toolNames).toContain('fetch-docs');
   });
@@ -150,8 +151,9 @@ describe('McpServer (High-Level API) + MCP-I Integration', () => {
     const { client, did } = await createPair();
 
     const result = await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `mcpserver-test-${Date.now()}`,
         audience: did,
         timestamp: Math.floor(Date.now() / 1000),
@@ -173,8 +175,9 @@ describe('McpServer (High-Level API) + MCP-I Integration', () => {
 
     // Handshake first
     await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `mcpserver-test-${Date.now()}`,
         audience: did,
         timestamp: Math.floor(Date.now() / 1000),
@@ -337,13 +340,13 @@ describe('McpServer + withMCPI() (Dream API)', () => {
     return { client, server, mcpi };
   }
 
-  it('listTools returns handshake + registered tools (withMCPI)', async () => {
+  it('listTools returns _mcpi + registered tools (withMCPI)', async () => {
     const { client } = await createWithMCPIPair();
 
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name);
 
-    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('_mcpi');
     expect(toolNames).toContain('search');
     expect(toolNames).toContain('fetch-docs');
   });
@@ -373,8 +376,9 @@ describe('McpServer + withMCPI() (Dream API)', () => {
     const { client, mcpi } = await createWithMCPIPair({ autoSession: false });
 
     const result = await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `withmcpi-test-${Date.now()}`,
         audience: mcpi.identity.did,
         timestamp: Math.floor(Date.now() / 1000),

--- a/src/__tests__/integration/mcp-transport.test.ts
+++ b/src/__tests__/integration/mcp-transport.test.ts
@@ -101,7 +101,7 @@ async function setupMcpPair(options?: { autoSession?: boolean }) {
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
-      mcpi.handshakeTool,
+      mcpi.mcpiTool,
       {
         name: 'greet',
         description: 'Returns a greeting with proof',
@@ -127,8 +127,8 @@ async function setupMcpPair(options?: { autoSession?: boolean }) {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
 
-    if (name === '_mcpi_handshake') {
-      return mcpi.handleHandshake(args as Record<string, unknown>);
+    if (name === '_mcpi') {
+      return mcpi.handleMCPI(args as Record<string, unknown>);
     }
     if (name === 'greet') {
       return greetHandler(args as Record<string, unknown>);
@@ -211,14 +211,14 @@ describe('MCP Transport Integration', () => {
     return pair;
   }
 
-  it('listTools returns handshake + app tools', async () => {
+  it('listTools returns _mcpi + app tools', async () => {
     const { client } = await createPair();
 
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name);
 
     expect(toolNames).toHaveLength(3);
-    expect(toolNames).toContain('_mcpi_handshake');
+    expect(toolNames).toContain('_mcpi');
     expect(toolNames).toContain('greet');
     expect(toolNames).toContain('restricted_greet');
   });
@@ -227,8 +227,9 @@ describe('MCP Transport Integration', () => {
     const { client, did } = await createPair();
 
     const result = await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `transport-test-${Date.now()}`,
         audience: did,
         timestamp: Math.floor(Date.now() / 1000),
@@ -250,8 +251,9 @@ describe('MCP Transport Integration', () => {
 
     // Handshake first
     await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `transport-test-${Date.now()}`,
         audience: did,
         timestamp: Math.floor(Date.now() / 1000),
@@ -287,8 +289,9 @@ describe('MCP Transport Integration', () => {
 
     // Handshake
     await client.callTool({
-      name: '_mcpi_handshake',
+      name: '_mcpi',
       arguments: {
+        action: 'handshake',
         nonce: `transport-test-${Date.now()}`,
         audience: did,
         timestamp: Math.floor(Date.now() / 1000),

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -130,6 +130,94 @@ describe('createMCPIMiddleware', () => {
     });
   });
 
+  describe('_mcpi unified tool', () => {
+    it('should expose mcpiTool with name "_mcpi"', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      expect(mcpi.mcpiTool.name).toBe('_mcpi');
+      expect(mcpi.mcpiTool.inputSchema.properties?.action).toBeDefined();
+      expect(
+        (mcpi.mcpiTool.inputSchema.properties?.action as { enum?: string[] })?.enum,
+      ).toContain('handshake');
+      expect(
+        (mcpi.mcpiTool.inputSchema.properties?.action as { enum?: string[] })?.enum,
+      ).toContain('identity');
+      expect(mcpi.mcpiTool.inputSchema.required).toEqual(['action']);
+    });
+
+    it('should still expose handshakeTool as deprecated alias', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      expect(mcpi.handshakeTool).toBeDefined();
+      expect(mcpi.handshakeTool.name).toBe('_mcpi_handshake');
+    });
+
+    it('should dispatch action: "handshake" to handleHandshake', async () => {
+      const { middleware: mcpi, did } = await createTestMiddleware();
+      const result = await mcpi.handleMCPI({
+        action: 'handshake',
+        nonce: 'test-nonce',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(parsed.sessionId).toMatch(/^mcpi_/);
+    });
+
+    it('should dispatch action: "identity" and return server metadata', async () => {
+      const { middleware: mcpi, did } = await createTestMiddleware();
+      const result = await mcpi.handleMCPI({ action: 'identity' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.did).toBe(did);
+      expect(parsed.kid).toContain('#keys-1');
+      expect(parsed.capabilities).toContain('handshake');
+      expect(parsed.capabilities).toContain('signing');
+      expect(parsed.capabilities).toContain('verification');
+    });
+
+    it('should return error for unknown action', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const result = await mcpi.handleMCPI({ action: 'does_not_exist' });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe('XMCP_I_EUNKNOWN_ACTION');
+    });
+
+    it('should return error when action is missing', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const result = await mcpi.handleMCPI({});
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe('XMCP_I_EUNKNOWN_ACTION');
+    });
+
+    it('should return "not implemented" for action: "reputation"', async () => {
+      const { middleware: mcpi } = await createTestMiddleware();
+      const result = await mcpi.handleMCPI({ action: 'reputation' });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe('XMCP_I_ENOT_IMPLEMENTED');
+    });
+
+    it('should still support handleHandshake() directly (backward compat)', async () => {
+      const { middleware: mcpi, did } = await createTestMiddleware();
+      const result = await mcpi.handleHandshake({
+        nonce: 'legacy-nonce',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
   describe('wrapWithProof', () => {
     it('should attach proof in _meta after handshake', async () => {
       const { middleware: mcpi, did } = await createTestMiddleware();

--- a/src/middleware/mcpi-transport.ts
+++ b/src/middleware/mcpi-transport.ts
@@ -53,7 +53,7 @@ type ToolResult = {
 export function createMCPITransport(
   inner: Transport,
   mcpi: MCPIMiddleware,
-  exclude: string[] = ["_mcpi_handshake"],
+  exclude: string[] = ["_mcpi", "_mcpi_handshake"],
 ): Transport {
   // Request id → { toolName, args } for pending tool calls
   const pending = new Map<unknown, PendingCall>();

--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -14,6 +14,7 @@
 import type { CryptoProvider } from "../providers/base.js";
 import { generateDidKeyFromBase64 } from "../utils/did-helpers.js";
 import {
+  MCPI_ACTIONS,
   createMCPIMiddleware,
   type MCPIIdentityConfig,
   type MCPIDelegationConfig,
@@ -37,6 +38,12 @@ export interface WithMCPIOptions {
   excludeTools?: string[];
   /** Delegation verification config */
   delegation?: MCPIDelegationConfig;
+  /**
+   * How the MCP-I protocol tool is exposed on the server.
+   * - "tool" (default): auto-register `_mcpi`
+   * - "none": do not register MCP-I tool (use middleware APIs for custom runtime hooks)
+   */
+  handshakeExposure?: "tool" | "none";
 }
 
 /**
@@ -73,7 +80,7 @@ interface McpServerLike {
  * Add MCP-I to a McpServer instance.
  *
  * 1. Auto-generates Ed25519 identity (or uses provided one)
- * 2. Registers `_mcpi_handshake` tool
+ * 2. Registers `_mcpi` tool by default (`handshakeExposure: "tool"`)
  * 3. Patches `server.connect()` to transparently wrap the transport with
  *    MCPITransport, which injects detached proofs into all `tools/call`
  *    responses using only the public Transport interface.
@@ -107,30 +114,47 @@ export async function withMCPI(
     options.crypto,
   );
 
-  // Register _mcpi_handshake tool
-  server.registerTool(
-    "_mcpi_handshake",
-    {
-      description:
-        "MCP-I identity handshake — establishes a cryptographic session",
-      inputSchema: {
-        nonce: z.string().describe("Client-generated unique nonce"),
-        audience: z
-          .string()
-          .describe("Intended audience (server DID or URL)"),
-        timestamp: z.number().describe("Unix epoch seconds"),
+  if ((options.handshakeExposure ?? "tool") === "tool") {
+    // Register the unified _mcpi tool for protocol operations.
+    server.registerTool(
+      "_mcpi",
+      {
+        description:
+          "MCP-I protocol — identity verification, session handshake, and server metadata",
+        annotations: { title: "MCP-I Protocol", readOnlyHint: true },
+        inputSchema: {
+          action: z
+            .enum(MCPI_ACTIONS)
+            .describe("Protocol operation to perform"),
+          nonce: z
+            .string()
+            .optional()
+            .describe("Client-generated unique nonce (handshake)"),
+          audience: z
+            .string()
+            .optional()
+            .describe("Intended audience (handshake)"),
+          timestamp: z
+            .number()
+            .optional()
+            .describe("Unix epoch seconds (handshake)"),
+          agentDid: z
+            .string()
+            .optional()
+            .describe("Client agent DID (handshake, optional)"),
+        },
       },
-    },
-    async (args: unknown) => {
-      const result = await mcpi.handleHandshake(
-        args as Record<string, unknown>,
-      );
-      return {
-        ...result,
-        content: result.content.map((c) => ({ ...c, type: "text" as const })),
-      };
-    },
-  );
+      async (args: unknown) => {
+        const result = await mcpi.handleMCPI(
+          args as Record<string, unknown>,
+        );
+        return {
+          ...result,
+          content: result.content.map((c) => ({ ...c, type: "text" as const })),
+        };
+      },
+    );
+  }
 
   // Auto-proof interception via transport wrapper (public API only).
   //
@@ -139,7 +163,7 @@ export async function withMCPI(
   // Tool registration order does not matter — proofs are injected at the
   // transport boundary, after McpServer has already dispatched the call.
   if (options.proofAllTools !== false) {
-    const exclude = ["_mcpi_handshake", ...(options.excludeTools ?? [])];
+    const exclude = ["_mcpi", "_mcpi_handshake", ...(options.excludeTools ?? [])];
     const originalConnect = server.connect.bind(server);
 
     server.connect = (transport: Transport) =>

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -4,8 +4,8 @@
  * Adds identity, session management, and proof generation to MCP servers.
  *
  * For most use cases, prefer the high-level `withMCPI()` adapter from
- * `./with-mcpi-server.ts` which auto-registers the handshake tool and
- * auto-attaches proofs to all tool responses:
+ * `./with-mcpi-server.ts` which (by default) auto-registers the handshake
+ * tool and auto-attaches proofs to all tool responses:
  *
  *   import { withMCPI } from '@mcp-i/core';
  *   await withMCPI(server, { crypto: new NodeCryptoProvider() });
@@ -55,7 +55,11 @@ export interface MCPIIdentityConfig {
   kid: string;
   privateKey: string;
   publicKey: string;
+  agentName?: string;
 }
+
+export const MCPI_ACTIONS = ["handshake", "identity", "reputation"] as const;
+type MCPIAction = (typeof MCPI_ACTIONS)[number];
 
 export interface MCPIDelegationConfig {
   /**
@@ -103,8 +107,8 @@ export interface MCPIConfig {
   /**
    * When true, automatically creates a session on the first tool call
    * if no session exists. Useful for demos and development where
-   * MCP clients don't support the _mcpi_handshake flow.
-   * In production, MCP-I-aware clients handle handshake automatically.
+   * MCP clients don't support the `_mcpi` handshake flow.
+   * In production, MCP-I-aware runtimes should execute handshake before tool calls.
    */
   autoSession?: boolean;
 }
@@ -155,12 +159,29 @@ export interface MCPIMiddleware {
   proofGenerator: ProofGenerator;
 
   /**
+   * Unified tool definition for `_mcpi`.
+   * Include this in your ListToolsRequest handler's tool list.
+   */
+  mcpiTool: MCPIToolDefinition;
+
+  /**
+   * @deprecated Use `mcpiTool` (`_mcpi` with `action: "handshake"`).
    * Tool definition for `_mcpi_handshake`.
    * Include this in your ListToolsRequest handler's tool list.
    */
   handshakeTool: MCPIToolDefinition;
 
   /**
+   * Handle a unified `_mcpi` action. Use this in your CallToolRequest handler
+   * when `request.params.name === '_mcpi'`.
+   */
+  handleMCPI(args: Record<string, unknown>): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+
+  /**
+   * @deprecated Use `handleMCPI` with `action: "handshake"`.
    * Handle a handshake call. Use this in your CallToolRequest handler
    * when `request.params.name === '_mcpi_handshake'`.
    */
@@ -267,7 +288,8 @@ function validateScopeAttenuation(
  * Create MCP-I middleware for a standard MCP SDK Server.
  *
  * For most use cases, prefer {@link withMCPI} from `./with-mcpi-server.ts`
- * which wraps this function and auto-registers handshake + auto-attaches proofs.
+ * which wraps this function and (by default) auto-registers handshake +
+ * auto-attaches proofs.
  *
  * Use `createMCPIMiddleware` directly when:
  * - You use the low-level `Server` API (not `McpServer`)
@@ -331,6 +353,33 @@ export function createMCPIMiddleware(
     },
   };
 
+  const mcpiTool: MCPIToolDefinition = {
+    name: "_mcpi",
+    description:
+      "MCP-I protocol — identity verification, session handshake, and server metadata",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          enum: [...MCPI_ACTIONS],
+          description: "Protocol operation to perform",
+        },
+        nonce: { type: "string", description: "Client-generated unique nonce" },
+        audience: {
+          type: "string",
+          description: "Intended audience (server DID or URL)",
+        },
+        timestamp: { type: "number", description: "Unix epoch seconds" },
+        agentDid: {
+          type: "string",
+          description: "Client agent DID (optional)",
+        },
+      },
+      required: ["action"],
+    },
+  };
+
   async function handleHandshake(args: Record<string, unknown>): Promise<{
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
@@ -381,9 +430,82 @@ export function createMCPIMiddleware(
     };
   }
 
+  async function handleIdentity(): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }> {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            did: identity.did,
+            kid: identity.kid,
+            name: config.identity.agentName ?? identity.did,
+            capabilities: ["handshake", "signing", "verification"],
+            protocolVersion: "1.0.0",
+          }),
+        },
+      ],
+    };
+  }
+
+  async function handleMCPI(args: Record<string, unknown>): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }> {
+    const action =
+      typeof args.action === "string"
+        ? (args.action as MCPIAction)
+        : undefined;
+
+    switch (action) {
+      case "handshake":
+        return handleHandshake(args);
+
+      case "identity":
+        return handleIdentity();
+
+      case "reputation":
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: {
+                  code: "XMCP_I_ENOT_IMPLEMENTED",
+                  message:
+                    'action: "reputation" is not yet implemented.',
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+
+      default:
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: {
+                  code: "XMCP_I_EUNKNOWN_ACTION",
+                  message: `Unknown _mcpi action: "${action ?? "(missing)"}". Valid actions: ${MCPI_ACTIONS.join(", ")}`,
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+    }
+  }
+
   /**
    * Auto-create a session for proof generation when no handshake has occurred.
-   * In production, MCP-I-aware clients handle the handshake automatically.
+   * In production, MCP-I-aware runtimes should execute handshake before tool calls.
    * This convenience mode allows non-MCP-I clients (like MCP Inspector) to
    * still see proofs without manual handshake.
    */
@@ -780,7 +902,9 @@ export function createMCPIMiddleware(
     identity: config.identity,
     sessionManager,
     proofGenerator,
+    mcpiTool,
     handshakeTool,
+    handleMCPI,
     handleHandshake,
     wrapWithProof,
     wrapWithDelegation,


### PR DESCRIPTION
## Summary

- Adds `examples/consent-full/` — same MCP-I consent flow as consent-basic, but the consent page is rendered by [`@kya-os/consent`](https://www.npmjs.com/package/@kya-os/consent) via `generateConsentShell()`
- Demonstrates multi-mode auth (consent-only default, credentials via `AUTH_MODE` env var), configurable branding (`BRAND_COLOR`, `COMPANY_NAME`), loading skeleton, and no-JS fallback
- No template files — the entire consent UI is generated by the `<mcp-consent>` web component

### What's different from consent-basic?

| | consent-basic | consent-full |
|---|---|---|
| **Consent UI** | Hand-rolled HTML + vanilla JS | `@kya-os/consent` web component |
| **Auth modes** | Consent-only | Consent-only + credentials |
| **Branding** | Hardcoded dark theme | Configurable via env vars |
| **Loading UX** | None | Skeleton loader + no-JS fallback |
| **Approval format** | JSON POST to `/approve` | FormData POST to `/consent/approve` |
| **Template** | `public/consent.html` (215 lines) | `generateConsentShell()` (zero template files) |

## Test plan

- [x] 41 tests pass across 4 test files (delegation, consent-server, server, e2e)
- [x] consent-basic tests still pass (35 tests)
- [x] Manual test: consent page renders `<mcp-consent>` component in browser
- [x] Manual test: credentials mode with `AUTH_MODE=credentials`
- [x] CI passes on Node 20/22