### PR TITLE
chore: remove unused _resumeToken parameter from verifyOrHints

### DIFF
--- a/src/auth/handshake.ts
+++ b/src/auth/handshake.ts
@@ -202,14 +202,12 @@ export class MemoryResumeTokenStore implements ResumeTokenStore {
  * @param agentDid - The agent's DID to verify
  * @param scopes - Required scopes for the operation
  * @param config - Authorization configuration including verifier, token store, etc.
- * @param _resumeToken - Optional resume token from previous authorization attempt
  * @returns Result indicating authorization status, delegation, or auth hints
  */
 export async function verifyOrHints(
   agentDid: string,
   scopes: string[],
   config: AuthHandshakeConfig,
-  _resumeToken?: string
 ): Promise<VerifyOrHintsResult> {
   const startTime = Date.now();
 


### PR DESCRIPTION
## Summary
- Removes the unused `_resumeToken?: string` parameter from `verifyOrHints()` and its JSDoc
- Resume token resolution is an application-level concern — the full consent flow works without this parameter
- Tokens are generated in the `NeedsAuthorizationError` response, embedded in the authorization URL, and resolved by the application's consent server / delegation store
- The `examples/consent-full` e2e tests demonstrate the complete loop without this parameter

## Test plan
- [x] All 727 tests pass (39 test files)
- [x] No callers pass a 4th argument to `verifyOrHints`
- [x] SPEC.md describes resume tokens in the error response and client retry flow, not as a `verifyOrHints` parameter — no spec change needed

