### PR TITLE
fix: StatusList2021 fails closed when no resolver configured

### DIFF
--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -471,7 +471,7 @@ describe("DelegationCredentialVerifier", () => {
       expect(mockStatusListResolver.checkStatus).not.toHaveBeenCalled();
     });
 
-    it("should skip status checking when no resolver available", async () => {
+    it("should fail closed when no status resolver available but credential has credentialStatus", async () => {
       await setupDefaultContractsMocks();
       const verifierWithoutResolver = new DelegationCredentialVerifier({
         didResolver: mockDidResolver,
@@ -506,8 +506,9 @@ describe("DelegationCredentialVerifier", () => {
       const result =
         await verifierWithoutResolver.verifyDelegationCredential(vcWithStatus);
 
-      expect(result.valid).toBe(true);
-      expect(result.checks?.statusValid).toBe(true); // Trust but don't verify
+      expect(result.valid).toBe(false);
+      expect(result.checks?.statusValid).toBe(false);
+      expect(result.reason).toContain("no status list resolver is configured");
     });
 
     it("should fail when credential is revoked", async () => {

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -350,8 +350,9 @@ export class DelegationCredentialVerifier {
     try {
       if (!statusListResolver) {
         return {
-          valid: true,
-          reason: "No status list resolver available, skipping status check",
+          valid: false,
+          reason:
+            "Credential has credentialStatus but no status list resolver is configured — cannot verify revocation status",
           durationMs: Date.now() - startTime,
         };
       }

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -760,8 +760,13 @@ export function createMCPIMiddleware(
           }
         }
 
+        const skipStatusForLegacy =
+          legacyUnsafeDelegationEnabled &&
+          !!credential.credentialStatus &&
+          !delegationConfig?.statusListResolver;
         const credentialVerification = await verifier.verifyDelegationCredential(
           credential,
+          skipStatusForLegacy ? { skipStatus: true } : undefined,
         );
         if (!credentialVerification.valid) {
           return {


### PR DESCRIPTION
## Summary
- **Security fix:** `checkCredentialStatus()` in `vc-verifier.ts` returned `valid: true` when no `statusListResolver` was configured, allowing a credential with a `credentialStatus` field (i.e. one the issuer intended to be revocation-checkable) to pass verification even if revoked. Now returns `valid: false` (fail closed), matching the existing pattern in `verifySignature()`.
- **Legacy mode preserved:** The middleware's `allowLegacyUnsafeDelegation` path now explicitly passes `skipStatus: true` to the verifier so the intentional opt-in bypass still works.
- **Test corrected:** The test that previously asserted the broken behavior (`// Trust but don't verify`) now asserts fail-closed.

## Impact
- Consumers using the middleware without a `statusListResolver` are **unaffected** — the middleware already rejected this case at line 750-758 before the verifier was reached.
- Consumers using `allowLegacyUnsafeDelegation: true` are **unaffected** — the explicit `skipStatus` bypass preserves existing behavior.
- Consumers calling `DelegationCredentialVerifier` directly without a resolver will now correctly get `valid: false` instead of a silent pass.
- Same bug exists in upstream `@mcp-i/core@1.1.0-canary.2` — should be upstreamed.

## Test plan
- [x] `vc-verifier.test.ts` — 38 tests pass (including updated fail-closed assertion)
- [x] `with-mcpi.test.ts` — legacy mode test passes with skipStatus bypass
- [x] Full suite — 712/712 tests pass