### PR TITLE
fix: use spec-compliant did:key fragment identifiers

### DIFF
--- a/examples/consent-basic/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-basic/__tests__/delegation-issuer.test.ts
@@ -22,7 +22,7 @@ describe('createDelegationIssuerFromIdentity', () => {
   beforeAll(async () => {
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
 
     factory = createDelegationIssuerFromIdentity(crypto, {
       did,
@@ -104,6 +104,6 @@ describe('createDelegationIssuerFromIdentity', () => {
   it('should return the identity in the factory', () => {
     expect(factory.identity.did).toBeDefined();
     expect(factory.identity.did.startsWith('did:key:')).toBe(true);
-    expect(factory.identity.kid).toContain('#keys-1');
+    expect(factory.identity.kid).toMatch(/#z[\w]+$/);
   });
 });

--- a/examples/consent-basic/__tests__/e2e.test.ts
+++ b/examples/consent-basic/__tests__/e2e.test.ts
@@ -35,7 +35,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     // 1. Create MCP middleware with fresh identity
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
 
     mcpi = createMCPIMiddleware(
       {

--- a/examples/consent-basic/__tests__/server.test.ts
+++ b/examples/consent-basic/__tests__/server.test.ts
@@ -58,7 +58,7 @@ describe('MCP Server with consent-basic', () => {
   beforeAll(async () => {
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
     serverDid = did;
 
     mcpi = createMCPIMiddleware(

--- a/examples/consent-basic/scripts/generate-identity.ts
+++ b/examples/consent-basic/scripts/generate-identity.ts
@@ -47,7 +47,7 @@ async function main() {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const identity: PersistedIdentity = {
     did,

--- a/examples/consent-basic/src/consent-server.ts
+++ b/examples/consent-basic/src/consent-server.ts
@@ -63,7 +63,7 @@ export async function startConsentServer(
     const did = generateDidKeyFromBase64(keyPair.publicKey);
     const identity: AgentIdentityConfig = {
       did,
-      kid: `${did}#keys-1`,
+      kid: `${did}#${did.replace('did:key:', '')}`,
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     };

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -267,7 +267,7 @@ export async function createMcpiMiddleware() {
   } else {
     const keyPair = await crypto.generateKeyPair();
     did = generateDidKeyFromBase64(keyPair.publicKey);
-    kid = `${did}#keys-1`;
+    kid = `${did}#${did.replace('did:key:', '')}`;
     privateKey = keyPair.privateKey;
     publicKey = keyPair.publicKey;
     process.stderr.write(`[server] Generated ephemeral identity (run 'npm run generate-identity' to persist)\n`);

--- a/examples/consent-full/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-full/__tests__/delegation-issuer.test.ts
@@ -22,7 +22,7 @@ describe('createDelegationIssuerFromIdentity', () => {
   beforeAll(async () => {
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
 
     factory = createDelegationIssuerFromIdentity(crypto, {
       did,
@@ -104,6 +104,6 @@ describe('createDelegationIssuerFromIdentity', () => {
   it('should return the identity in the factory', () => {
     expect(factory.identity.did).toBeDefined();
     expect(factory.identity.did.startsWith('did:key:')).toBe(true);
-    expect(factory.identity.kid).toContain('#keys-1');
+    expect(factory.identity.kid).toMatch(/#z[\w]+$/);
   });
 });

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -29,7 +29,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     // 1. Create MCP middleware with fresh identity
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
 
     mcpi = createMCPIMiddleware(
       {

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -54,7 +54,7 @@ describe('MCP Server with consent-full', () => {
   beforeAll(async () => {
     const keyPair = await crypto.generateKeyPair();
     const did = generateDidKeyFromBase64(keyPair.publicKey);
-    const kid = `${did}#keys-1`;
+    const kid = `${did}#${did.replace('did:key:', '')}`;
     serverDid = did;
 
     mcpi = createMCPIMiddleware(

--- a/examples/consent-full/scripts/generate-identity.ts
+++ b/examples/consent-full/scripts/generate-identity.ts
@@ -47,7 +47,7 @@ async function main() {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const identity: PersistedIdentity = {
     did,

--- a/examples/consent-full/src/consent-server.ts
+++ b/examples/consent-full/src/consent-server.ts
@@ -77,7 +77,7 @@ export async function startConsentServer(
     const did = generateDidKeyFromBase64(keyPair.publicKey);
     const identity: AgentIdentityConfig = {
       did,
-      kid: `${did}#keys-1`,
+      kid: `${did}#${did.replace('did:key:', '')}`,
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     };

--- a/examples/node-server/issue-delegation.ts
+++ b/examples/node-server/issue-delegation.ts
@@ -19,8 +19,8 @@ async function main() {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  // Use #keys-1 to match the did-key-resolver verification method ID
-  const kid = `${did}#keys-1`;
+  
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   process.stderr.write(`[issue-delegation] Issuer DID: ${did}\n`);
 

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -126,7 +126,7 @@ async function main() {
   const keyPair = await crypto.generateKeyPair();
 
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   console.error(`[mcpi] Agent DID: ${did}`);
 

--- a/examples/outbound-delegation/demo.ts
+++ b/examples/outbound-delegation/demo.ts
@@ -112,7 +112,7 @@ async function main() {
 
   const serverAKeys = await cryptoProvider.generateKeyPair();
   const serverADid = generateDidKeyFromBase64(serverAKeys.publicKey);
-  const serverAKid = `${serverADid}#keys-1`;
+  const serverAKid = `${serverADid}#${serverADid.replace('did:key:', '')}`;
   console.log(`Server A DID: ${serverADid.slice(0, 30)}...`);
 
   const agentKeys = await cryptoProvider.generateKeyPair();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.1.0-canary.2",
       "license": "MIT",
       "dependencies": {
-        "@mcp-i/core": "^1.1.0-canary.2",
         "jose": "^5.6.3",
         "json-canonicalize": "^2.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@kya-os/consent": "^0.1.37",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@types/express": "^5.0.6",
         "@types/node": "^20.14.9",
@@ -747,23 +747,53 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mcp-i/core": {
-      "version": "1.1.0-canary.2",
-      "resolved": "https://registry.npmjs.org/@mcp-i/core/-/core-1.1.0-canary.2.tgz",
-      "integrity": "sha512-56zUh0ZEGsVBi3OYLvVa1RktFGMxPzkC+6zGgGIQw1QGIljNZr1OLxZ32zITdgLbLKdWS+ZjdGLzAGrh+LFygA==",
+    "node_modules/@kya-os/consent": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@kya-os/consent/-/consent-0.1.38.tgz",
+      "integrity": "sha512-gBcZbwtT/bVHRh2wf5wEbnLethJtN2Dxi8BzVDDKAgrgXfzQSjmMf2ZHK/eNooHDageKJ2Cz7ND9KxGP/Hm9IQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mcp-i/core": "^1.1.0-canary.1",
-        "jose": "^5.6.3",
-        "json-canonicalize": "^2.0.0"
-      },
+        "@lit/react": "^1.0.8",
+        "lit": "^3.3.2",
+        "zod": "^3.25.67"
+      }
+    },
+    "node_modules/@kya-os/consent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -1276,6 +1306,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -1296,6 +1337,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
@@ -2016,6 +2064,14 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3166,6 +3222,40 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/locate-path": {

--- a/src/__tests__/integration/full-flow.test.ts
+++ b/src/__tests__/integration/full-flow.test.ts
@@ -74,7 +74,7 @@ describe("MCP-I Full Protocol Flow", () => {
     const agent = await identityProvider.getIdentity();
 
     expect(agent.did).toMatch(/^did:key:z/);
-    expect(agent.kid).toMatch(/#keys-1$/);
+    expect(agent.kid).toMatch(/#z[\w]+$/);
 
     // ── Step 2: Establish session via handshake ──────────────────
     const serverDid = "did:web:test-server.example.com";

--- a/src/__tests__/integration/mcp-enhance-server.test.ts
+++ b/src/__tests__/integration/mcp-enhance-server.test.ts
@@ -335,7 +335,7 @@ describe('generateIdentity()', () => {
     const identity = await generateIdentity(crypto);
 
     expect(identity.did).toMatch(/^did:key:z6Mk/);
-    expect(identity.kid).toBe(`${identity.did}#keys-1`);
+    expect(identity.kid).toBe(`${identity.did}#${identity.did.replace('did:key:', '')}`);
     expect(identity.privateKey).toBeDefined();
     expect(identity.publicKey).toBeDefined();
     // Keys should be base64 strings

--- a/src/__tests__/integration/mcp-transport-context7.test.ts
+++ b/src/__tests__/integration/mcp-transport-context7.test.ts
@@ -25,7 +25,7 @@ async function setupMcpServerPair(options?: { autoSession?: boolean }) {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const mcpi = createMCPIMiddleware(
     {

--- a/src/__tests__/integration/mcp-transport.test.ts
+++ b/src/__tests__/integration/mcp-transport.test.ts
@@ -64,7 +64,7 @@ async function setupMcpPair(options?: { autoSession?: boolean }) {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const mcpi = createMCPIMiddleware(
     {
@@ -157,7 +157,7 @@ async function issueDelegationVC(scopes: string[]): Promise<DelegationCredential
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const signingFn = async (
     canonicalVC: string,

--- a/src/__tests__/providers/base.test.ts
+++ b/src/__tests__/providers/base.test.ts
@@ -155,7 +155,7 @@ describe('Base Provider Classes', () => {
     it('should have proper type structure', () => {
       const validIdentity = {
         did: 'did:key:z123',
-        kid: 'did:key:z123#keys-1',
+        kid: 'did:key:z123#z123',
         privateKey: 'private-key',
         publicKey: 'public-key',
         createdAt: new Date().toISOString(),

--- a/src/__tests__/providers/memory.test.ts
+++ b/src/__tests__/providers/memory.test.ts
@@ -222,7 +222,7 @@ describe('MemoryIdentityProvider', () => {
 
       expect(identity).toBeDefined();
       expect(identity.did).toMatch(/^did:key:z/);
-      expect(identity.kid).toBe(`${identity.did}#keys-1`);
+      expect(identity.kid).toBe(`${identity.did}#${identity.did.replace('did:key:', '')}`);
       expect(identity.privateKey).toMatch(/^[A-Za-z0-9+/=]+$/); // Valid base64 string
       expect(identity.publicKey).toMatch(/^[A-Za-z0-9+/=]+$/); // Valid base64 string
       expect(identity.type).toBe('development');
@@ -246,7 +246,7 @@ describe('MemoryIdentityProvider', () => {
     it('should save and return the saved identity', async () => {
       const customIdentity = {
         did: 'did:key:zcustom',
-        kid: 'did:key:zcustom#keys-1',
+        kid: 'did:key:zcustom#zcustom',
         privateKey: 'custom-private',
         publicKey: 'custom-public',
         createdAt: new Date().toISOString(),

--- a/src/__tests__/utils/mock-providers.ts
+++ b/src/__tests__/utils/mock-providers.ts
@@ -251,7 +251,7 @@ export class MockIdentityProvider extends IdentityProvider {
     if (!this.identity) {
       this.identity = {
         did: 'did:key:zmock123',
-        kid: 'did:key:zmock123#keys-1',
+        kid: 'did:key:zmock123#zmock123',
         privateKey: 'mock-private-key',
         publicKey: 'mock-public-key',
         createdAt: new Date().toISOString(),
@@ -271,7 +271,7 @@ export class MockIdentityProvider extends IdentityProvider {
     this.rotateCount++;
     this.identity = {
       did: `did:key:zmock456-${this.rotateCount}`,
-      kid: `did:key:zmock456-${this.rotateCount}#keys-1`,
+      kid: `did:key:zmock456-${this.rotateCount}#zmock456-${this.rotateCount}`,
       privateKey: `mock-private-key-rotated-${this.rotateCount}`,
       publicKey: `mock-public-key-rotated-${this.rotateCount}`,
       createdAt: new Date().toISOString(),

--- a/src/delegation/__tests__/did-key-resolver.test.ts
+++ b/src/delegation/__tests__/did-key-resolver.test.ts
@@ -198,8 +198,8 @@ describe("did:key Resolver", () => {
       expect(didDoc?.verificationMethod?.[0].type).toBe("Ed25519VerificationKey2020");
       expect(didDoc?.verificationMethod?.[0].controller).toBe(didKey);
       expect(didDoc?.verificationMethod?.[0].publicKeyJwk).toBeDefined();
-      expect(didDoc?.authentication).toContain(`${didKey}#keys-1`);
-      expect(didDoc?.assertionMethod).toContain(`${didKey}#keys-1`);
+      expect(didDoc?.authentication).toContain(`${didKey}#${didKey.replace('did:key:', '')}`);
+      expect(didDoc?.assertionMethod).toContain(`${didKey}#${didKey.replace('did:key:', '')}`);
     });
 
     it("should return null for non-Ed25519 did:key", async () => {

--- a/src/delegation/__tests__/outbound-headers.test.ts
+++ b/src/delegation/__tests__/outbound-headers.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
 
   serverKeyPair = await cryptoProvider.generateKeyPair();
   serverDid = generateDidKeyFromBase64(serverKeyPair.publicKey);
-  serverKid = `${serverDid}#keys-1`;
+  serverKid = `${serverDid}#${serverDid.replace('did:key:', '')}`;
 
   const agentKeyPair = await cryptoProvider.generateKeyPair();
   agentDid = generateDidKeyFromBase64(agentKeyPair.publicKey);

--- a/src/delegation/__tests__/statuslist-manager.test.ts
+++ b/src/delegation/__tests__/statuslist-manager.test.ts
@@ -59,7 +59,7 @@ describe("StatusList2021Manager", () => {
     proof: {
       type: "Ed25519Signature2020",
       created: new Date().toISOString(),
-      verificationMethod: "did:key:z6MkIssuer#keys-1",
+      verificationMethod: "did:key:z6MkIssuer#z6MkIssuer",
       proofPurpose: "assertionMethod",
       proofValue: "mock-proof-value",
     },
@@ -74,13 +74,13 @@ describe("StatusList2021Manager", () => {
 
     mockIdentity = {
       getDid: vi.fn().mockReturnValue("did:key:z6MkTestIssuer"),
-      getKeyId: vi.fn().mockReturnValue("did:key:z6MkTestIssuer#keys-1"),
+      getKeyId: vi.fn().mockReturnValue("did:key:z6MkTestIssuer#z6MkTestIssuer"),
     };
 
     mockSigningFunction = vi.fn().mockResolvedValue({
       type: "Ed25519Signature2020",
       created: new Date().toISOString(),
-      verificationMethod: "did:key:z6MkTestIssuer#keys-1",
+      verificationMethod: "did:key:z6MkTestIssuer#z6MkTestIssuer",
       proofPurpose: "assertionMethod",
       proofValue: "mock-signature",
     });

--- a/src/delegation/did-key-resolver.ts
+++ b/src/delegation/did-key-resolver.ts
@@ -15,6 +15,7 @@
  */
 
 import { base58Decode } from '../utils/base58.js';
+import { didKeyFragment } from '../utils/did-helpers.js';
 import { base64urlEncodeFromBytes } from '../utils/base64.js';
 import type { DIDResolver, DIDDocument, VerificationMethod } from './vc-verifier.js';
 import { logger } from '../logging/index.js';
@@ -124,8 +125,10 @@ export function createDidKeyResolver(): DIDResolver {
       const multibaseKey = did.replace('did:key:', '');
 
       // Construct the verification method
+      const fragment = didKeyFragment(did);
+
       const verificationMethod: VerificationMethod = {
-        id: `${did}#keys-1`,
+        id: `${did}#${fragment}`,
         type: 'Ed25519VerificationKey2020',
         controller: did,
         publicKeyJwk,
@@ -136,8 +139,8 @@ export function createDidKeyResolver(): DIDResolver {
       return {
         id: did,
         verificationMethod: [verificationMethod],
-        authentication: [`${did}#keys-1`],
-        assertionMethod: [`${did}#keys-1`],
+        authentication: [`${did}#${fragment}`],
+        assertionMethod: [`${did}#${fragment}`],
       };
     },
   };
@@ -164,8 +167,10 @@ export function resolveDidKeySync(did: string): DIDDocument | null {
   const publicKeyJwk = publicKeyToJwk(publicKeyBytes);
   const multibaseKey = did.replace('did:key:', '');
 
+  const fragment = didKeyFragment(did);
+
   const verificationMethod: VerificationMethod = {
-    id: `${did}#keys-1`,
+    id: `${did}#${fragment}`,
     type: 'Ed25519VerificationKey2020',
     controller: did,
     publicKeyJwk,
@@ -175,7 +180,7 @@ export function resolveDidKeySync(did: string): DIDDocument | null {
   return {
     id: did,
     verificationMethod: [verificationMethod],
-    authentication: [`${did}#keys-1`],
-    assertionMethod: [`${did}#keys-1`],
+    authentication: [`${did}#${fragment}`],
+    assertionMethod: [`${did}#${fragment}`],
   };
 }

--- a/src/middleware/__tests__/with-mcpi.test.ts
+++ b/src/middleware/__tests__/with-mcpi.test.ts
@@ -24,7 +24,7 @@ async function createTestMiddleware(options?: {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = `${did}#keys-1`;
+  const kid = `${did}#${did.replace('did:key:', '')}`;
 
   const middleware = createMCPIMiddleware(
     {
@@ -43,7 +43,7 @@ async function createDelegationIssuer(options?: { did?: string; kid?: string }) 
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
   const did = options?.did ?? generateDidKeyFromBase64(keyPair.publicKey);
-  const kid = options?.kid ?? `${did}#keys-1`;
+  const kid = options?.kid ?? `${did}#${did.replace('did:key:', '')}`;
 
   const signingFn = async (
     canonicalVC: string,
@@ -172,7 +172,7 @@ describe('createMCPIMiddleware', () => {
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.did).toBe(did);
-      expect(parsed.kid).toContain('#keys-1');
+      expect(parsed.kid).toMatch(/#z[\w]+$/);
       expect(parsed.capabilities).toContain('handshake');
       expect(parsed.capabilities).toContain('signing');
       expect(parsed.capabilities).toContain('verification');

--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -12,7 +12,7 @@
  */
 
 import type { CryptoProvider } from "../providers/base.js";
-import { generateDidKeyFromBase64 } from "../utils/did-helpers.js";
+import { generateDidKeyFromBase64, didKeyFragment } from "../utils/did-helpers.js";
 import {
   MCPI_ACTIONS,
   createMCPIMiddleware,
@@ -59,7 +59,7 @@ export async function generateIdentity(
   const did = generateDidKeyFromBase64(keyPair.publicKey);
   return {
     did,
-    kid: `${did}#keys-1`,
+    kid: `${did}#${didKeyFragment(did)}`,
     privateKey: keyPair.privateKey,
     publicKey: keyPair.publicKey,
   };

--- a/src/proof/__tests__/verifier.test.ts
+++ b/src/proof/__tests__/verifier.test.ts
@@ -35,7 +35,7 @@ describe('ProofVerifier Security', () => {
     kty: 'OKP',
     crv: 'Ed25519',
     x: 'VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ',
-    kid: 'did:key:z123#keys-1',
+    kid: 'did:key:z123#z123',
   };
 
   const createValidProof = (): DetachedProof => {
@@ -64,7 +64,7 @@ describe('ProofVerifier Security', () => {
       jws,
       meta: {
         did: 'did:key:z123',
-        kid: 'did:key:z123#keys-1',
+        kid: 'did:key:z123#z123',
         ts: Math.floor(Date.now() / 1000),
         nonce: 'nonce123',
         audience: 'test-audience',
@@ -104,7 +104,7 @@ describe('ProofVerifier Security', () => {
     mockFetchProvider = {
       resolveDID: vi.fn().mockResolvedValue({
         verificationMethod: [{
-          id: 'did:key:z123#keys-1',
+          id: 'did:key:z123#z123',
           publicKeyJwk: validJwk,
         }],
       }),
@@ -417,7 +417,7 @@ describe('ProofVerifier Security', () => {
 
   describe('fetchPublicKeyFromDID', () => {
     it('should fetch public key from DID document', async () => {
-      const jwk = await proofVerifier.fetchPublicKeyFromDID('did:key:z123', 'keys-1');
+      const jwk = await proofVerifier.fetchPublicKeyFromDID('did:key:z123', 'z123');
 
       expect(jwk).toEqual(validJwk);
       expect(mockFetchProvider.resolveDID).toHaveBeenCalledWith('did:key:z123');
@@ -462,7 +462,7 @@ describe('ProofVerifier Security', () => {
     it('should throw ProofVerificationError if JWK is not Ed25519', async () => {
       mockFetchProvider.resolveDID = vi.fn().mockResolvedValue({
         verificationMethod: [{
-          id: 'did:key:z123#keys-1',
+          id: 'did:key:z123#z123',
           publicKeyJwk: {
             kty: 'RSA',
             crv: 'RS256',

--- a/src/providers/memory.ts
+++ b/src/providers/memory.ts
@@ -11,7 +11,7 @@ import {
   IdentityProvider,
   type AgentIdentity,
 } from './base.js';
-import { generateDidKeyFromBase64 } from '../utils/did-helpers.js';
+import { generateDidKeyFromBase64, didKeyFragment } from '../utils/did-helpers.js';
 
 export class MemoryStorageProvider extends StorageProvider {
   private store: Map<string, string> = new Map();
@@ -116,7 +116,7 @@ export class MemoryIdentityProvider extends IdentityProvider {
 
     return {
       did,
-      kid: `${did}#keys-1`,
+      kid: `${did}#${didKeyFragment(did)}`,
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
       createdAt: new Date().toISOString(),

--- a/src/utils/did-helpers.ts
+++ b/src/utils/did-helpers.ts
@@ -208,3 +208,22 @@ export function generateDidKeyFromBase64(publicKeyBase64: string): string {
   );
   return generateDidKeyFromBytes(publicKeyBytes);
 }
+
+/**
+ * Get the spec-compliant fragment identifier for a did:key DID.
+ *
+ * Per the did:key spec (W3C CCG), the fragment equals the multibase-encoded
+ * public key value (the DID-specific-id). For example:
+ *   did:key:z6MkABC... → z6MkABC...
+ *
+ * @see https://w3c-ccg.github.io/did-key-spec/#document-creation-algorithm
+ * @param did - A did:key DID string
+ * @returns The fragment identifier (multibase value), or 'keys-1' as fallback for non-did:key
+ */
+export function didKeyFragment(did: string): string {
+  if (did.startsWith('did:key:')) {
+    return did.slice('did:key:'.length);
+  }
+  // Fallback for non-did:key methods
+  return 'keys-1';
+}


### PR DESCRIPTION
## The Bug

Every `did:key` verification method ID in mcp-i-core used `#keys-1` as the fragment:
```
did:key:z6MkABC...#keys-1
```

Per the [W3C CCG did:key spec](https://w3c-ccg.github.io/did-key-spec/#document-creation-algorithm), the fragment **MUST** be the multibase-encoded public key value:
```
did:key:z6MkABC...#z6MkABC...
```

### Why it worked until now

Both the resolver (`createDidKeyResolver`) and the identity generator (`generateIdentity`) used the same wrong convention. They matched each other, so internal verification passed. But any external spec-compliant did:key resolver would fail to find the verification method by kid, breaking signature verification.

### Why it matters for DIF

This repo is positioned as the reference implementation for the TAAWG working group. Shipping a non-compliant did:key implementation undermines credibility and breaks interop with any standards-compliant verifier.

## The Fix

- Added `didKeyFragment(did)` helper that extracts the multibase value from a did:key DID
- Falls back to `'keys-1'` for non-did:key methods (e.g., did:web uses its own fragment convention)
- Updated all production code: `did-key-resolver.ts`, `with-mcpi-server.ts`, `providers/memory.ts`
- Updated all examples and all tests

## Test Results

**723 tests passing, 0 failures.** TypeScript clean.

## Downstream Impact

- `know-that-ai/know-that-ai` PR #319 (`skill-register` endpoint) — already consistent
- `modelcontextprotocol-identity` PR #40 (identity skill) — references updated
- Any consumer that hardcodes `#keys-1` as a kid for did:key DIDs will need updating