### PR TITLE
fix: surface proof generation failures instead of silently swallowing

### DIFF
--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   createMCPIMiddleware,
   type MCPIDelegationConfig,
@@ -36,7 +36,7 @@ async function createTestMiddleware(options?: {
     crypto,
   );
 
-  return { middleware, did };
+  return { middleware, did, crypto };
 }
 
 async function createDelegationIssuer(options?: { did?: string; kid?: string }) {
@@ -282,6 +282,36 @@ describe('createMCPIMiddleware', () => {
       const result = await handler({});
       expect(result.content[0].text).toBe('Hello!');
       expect(result._meta).toBeUndefined();
+    });
+
+    it('should surface proofError in _meta when proof generation fails', async () => {
+      const { middleware: mcpi, did, crypto } = await createTestMiddleware();
+
+      // Handshake first
+      const hs = await mcpi.handleHandshake({
+        nonce: 'test-nonce-proof-fail',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      // Make crypto.hash throw to break proof generation after handshake succeeds
+      vi.spyOn(crypto, 'hash').mockRejectedValue(new Error('HSM unavailable'));
+
+      const handler = mcpi.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'Hello!' }],
+      }));
+
+      const result = await handler({}, sessionId);
+
+      // Tool result still returned
+      expect(result.content[0].text).toBe('Hello!');
+      expect(result.isError).toBeUndefined();
+
+      // But _meta signals the proof failure
+      expect(result._meta).toBeDefined();
+      expect(result._meta!.proofError).toBeDefined();
+      expect(result._meta!.proof).toBeUndefined();
     });
   });
 

--- a/src/middleware/mcpi-transport.ts
+++ b/src/middleware/mcpi-transport.ts
@@ -18,6 +18,7 @@
  */
 
 import type { MCPIMiddleware, MCPIToolHandler } from "./with-mcpi.js";
+import { logger } from "../logging/index.js";
 
 /** Minimal Transport interface — matches @modelcontextprotocol/sdk Transport */
 export interface Transport {
@@ -106,9 +107,18 @@ export function createMCPITransport(
               };
             }
           }
-        } catch {
-          // Proof generation failure must never block the tool response.
-          // The result still reaches the client; the proof is simply absent.
+        } catch (error) {
+          logger.error("[mcpi-transport] Proof injection failed", {
+            tool: call.toolName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          const rawResult = message.result as ToolResult | undefined;
+          if (rawResult) {
+            rawResult._meta = {
+              proofError: "Proof generation failed — response is unproven",
+            };
+            message = { ...message, result: rawResult };
+          }
         }
       }
 

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -571,8 +571,14 @@ export function createMCPIMiddleware(
 
         // Attach proof as _meta (rendered by MCP Inspector, invisible to LLMs)
         result._meta = { proof };
-      } catch {
-        // Proof generation failure is non-fatal — the tool result is still valid
+      } catch (error) {
+        logger.error("[mcpi] Proof generation failed", {
+          tool: toolName,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        result._meta = {
+          proofError: "Proof generation failed — response is unproven",
+        };
       }
 
       return result;


### PR DESCRIPTION
## Summary
- **with-mcpi.ts:574-576** and **mcpi-transport.ts:109-112** had empty catch blocks that silently swallowed proof generation errors, sending unproven responses with no signal to the client or server operator.
- Now on failure: logs via `logger.error` and sets `_meta.proofError` so the client can distinguish "no proof support" from "proof generation broke". The tool result still goes through (non-fatal).
- Same pattern exists in upstream `@mcp-i/core@1.1.0-canary.2`.

## Impact
- No breaking changes — responses still return successfully on proof failure.
- Clients that inspect `_meta` will now see `proofError` instead of a missing `proof` with no explanation.
- Server operators get error logs for proof failures that were previously invisible.

## Test plan
- [x] New test: `should surface proofError in _meta when proof generation fails` — verifies tool result returns, `_meta.proofError` is set, `_meta.proof` is absent
- [x] Full suite — 713/713 tests pass