### PR TITLE
feat: unknownAgentPolicy — separate unknown agents from low-score agents

### DIFF
--- a/src/auth/__tests__/handshake.test.ts
+++ b/src/auth/__tests__/handshake.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  verifyOrHints,
+  MemoryResumeTokenStore,
+  type AuthHandshakeConfig,
+} from '../handshake.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function createConfig(overrides?: {
+  minReputationScore?: number;
+  unknownAgentPolicy?: 'deny' | 'require-consent' | 'allow';
+  reputationApiUrl?: string;
+}): AuthHandshakeConfig {
+  return {
+    delegationVerifier: {
+      verify: vi.fn().mockResolvedValue({ valid: false, reason: 'No delegation' }),
+    },
+    resumeTokenStore: new MemoryResumeTokenStore(),
+    reputationService: {
+      apiUrl: overrides?.reputationApiUrl ?? 'https://reputation.example.com',
+    },
+    authorization: {
+      authorizationUrl: 'https://example.com/consent',
+      minReputationScore: overrides?.minReputationScore ?? 30,
+      unknownAgentPolicy: overrides?.unknownAgentPolicy,
+    },
+  };
+}
+
+function mockReputationResponse(score: number, status = 200) {
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => ({ score }),
+  });
+}
+
+function mockReputationNotFound() {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status: 404,
+    statusText: 'Not Found',
+  });
+}
+
+function mockReputationNetworkError() {
+  mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+}
+
+describe('verifyOrHints — unknownAgentPolicy', () => {
+  const agentDid = 'did:key:z6MkTest';
+  const scopes = ['read:data'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('known agents (reputation service returns a score)', () => {
+    it('should reject known agent with score below threshold', async () => {
+      const config = createConfig({ minReputationScore: 30 });
+      mockReputationResponse(10);
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Low reputation score');
+      expect(result.reputation?.score).toBe(10);
+    });
+
+    it('should allow known agent with score above threshold to proceed to delegation', async () => {
+      const config = createConfig({ minReputationScore: 30 });
+      mockReputationResponse(80);
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      // Not authorized (no delegation), but passed reputation gate
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('No delegation');
+      expect(result.reputation?.score).toBe(80);
+    });
+  });
+
+  describe('unknown agents (404 from reputation service)', () => {
+    it('should deny unknown agent when policy is "deny"', async () => {
+      const config = createConfig({ unknownAgentPolicy: 'deny' });
+      mockReputationNotFound();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Unknown agent — policy: deny');
+      expect(result.reputation?.score).toBeNull();
+    });
+
+    it('should require consent for unknown agent when policy is "require-consent"', async () => {
+      const config = createConfig({ unknownAgentPolicy: 'require-consent' });
+      mockReputationNotFound();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Unknown agent — policy: require-consent');
+      expect(result.authError).toBeDefined();
+      expect(result.reputation?.score).toBeNull();
+    });
+
+    it('should default to "require-consent" when no policy is set', async () => {
+      const config = createConfig(); // no unknownAgentPolicy
+      mockReputationNotFound();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Unknown agent — policy: require-consent');
+    });
+
+    it('should allow unknown agent when policy is "allow"', async () => {
+      const config = createConfig({ unknownAgentPolicy: 'allow' });
+      mockReputationNotFound();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      // Not authorized (no delegation), but passed reputation gate
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('No delegation');
+      expect(result.reputation?.score).toBeNull();
+    });
+  });
+
+  describe('reputation service unreachable (network error)', () => {
+    it('should treat network errors as unknown agent', async () => {
+      const config = createConfig({ unknownAgentPolicy: 'deny' });
+      mockReputationNetworkError();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Unknown agent — policy: deny');
+      expect(result.reputation?.score).toBeNull();
+      expect(result.reputation?.riskLevel).toBe('unknown');
+    });
+
+    it('should route to consent on network error with default policy', async () => {
+      const config = createConfig(); // default = require-consent
+      mockReputationNetworkError();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('Unknown agent — policy: require-consent');
+      expect(result.authError).toBeDefined();
+    });
+
+    it('should allow through on network error when policy is "allow"', async () => {
+      const config = createConfig({ unknownAgentPolicy: 'allow' });
+      mockReputationNetworkError();
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      // Passes reputation gate, fails on delegation
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe('No delegation');
+    });
+  });
+
+  describe('no reputation service configured', () => {
+    it('should skip reputation check entirely when no service configured', async () => {
+      const config: AuthHandshakeConfig = {
+        delegationVerifier: {
+          verify: vi.fn().mockResolvedValue({ valid: false, reason: 'No delegation' }),
+        },
+        resumeTokenStore: new MemoryResumeTokenStore(),
+        // No reputationService
+        authorization: {
+          authorizationUrl: 'https://example.com/consent',
+          minReputationScore: 30,
+        },
+      };
+
+      const result = await verifyOrHints(agentDid, scopes, config);
+
+      expect(result.reputation).toBeUndefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/auth/handshake.ts
+++ b/src/auth/handshake.ts
@@ -23,12 +23,21 @@ export type { DelegationVerifier, VerifyDelegationResult };
 
 export interface AgentReputation {
   agentDid: string;
-  score: number;
+  score: number | null;
   totalInteractions: number;
   successRate: number;
   riskLevel: 'low' | 'medium' | 'high' | 'unknown';
   updatedAt: number;
 }
+
+/**
+ * Policy for handling agents with no reputation history.
+ *
+ * - 'deny'            — reject unknown agents outright (strict environments)
+ * - 'require-consent' — route to the consent/authorization flow (default)
+ * - 'allow'           — let unknown agents through (reputation is advisory only)
+ */
+export type UnknownAgentPolicy = 'deny' | 'require-consent' | 'allow';
 
 export interface AuthHandshakeConfig {
   delegationVerifier: DelegationVerifier;
@@ -41,7 +50,15 @@ export interface AuthHandshakeConfig {
   authorization: {
     authorizationUrl: string;
     resumeTokenTtl?: number;
-    requireAuthForUnknown?: boolean;
+    /**
+     * How to handle agents with no reputation history (404 from reputation
+     * service, network error, or first-time agent).
+     *
+     * - 'deny'            — reject outright
+     * - 'require-consent' — route to consent flow (default)
+     * - 'allow'           — skip reputation gate for unknowns
+     */
+    unknownAgentPolicy?: UnknownAgentPolicy;
     minReputationScore?: number;
   };
   debug?: boolean;
@@ -202,36 +219,85 @@ export async function verifyOrHints(
 
   let reputation: AgentReputation | undefined;
   if (config.reputationService && config.authorization.minReputationScore !== undefined) {
+    const unknownPolicy = config.authorization.unknownAgentPolicy ?? 'require-consent';
+
     try {
       reputation = await fetchAgentReputation(agentDid, config.reputationService);
+    } catch (error) {
+      logger.error('[AuthHandshake] Reputation service unreachable, treating agent as unknown:', error);
+      reputation = {
+        agentDid,
+        score: null,
+        totalInteractions: 0,
+        successRate: 0,
+        riskLevel: 'unknown',
+        updatedAt: Date.now(),
+      };
+    }
 
-      if (config.debug) {
-        logger.debug(`[AuthHandshake] Reputation score: ${reputation.score}`);
-      }
+    if (config.debug) {
+      logger.debug(`[AuthHandshake] Reputation score: ${reputation.score}`);
+    }
 
-      if (reputation.score < config.authorization.minReputationScore) {
-        if (config.debug) {
-          logger.debug(
-            `[AuthHandshake] Reputation ${reputation.score} < ${config.authorization.minReputationScore}, requiring authorization`
-          );
-        }
-
+    // Unknown agent (no reputation data)
+    if (reputation.score === null) {
+      if (unknownPolicy === 'deny') {
         const authError = await buildNeedsAuthorizationError(
           agentDid,
           scopes,
           config,
-          'Agent reputation score below threshold'
+          'Unknown agent denied by policy'
         );
-
         return {
           authorized: false,
           authError,
           reputation,
-          reason: 'Low reputation score',
+          reason: 'Unknown agent — policy: deny',
         };
       }
-    } catch (error) {
-      logger.warn('[AuthHandshake] Failed to check reputation:', error);
+
+      if (unknownPolicy === 'require-consent') {
+        const authError = await buildNeedsAuthorizationError(
+          agentDid,
+          scopes,
+          config,
+          'Unknown agent requires consent'
+        );
+        return {
+          authorized: false,
+          authError,
+          reputation,
+          reason: 'Unknown agent — policy: require-consent',
+        };
+      }
+
+      // unknownPolicy === 'allow' — skip reputation gate, continue to delegation check
+      if (config.debug) {
+        logger.debug('[AuthHandshake] Unknown agent allowed by policy, skipping reputation gate');
+      }
+    }
+
+    // Known agent with score below threshold
+    if (reputation.score !== null && reputation.score < config.authorization.minReputationScore) {
+      if (config.debug) {
+        logger.debug(
+          `[AuthHandshake] Reputation ${reputation.score} < ${config.authorization.minReputationScore}, requiring authorization`
+        );
+      }
+
+      const authError = await buildNeedsAuthorizationError(
+        agentDid,
+        scopes,
+        config,
+        'Agent reputation score below threshold'
+      );
+
+      return {
+        authorized: false,
+        authError,
+        reputation,
+        reason: 'Low reputation score',
+      };
     }
   }
 
@@ -325,7 +391,7 @@ async function fetchAgentReputation(
     if (response.status === 404) {
       return {
         agentDid,
-        score: 50,
+        score: null,
         totalInteractions: 0,
         successRate: 0,
         riskLevel: 'unknown',
@@ -337,7 +403,7 @@ async function fetchAgentReputation(
 
   const data = (await response.json()) as Record<string, unknown>;
 
-  const score = (data['score'] as number | undefined) ?? 50;
+  const score = (data['score'] as number | undefined) ?? 0;
   const levelRaw = (
     (data['level'] as string | undefined) ??
     (data['riskLevel'] as string | undefined) ??

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -6,6 +6,7 @@ export {
   type VerifyOrHintsResult,
   type AgentReputation,
   type ResumeTokenStore,
+  type UnknownAgentPolicy,
 } from './handshake.js';
 
 export type { DelegationVerifier, VerifyDelegationResult } from './types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ export {
   type VerifyOrHintsResult,
   type AgentReputation,
   type ResumeTokenStore,
+  type UnknownAgentPolicy,
   type DelegationVerifier,
   type VerifyDelegationResult,
 } from './auth/index.js';


### PR DESCRIPTION
## Summary

The reputation service conflated "unknown agent" (no reputation data) with "known agent with a low score" by returning `score: 50` as a default for 404s. This meant unknown agents silently passed any threshold below 50, and network errors silently skipped the reputation gate entirely.

**Changes:**
- New `UnknownAgentPolicy` type: `'deny' | 'require-consent' | 'allow'`
- `fetchAgentReputation` returns `score: null` for 404 (unknown agent) instead of `score: 50`
- Network errors are caught and treated as unknown (logged, not silently skipped)
- `verifyOrHints` applies the policy for unknown agents separately from the numeric score threshold for known agents
- Default policy is `'require-consent'` — unknown agents route to consent flow
- Removed dead `requireAuthForUnknown` config field (was defined but never read)
- Added `docs/fail-modes.md` cataloguing all 11 external dependencies with current behavior, recommendations, and spec language

**Type change:** `AgentReputation.score` is now `number | null` to distinguish "no data" from "score is 0".

## Configuration

```typescript
authorization: {
  minReputationScore: 30,                // gate for KNOWN agents
  unknownAgentPolicy: 'require-consent', // policy for UNKNOWN agents (default)
}
```

| Policy | Use case |
|--------|----------|
| `'deny'` | High-security (bank, medical) — no unknowns allowed |
| `'require-consent'` | Standard SaaS — unknowns go through consent flow (default) |
| `'allow'` | Open platforms — reputation is advisory only |

## Test plan
- [x] New test suite: `src/auth/__tests__/handshake.test.ts` — 10 tests covering all policy variants, network errors, and known-agent thresholds
- [x] Full suite — 722/722 tests pass (38 files)