### PR TITLE
fix: StatusList2021 checkStatus fails closed on missing status list

### DIFF
--- a/src/delegation/__tests__/statuslist-manager.test.ts
+++ b/src/delegation/__tests__/statuslist-manager.test.ts
@@ -405,7 +405,7 @@ describe("StatusList2021Manager", () => {
       expect(isRevoked).toBe(true);
     });
 
-    it("should return false if status list doesn't exist", async () => {
+    it("should throw if status list doesn't exist (fail closed)", async () => {
       const manager = new StatusList2021Manager(
         mockStorage,
         mockIdentity,
@@ -424,9 +424,9 @@ describe("StatusList2021Manager", () => {
         statusListCredential: "https://status.example.com/revocation/v1",
       };
 
-      const isRevoked = await manager.checkStatus(credentialStatus);
-
-      expect(isRevoked).toBe(false);
+      await expect(
+        manager.checkStatus(credentialStatus)
+      ).rejects.toThrow("Status list not found");
     });
   });
 
@@ -510,6 +510,119 @@ describe("StatusList2021Manager", () => {
 
       expect(manager).toBeInstanceOf(StatusList2021Manager);
       expect(manager.getStatusListBaseUrl()).toBe("https://status.example.com");
+    });
+  });
+
+  describe("checkStatus fail-closed behavior", () => {
+    it("should throw with the status list URL in the error message", async () => {
+      const manager = new StatusList2021Manager(
+        mockStorage,
+        mockIdentity,
+        mockSigningFunction,
+        mockCompressor,
+        mockDecompressor
+      );
+
+      vi.mocked(mockStorage.getStatusList).mockResolvedValue(null);
+
+      const statusListUrl = "https://status.example.com/revocation/v1";
+      const credentialStatus: CredentialStatus = {
+        id: `${statusListUrl}#5`,
+        type: "StatusList2021Entry",
+        statusPurpose: "revocation",
+        statusListIndex: "5",
+        statusListCredential: statusListUrl,
+      };
+
+      await expect(manager.checkStatus(credentialStatus)).rejects.toThrow(
+        statusListUrl
+      );
+    });
+
+    it("should throw when storage provider rejects", async () => {
+      const manager = new StatusList2021Manager(
+        mockStorage,
+        mockIdentity,
+        mockSigningFunction,
+        mockCompressor,
+        mockDecompressor
+      );
+
+      vi.mocked(mockStorage.getStatusList).mockRejectedValue(
+        new Error("Redis connection refused")
+      );
+
+      const credentialStatus: CredentialStatus = {
+        id: "https://status.example.com/revocation/v1#5",
+        type: "StatusList2021Entry",
+        statusPurpose: "revocation",
+        statusListIndex: "5",
+        statusListCredential: "https://status.example.com/revocation/v1",
+      };
+
+      await expect(manager.checkStatus(credentialStatus)).rejects.toThrow(
+        "Redis connection refused"
+      );
+    });
+
+    it("should still return false for non-revoked credential with valid storage", async () => {
+      const manager = new StatusList2021Manager(
+        mockStorage,
+        mockIdentity,
+        mockSigningFunction,
+        mockCompressor,
+        mockDecompressor
+      );
+
+      const statusListId = "https://status.example.com/revocation/v1";
+      const existingCredential = createStatusListCredential(
+        statusListId,
+        "revocation"
+      );
+      vi.mocked(mockStorage.getStatusList).mockResolvedValue(existingCredential);
+
+      const credentialStatus: CredentialStatus = {
+        id: `${statusListId}#3`,
+        type: "StatusList2021Entry",
+        statusPurpose: "revocation",
+        statusListIndex: "3",
+        statusListCredential: statusListId,
+      };
+
+      const isRevoked = await manager.checkStatus(credentialStatus);
+      expect(isRevoked).toBe(false);
+    });
+
+    it("should still return true for revoked credential with valid storage", async () => {
+      const manager = new StatusList2021Manager(
+        mockStorage,
+        mockIdentity,
+        mockSigningFunction,
+        mockCompressor,
+        mockDecompressor
+      );
+
+      const statusListId = "https://status.example.com/revocation/v1";
+      const bytes = new Uint8Array(2);
+      bytes[0] = 0b00001000; // Bit 3 set
+      const encodedList = Buffer.from(bytes).toString("base64url");
+      const existingCredential = createStatusListCredential(
+        statusListId,
+        "revocation",
+        encodedList
+      );
+      vi.mocked(mockStorage.getStatusList).mockResolvedValue(existingCredential);
+
+      const credentialStatus: CredentialStatus = {
+        id: `${statusListId}#3`,
+        type: "StatusList2021Entry",
+        statusPurpose: "revocation",
+        statusListIndex: "3",
+        statusListCredential: statusListId,
+      };
+
+      const isRevoked = await manager.checkStatus(credentialStatus);
+      expect(isRevoked).toBe(true);
     });
   });
 });

--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -1027,4 +1027,45 @@ describe("DelegationCredentialVerifier", () => {
       });
     });
   });
+
+  describe("E2E: StatusList2021 missing storage → verifier rejects", () => {
+    it("should return valid: false when status list resolver throws (missing storage)", async () => {
+      await setupDefaultContractsMocks();
+      const vcWithStatus = {
+        ...mockValidVC,
+        credentialStatus: {
+          id: "https://example.com/status#123",
+          type: "StatusList2021Entry" as const,
+          statusPurpose: "revocation" as const,
+          statusListIndex: "123",
+          statusListCredential: "https://example.com/status",
+        },
+      };
+
+      mockDidResolver.resolve.mockResolvedValue({
+        id: "did:web:example.com:issuer",
+        verificationMethod: [
+          {
+            id: "did:web:example.com:issuer#key-1",
+            type: "Ed25519VerificationKey2020",
+            controller: "did:web:example.com:issuer",
+            publicKeyJwk: { kty: "OKP", crv: "Ed25519", x: "mock-key" },
+          },
+        ],
+      });
+      mockSignatureVerifier.mockResolvedValue({ valid: true });
+
+      // Simulate StatusList2021Manager.checkStatus throwing on missing storage
+      mockStatusListResolver.checkStatus.mockRejectedValue(
+        new Error("Status list not found: https://example.com/status — cannot determine revocation status")
+      );
+
+      const result = await verifier.verifyDelegationCredential(vcWithStatus);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("Status list not found");
+      expect(result.reason).toContain("cannot determine revocation status");
+      expect(result.checks?.statusValid).toBe(false);
+    });
+  });
 });

--- a/src/delegation/statuslist-manager.ts
+++ b/src/delegation/statuslist-manager.ts
@@ -112,7 +112,9 @@ export class StatusList2021Manager {
 
     const statusList = await this.storage.getStatusList(statusListCredential);
     if (!statusList) {
-      return false;
+      throw new Error(
+        `Status list not found: ${statusListCredential} — cannot determine revocation status`
+      );
     }
 
     const manager = await BitstringManager.decode(


### PR DESCRIPTION
## Summary

**Security fix:** `StatusList2021Manager.checkStatus()` returned `false` (not revoked) when the status list was missing from storage. This is a fail-open bug — a missing status list is not evidence of non-revocation, it means revocation status is indeterminate.

Now throws an error, matching the pattern already used by `updateStatus()` (line 69-71). The `vc-verifier` catch block at line 374 converts thrown errors to `{ valid: false }`, so credentials with missing status lists are correctly rejected.

This was the last P1 item from the DIF submission audit fail-modes analysis.

## Impact

- Consumers using `StatusList2021Manager` as their `StatusListResolver` will now get a thrown error instead of silent `false` when storage is missing/unreachable
- The `vc-verifier` already handles this correctly via its catch block → `valid: false`
- The `cascading-revocation` module will propagate the error (correct — administrative operations should surface storage failures)

## Test plan
- [x] `checkStatus` throws with status list URL in error message
- [x] `checkStatus` throws when storage provider rejects (e.g. Redis down)
- [x] Non-revoked credential with valid storage still returns `false`
- [x] Revoked credential with valid storage still returns `true`
- [x] E2E: verifier returns `valid: false` when resolver throws on missing storage
- [x] Full suite — 751/751 tests pass (42 files)