### PR TITLE
fix: widen McpServerLike.registerTool to accept SDK v1.27+ signatures

### DIFF
--- a/src/middleware/with-mcpi-server.ts
+++ b/src/middleware/with-mcpi-server.ts
@@ -71,11 +71,7 @@ export async function generateIdentity(
  */
 interface McpServerLike {
   connect(transport: Transport): Promise<unknown>;
-  registerTool(
-    name: string,
-    config: Record<string, unknown>,
-    handler: (args: unknown) => Promise<unknown>,
-  ): void;
+  registerTool(...args: unknown[]): void;
 }
 
 /**


### PR DESCRIPTION
## Problem
`@modelcontextprotocol/sdk` v1.27.1 changed `McpServer.registerTool` to use generics. Our `McpServerLike` interface had the old strict signature, causing type errors when passing an `McpServer` to `withMCPI()`.

## Fix
Widen `registerTool` to `(...args: unknown[]): void`. We never call it ourselves — we only need the server object to patch `connect()`.

## Impact
- Zero runtime behavior change
- 43 test files, 756 tests passing
- context7-with-mcpi now type-checks clean