### PR TITLE
chore(context7): use published @mcp-i/core package instead of local imports

### DIFF
--- a/examples/context7-with-mcpi/package-lock.json
+++ b/examples/context7-with-mcpi/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@context7/mcp-with-mcpi",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.1",
+        "@mcp-i/core": "^1.1.1",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^14.0.0",
         "express": "^5.1.0",
         "jose": "^6.1.3",
@@ -31,6 +32,33 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@mcp-i/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mcp-i/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-x4YY4RE1GstGBgyov0CPsPZ2af/pg2AmcQ6SBXd/hhgXVSbfAKux61f2+WNZipGenBNKPGQMuWtvSwe+0vMv2A==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^5.6.3",
+        "json-canonicalize": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-i/core/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/examples/context7-with-mcpi/package.json
+++ b/examples/context7-with-mcpi/package.json
@@ -10,7 +10,8 @@
     "start:http": "npx tsx src/index.ts --transport http"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@mcp-i/core": "^1.1.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^14.0.0",
     "express": "^5.1.0",
     "jose": "^6.1.3",

--- a/examples/context7-with-mcpi/src/index.ts
+++ b/examples/context7-with-mcpi/src/index.ts
@@ -30,8 +30,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { SERVER_VERSION, RESOURCE_URL, AUTH_SERVER_URL } from "./lib/constants.js";
 
 // ── MCP-I imports ──────────────────────────────────────────────────
-import { withMCPI } from '../../../src/middleware/with-mcpi-server.js';
-import { NodeCryptoProvider } from '../../node-server/node-crypto.js';
+import { withMCPI, NodeCryptoProvider } from '@mcp-i/core';
 
 /** Default HTTP server port */
 const DEFAULT_PORT = 3000;

--- a/examples/context7-with-mcpi/tsconfig.json
+++ b/examples/context7-with-mcpi/tsconfig.json
@@ -9,7 +9,10 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@mcp-i/core": ["../../src/index.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Updates the context7-with-mcpi example to import from the published `@mcp-i/core` package instead of relative paths into monorepo source.

## Changes
- `withMCPI` and `NodeCryptoProvider` imported from `@mcp-i/core` (single import line)
- Added `@mcp-i/core@^1.1.2` as dependency
- Bumped `@modelcontextprotocol/sdk` to `^1.27.1`  
- Added `tsconfig.json` paths fallback so it still works in monorepo dev

## Testing
- Type-checks clean (`tsc --noEmit`)
- Server starts and serves on `http://localhost:3000/mcp`
- Tool calls return cryptographic proofs in `_meta.proof`

## Note
Requires `@mcp-i/core@1.1.2` to be published (includes the McpServerLike fix from PR #26). Until then, the tsconfig paths fallback resolves to local source.