### PR TITLE
feat: unified error contract — canonical snake_case codes

### DIFF
--- a/examples/consent-basic/__tests__/e2e.test.ts
+++ b/examples/consent-basic/__tests__/e2e.test.ts
@@ -141,7 +141,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     const result = await checkoutHandler({ item: 'laptop', _mcpi_delegation: vc });
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content[0]!.text) as { error: string };
-    expect(parsed.error).toBe('delegation_scope_missing');
+    expect(parsed.error).toBe('insufficient_scope');
   });
 
   // Deny flow

--- a/examples/consent-basic/__tests__/server.test.ts
+++ b/examples/consent-basic/__tests__/server.test.ts
@@ -138,7 +138,7 @@ describe('MCP Server with consent-basic', () => {
 
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content[0]!.text) as { error: string };
-    expect(parsed.error).toBe('delegation_scope_missing');
+    expect(parsed.error).toBe('insufficient_scope');
   });
 
   // §4.2 — Expired delegation

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -141,7 +141,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     const result = await checkoutHandler({ item: 'laptop', _mcpi_delegation: vc });
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content[0]!.text) as { error: string };
-    expect(parsed.error).toBe('delegation_scope_missing');
+    expect(parsed.error).toBe('insufficient_scope');
   });
 
   // Deny flow

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -165,7 +165,7 @@ describe('MCP Server with consent-full', () => {
 
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content[0]!.text) as { error: string };
-    expect(parsed.error).toBe('delegation_scope_missing');
+    expect(parsed.error).toBe('insufficient_scope');
   });
 
   // §4.2 — Expired delegation

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  MCPI_ERROR_CODES,
+  createMCPIError,
+} from "../errors.js";
+
+describe("MCPI_ERROR_CODES", () => {
+  it("should define all canonical error codes", () => {
+    const codes = Object.values(MCPI_ERROR_CODES);
+    expect(codes).toContain("invalid_proof");
+    expect(codes).toContain("invalid_jws");
+    expect(codes).toContain("nonce_replay");
+    expect(codes).toContain("timestamp_skew");
+    expect(codes).toContain("did_not_found");
+    expect(codes).toContain("invalid_public_key");
+    expect(codes).toContain("handshake_failed");
+    expect(codes).toContain("session_expired");
+    expect(codes).toContain("invalid_request");
+    expect(codes).toContain("needs_authorization");
+    expect(codes).toContain("insufficient_scope");
+    expect(codes).toContain("delegation_expired");
+    expect(codes).toContain("delegation_not_yet_valid");
+    expect(codes).toContain("delegation_revoked");
+    expect(codes).toContain("delegation_invalid");
+    expect(codes).toContain("budget_exceeded");
+    expect(codes).toContain("rate_limit_exceeded");
+    expect(codes).toContain("invalid_token");
+    expect(codes).toContain("token_expired");
+    expect(codes).toContain("mirror_pending");
+    expect(codes).toContain("claim_failed");
+    expect(codes).toContain("configuration_error");
+    expect(codes).toContain("runtime_error");
+  });
+
+  it("should have key === value for every code", () => {
+    for (const [key, value] of Object.entries(MCPI_ERROR_CODES)) {
+      expect(key).toBe(value);
+    }
+  });
+});
+
+describe("createMCPIError", () => {
+  it("should create an error response with code and message", () => {
+    const error = createMCPIError("handshake_failed", "Nonce already used");
+    expect(error.code).toBe("handshake_failed");
+    expect(error.message).toBe("Nonce already used");
+    expect(error.details).toBeUndefined();
+  });
+
+  it("should include details when provided", () => {
+    const error = createMCPIError("delegation_revoked", "Credential revoked", {
+      credentialId: "urn:uuid:123",
+    });
+    expect(error.details).toEqual({ credentialId: "urn:uuid:123" });
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP-I Canonical Error Codes
+ *
+ * Single source of truth for all wire-format error codes.
+ * Aligned with the error catalog at modelcontextprotocol-identity.io.
+ *
+ * Naming convention: snake_case, no protocol prefix.
+ * Follows OAuth 2.0 / Stripe conventions for readability and portability.
+ */
+
+export const MCPI_ERROR_CODES = {
+  // Proof errors
+  invalid_proof: "invalid_proof",
+  invalid_jws: "invalid_jws",
+  nonce_replay: "nonce_replay",
+  timestamp_skew: "timestamp_skew",
+
+  // Identity / DID errors
+  did_not_found: "did_not_found",
+  invalid_public_key: "invalid_public_key",
+
+  // Session / Handshake errors
+  handshake_failed: "handshake_failed",
+  session_expired: "session_expired",
+  invalid_request: "invalid_request",
+
+  // Delegation errors
+  needs_authorization: "needs_authorization",
+  insufficient_scope: "insufficient_scope",
+  delegation_expired: "delegation_expired",
+  delegation_not_yet_valid: "delegation_not_yet_valid",
+  delegation_revoked: "delegation_revoked",
+  delegation_invalid: "delegation_invalid",
+  budget_exceeded: "budget_exceeded",
+  rate_limit_exceeded: "rate_limit_exceeded",
+
+  // Token errors
+  invalid_token: "invalid_token",
+  token_expired: "token_expired",
+
+  // Registry errors
+  mirror_pending: "mirror_pending",
+  claim_failed: "claim_failed",
+
+  // System errors
+  configuration_error: "configuration_error",
+  runtime_error: "runtime_error",
+} as const;
+
+export type MCPIErrorCode =
+  (typeof MCPI_ERROR_CODES)[keyof typeof MCPI_ERROR_CODES];
+
+export interface MCPIErrorResponse {
+  code: MCPIErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export function createMCPIError(
+  code: MCPIErrorCode,
+  message: string,
+  details?: Record<string, unknown>,
+): MCPIErrorResponse {
+  return details ? { code, message, details } : { code, message };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,14 @@
  * This ensures callers can always handle failures without try/catch on validation paths.
  */
 
+// Error contract
+export {
+  MCPI_ERROR_CODES,
+  createMCPIError,
+  type MCPIErrorCode,
+  type MCPIErrorResponse,
+} from './errors.js';
+
 // Protocol types
 export type {
   DelegationConstraints,

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -126,7 +126,7 @@ describe('createMCPIMiddleware', () => {
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.success).toBe(false);
-      expect(parsed.error.code).toBe('MCPI_INVALID_HANDSHAKE');
+      expect(parsed.error.code).toBe('handshake_failed');
     });
   });
 
@@ -184,7 +184,7 @@ describe('createMCPIMiddleware', () => {
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.error.code).toBe('XMCP_I_EUNKNOWN_ACTION');
+      expect(parsed.error.code).toBe('invalid_request');
     });
 
     it('should return error when action is missing', async () => {
@@ -193,7 +193,7 @@ describe('createMCPIMiddleware', () => {
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.error.code).toBe('XMCP_I_EUNKNOWN_ACTION');
+      expect(parsed.error.code).toBe('invalid_request');
     });
 
     it('should return "not implemented" for action: "reputation"', async () => {
@@ -202,7 +202,7 @@ describe('createMCPIMiddleware', () => {
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.error.code).toBe('XMCP_I_ENOT_IMPLEMENTED');
+      expect(parsed.error.code).toBe('runtime_error');
     });
 
     it('should still support handleHandshake() directly (backward compat)', async () => {
@@ -350,7 +350,7 @@ describe('createMCPIMiddleware', () => {
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.error).toBe('delegation_scope_missing');
+      expect(parsed.error).toBe('insufficient_scope');
     });
 
     it('should accept and call handler when VC has correct scope and valid signature', async () => {

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -47,6 +47,7 @@ import {
   type DelegationRecord,
 } from "../types/protocol.js";
 import { logger } from "../logging/index.js";
+import { MCPI_ERROR_CODES } from "../errors.js";
 import { canonicalizeJSON } from "../delegation/utils.js";
 import { base64urlDecodeToBytes, base64urlEncodeFromBytes, bytesToBase64 } from "../utils/base64.js";
 
@@ -392,7 +393,7 @@ export function createMCPIMiddleware(
             text: JSON.stringify({
               success: false,
               error: {
-                code: "MCPI_INVALID_HANDSHAKE",
+                code: MCPI_ERROR_CODES.handshake_failed,
                 message:
                   "Invalid handshake format: requires nonce (string), audience (string), and timestamp (positive integer)",
               },
@@ -474,7 +475,7 @@ export function createMCPIMiddleware(
               text: JSON.stringify({
                 success: false,
                 error: {
-                  code: "XMCP_I_ENOT_IMPLEMENTED",
+                  code: MCPI_ERROR_CODES.runtime_error,
                   message:
                     'action: "reputation" is not yet implemented.',
                 },
@@ -492,7 +493,7 @@ export function createMCPIMiddleware(
               text: JSON.stringify({
                 success: false,
                 error: {
-                  code: "XMCP_I_EUNKNOWN_ACTION",
+                  code: MCPI_ERROR_CODES.invalid_request,
                   message: `Unknown _mcpi action: "${action ?? "(missing)"}". Valid actions: ${MCPI_ACTIONS.join(", ")}`,
                 },
               }),
@@ -880,7 +881,7 @@ export function createMCPIMiddleware(
           `[mcpi] Delegation verification failed for "${toolName}": ${verificationResult.reason}`,
         );
         return buildDelegationErrorResponse(
-          "delegation_invalid",
+          MCPI_ERROR_CODES.delegation_invalid,
           verificationResult.reason ?? "Unknown delegation validation error",
         );
       }
@@ -891,7 +892,7 @@ export function createMCPIMiddleware(
           `[mcpi] Delegation missing required scope "${config.scopeId}" for "${toolName}"`,
         );
         return buildDelegationErrorResponse(
-          "delegation_scope_missing",
+          MCPI_ERROR_CODES.insufficient_scope,
           `Required scope "${config.scopeId}" not in delegation scopes`,
         );
       }

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -88,7 +88,7 @@ describe("SessionManager", () => {
       const result = await manager.validateHandshake(request);
 
       expect(result.success).toBe(false);
-      expect(result.error?.code).toBe("XMCP_I_EHANDSHAKE");
+      expect(result.error?.code).toBe("handshake_failed");
     });
 
     it("should accept request within timestamp skew", async () => {
@@ -106,7 +106,7 @@ describe("SessionManager", () => {
       // Same request again (same nonce)
       const second = await manager.validateHandshake(request);
       expect(second.success).toBe(false);
-      expect(second.error?.code).toBe("XMCP_I_EHANDSHAKE");
+      expect(second.error?.code).toBe("handshake_failed");
     });
 
     it("should accept different nonces in succession", async () => {
@@ -261,7 +261,7 @@ describe("SessionManager", () => {
       const result = await sm.validateHandshake(request);
 
       expect(result.success).toBe(false);
-      expect(result.error?.code).toBe("MCPI_AUDIENCE_MISMATCH");
+      expect(result.error?.code).toBe("handshake_failed");
       expect(result.error?.message).toContain("Audience mismatch");
     });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -9,6 +9,7 @@
  * Cloudflare Workers) to remain synchronous without platform-specific imports.
  */
 
+import { MCPI_ERROR_CODES, type MCPIErrorCode } from "../errors.js";
 import type {
   HandshakeRequest,
   SessionContext,
@@ -32,7 +33,7 @@ export interface HandshakeResult {
   success: boolean;
   session?: SessionContext;
   error?: {
-    code: string;
+    code: MCPIErrorCode;
     message: string;
     remediation?: string;
   };
@@ -94,7 +95,7 @@ export class SessionManager {
         return {
           success: false,
           error: {
-            code: 'XMCP_I_EHANDSHAKE',
+            code: MCPI_ERROR_CODES.handshake_failed,
             message: `Timestamp outside acceptable range (±${this.config.timestampSkewSeconds}s)`,
             remediation: `Check NTP sync on client and server. Current server time: ${now}, received: ${request.timestamp}, diff: ${timeDiff}s. Adjust timestampSkewSeconds if needed.`,
           },
@@ -106,7 +107,7 @@ export class SessionManager {
         return {
           success: false,
           error: {
-            code: 'MCPI_AUDIENCE_MISMATCH',
+            code: MCPI_ERROR_CODES.handshake_failed,
             message: `Audience mismatch: expected ${this.config.serverDid}, got ${request.audience}`,
           },
         };
@@ -120,7 +121,7 @@ export class SessionManager {
         return {
           success: false,
           error: {
-            code: 'XMCP_I_EHANDSHAKE',
+            code: MCPI_ERROR_CODES.handshake_failed,
             message: 'Nonce already used (replay attack prevention)',
             remediation: 'Generate a new unique nonce for each request',
           },
@@ -160,7 +161,7 @@ export class SessionManager {
       return {
         success: false,
         error: {
-          code: 'XMCP_I_EHANDSHAKE',
+          code: MCPI_ERROR_CODES.handshake_failed,
           message: `Handshake validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         },
       };


### PR DESCRIPTION
## Summary

Replaces ad-hoc error codes with canonical snake_case codes aligned with the error catalog at modelcontextprotocol-identity.io. New `src/errors.ts` is the single source of truth.

**Before (5 competing patterns):**
- `MCPI_INVALID_HANDSHAKE`, `XMCP_I_EHANDSHAKE`, `MCPI_AUDIENCE_MISMATCH` (session)
- `XMCP_I_EUNKNOWN_ACTION`, `XMCP_I_ENOT_IMPLEMENTED` (middleware)
- `delegation_scope_missing`, `delegation_invalid` (delegation)
- `PROOF_VERIFICATION_ERROR_CODES.*` (proof — unchanged, internal diagnostic codes)
- `needs_authorization` (consent)

**After (one canonical set, 23 codes):**
`handshake_failed`, `session_expired`, `invalid_request`, `invalid_proof`, `invalid_jws`, `nonce_replay`, `timestamp_skew`, `did_not_found`, `invalid_public_key`, `needs_authorization`, `insufficient_scope`, `delegation_expired`, `delegation_not_yet_valid`, `delegation_revoked`, `delegation_invalid`, `budget_exceeded`, `rate_limit_exceeded`, `invalid_token`, `token_expired`, `mirror_pending`, `claim_failed`, `configuration_error`, `runtime_error`

**Design decisions:**
- Snake_case without protocol prefix (OAuth 2.0 / Stripe convention)
- `ProofVerificationError` fine-grained codes are untouched (internal diagnostics only)
- `HandshakeResult.error.code` narrowed from `string` to `MCPIErrorCode`
- `needs_authorization` unchanged (already correct)
- `invalid_request` added for unknown/missing `_mcpi` actions (distinct from `handshake_failed`)

## Files changed (11)
- `src/errors.ts` — new canonical error codes, `MCPIErrorCode` type, `MCPIErrorResponse` interface, `createMCPIError` factory
- `src/session/manager.ts` — canonical codes + typed `MCPIErrorCode`
- `src/middleware/with-mcpi.ts` — canonical codes
- `src/index.ts` — exports
- 7 test files updated to match new codes

## Test plan
- [x] New test: `src/__tests__/errors.test.ts` — 4 tests covering codes and factory
- [x] Full suite — 727/727 tests pass (39 files)
- [x] Zero old error codes remain in `src/` or `examples/`