### PR TITLE
feat: transitive access scenario tests and audience enforcement for re-delegations

### DIFF
--- a/src/delegation/__tests__/transitive-access.test.ts
+++ b/src/delegation/__tests__/transitive-access.test.ts
@@ -1,0 +1,1233 @@
+/**
+ * Transitive Access — Scenario Tests
+ *
+ * These tests map directly to the transitive-access attack scenarios described
+ * in Alan Karp's use-case analysis (https://alanhkarp.com/UseCases.pdf),
+ * presented to the DIF MCP-I TaskForce on 2026-03-27.
+ *
+ * ┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+ * │   Aperture   │    │    Bluth     │    │  Cyberdyne   │
+ * │  (Alice, X,Y)│    │    (Bob)     │    │   (Carol)    │
+ * └──────────────┘    └──────────────┘    └──────────────┘
+ *
+ * Scenario: Alice (Aperture) delegates [query:x, update:y] to Bob (Bluth).
+ * Bob re-delegates a subset to Carol (Cyberdyne). Aperture's server must
+ * verify the complete chain, enforce attenuation, and prevent confused-deputy
+ * attacks — all without Alice having heard of Carol or Cyberdyne.
+ *
+ * With ACLs, Aperture sees Carol's requests as coming from Bluth due to
+ * federated identity. Capability certificates solve this by carrying the
+ * full delegation provenance and enforcing attenuation at every hop.
+ *
+ * Every test uses real Ed25519 key pairs and cryptographic signatures.
+ * No signing operations are mocked.
+ *
+ * Related Spec: MCP-I §4.4 (Delegation Chains), §11.3 (Scope Escalation),
+ *               §11.6 (Confused Deputy), §12.3 (Delegation Chain Disclosure)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  createMCPIMiddleware,
+  type MCPIDelegationConfig,
+  type MCPIMiddleware,
+} from '../../middleware/with-mcpi.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../vc-issuer.js';
+import type {
+  DelegationCredential,
+  Proof,
+} from '../../types/protocol.js';
+import { base64urlEncodeFromBytes } from '../../utils/base64.js';
+import { DelegationGraphManager } from '../delegation-graph.js';
+import { CascadingRevocationManager } from '../cascading-revocation.js';
+import { StatusList2021Manager } from '../statuslist-manager.js';
+import { MemoryDelegationGraphStorage } from '../storage/memory-graph-storage.js';
+import { MemoryStatusListStorage } from '../storage/memory-statuslist-storage.js';
+import {
+  buildOutboundDelegationHeaders,
+} from '../outbound-headers.js';
+
+// ---------------------------------------------------------------------------
+// Shared identity helpers
+// ---------------------------------------------------------------------------
+
+interface AgentIdentity {
+  crypto: NodeCryptoProvider;
+  keyPair: { privateKey: string; publicKey: string };
+  did: string;
+  kid: string;
+  issuer: DelegationCredentialIssuer;
+}
+
+/**
+ * Create an agent identity with a real Ed25519 key pair.
+ * Returns a DID, key ID, and a DelegationCredentialIssuer that
+ * produces cryptographically signed VCs.
+ */
+async function createAgentIdentity(): Promise<AgentIdentity> {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#${did.replace('did:key:', '')}`;
+
+  const signingFn = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kidArg: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, keyPair.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kidArg,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => did,
+      getKeyId: () => kid,
+      getPrivateKey: () => keyPair.privateKey,
+    },
+    signingFn,
+  );
+
+  return { crypto, keyPair, did, kid, issuer };
+}
+
+/**
+ * Issue a signed DelegationCredential.
+ */
+async function issueVC(opts: {
+  from: AgentIdentity;
+  to: AgentIdentity;
+  scopes: string[];
+  audience?: string | string[];
+  parentId?: string;
+}): Promise<DelegationCredential> {
+  return opts.from.issuer.createAndIssueDelegation({
+    id: `del-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    issuerDid: opts.from.did,
+    subjectDid: opts.to.did,
+    parentId: opts.parentId,
+    constraints: {
+      scopes: opts.scopes,
+      ...(opts.audience !== undefined && { audience: opts.audience }),
+      notAfter: Math.floor(Date.now() / 1000) + 3600,
+    },
+  });
+}
+
+/**
+ * Create a test middleware representing a verifying server (Aperture).
+ */
+async function createServer(opts?: {
+  delegation?: MCPIDelegationConfig;
+  autoSession?: boolean;
+}): Promise<{ middleware: MCPIMiddleware; did: string }> {
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#${did.replace('did:key:', '')}`;
+
+  const middleware = createMCPIMiddleware(
+    {
+      identity: {
+        did,
+        kid,
+        privateKey: keyPair.privateKey,
+        publicKey: keyPair.publicKey,
+      },
+      session: { sessionTtlMinutes: 60 },
+      delegation: opts?.delegation,
+      autoSession: opts?.autoSession,
+    },
+    crypto,
+  );
+
+  return { middleware, did };
+}
+
+// ---------------------------------------------------------------------------
+// Three-jurisdiction fixture
+// ---------------------------------------------------------------------------
+
+/** Shared state across all tests in this suite. */
+let alice: AgentIdentity; // Aperture — original delegator
+let bob: AgentIdentity; // Bluth   — intermediary
+let carol: AgentIdentity; // Cyberdyne — downstream
+
+beforeAll(async () => {
+  alice = await createAgentIdentity();
+  bob = await createAgentIdentity();
+  carol = await createAgentIdentity();
+});
+
+// ===========================================================================
+// 1. Valid transitive delegation
+// ===========================================================================
+
+describe('Transitive Access — Karp Use Cases', () => {
+  describe('1. Valid transitive delegation chain (Alice → Bob → Carol)', () => {
+    it('accepts a two-hop chain where Carol acts with attenuated scope', async () => {
+      // Alice delegates [query:x, update:y] to Bob
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+      });
+
+      // Bob re-delegates [query:x] to Carol (attenuated — drops update:y)
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      // Aperture's server is configured to resolve chains
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({
+          content: [{ type: 'text', text: 'query result for resource X' }],
+        }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe('query result for resource X');
+    });
+  });
+
+  // =========================================================================
+  // 2. Provenance visibility
+  // =========================================================================
+
+  describe('2. Provenance visibility (unlike ACL federation)', () => {
+    it('the delegation chain identifies Carol by her own DID, not Bob\'s', async () => {
+      // In ACL systems, Carol's identity is hidden behind Bluth's federated
+      // identity — Aperture sees the request as coming from Bob.
+      // With capability certificates, the chain explicitly names each party.
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      // Inspect the chain — the leaf credential names Carol, not Bob
+      const leafSubject = bobToCarol.credentialSubject.delegation.subjectDid;
+      const leafIssuer = bobToCarol.credentialSubject.delegation.issuerDid;
+
+      expect(leafSubject).toBe(carol.did);
+      expect(leafIssuer).toBe(bob.did);
+
+      // The root credential shows Alice→Bob
+      const rootSubject = aliceToBob.credentialSubject.delegation.subjectDid;
+      const rootIssuer = aliceToBob.credentialSubject.delegation.issuerDid;
+
+      expect(rootIssuer).toBe(alice.did);
+      expect(rootSubject).toBe(bob.did);
+
+      // The verifying server can reconstruct the full chain:
+      //   Alice (issuer) → Bob (subject/issuer) → Carol (subject)
+      // No identity is hidden or federated.
+      expect(leafIssuer).toBe(rootSubject); // Bob links the two credentials
+    });
+  });
+
+  // =========================================================================
+  // 3. Scope attenuation enforcement
+  // =========================================================================
+
+  describe('3. Scope attenuation across hops', () => {
+    it('accepts a child that narrows the parent\'s scopes', async () => {
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+      });
+
+      // Bob narrows to just query:x — valid attenuation
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('rejects a child that widens scopes beyond the parent\'s grant', async () => {
+      // Alice gave Bob [query:x, update:y]
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+      });
+
+      // Bob attempts to give Carol [query:x, update:y, admin:z]
+      // admin:z was never granted to Bob — this is scope escalation
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x', 'update:y', 'admin:z'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('widens scopes');
+      expect(parsed.reason).toContain('admin:z');
+    });
+
+    it('rejects a child that passes through equal scopes but adds new ones', async () => {
+      // Alice gave Bob [query:x]
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      // Bob passes through query:x but adds update:y — escalation
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x', 'update:y'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.reason).toContain('widens scopes');
+    });
+  });
+
+  // =========================================================================
+  // 4. Confused deputy prevention
+  // =========================================================================
+
+  describe('4. Confused deputy prevention', () => {
+    it('rejects a delegation presented to the wrong server (audience mismatch)', async () => {
+      // Karp scenario: Alice delegates to Bob for use at Aperture's server,
+      // but Carol presents it to Cyberdyne's server instead.
+      // The audience constraint binds the credential to a specific server DID.
+
+      const { did: apertureDid } = await createServer();
+      const { middleware: cyberdyneServer } = await createServer();
+
+      // Alice delegates to Bob, audience-bound to Aperture
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+        audience: apertureDid,
+      });
+
+      // Bob re-delegates to Carol, still audience-bound to Aperture
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+        audience: apertureDid,
+      });
+
+      // Cyberdyne's server has a chain resolver but its DID differs from the
+      // audience in the credentials. The audience check fires during chain
+      // validation when each credential is individually verified.
+      const { middleware: cyberdyneMiddleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = cyberdyneMiddleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://cyberdyne.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('audience');
+    });
+
+    it('rejects when Carol invokes a tool requiring a scope she was not delegated', async () => {
+      // Karp scenario: Alice delegated [query:x] to Bob.
+      // Bob delegated [query:x] to Carol. Carol tries to use update:y.
+      // Even if the chain is perfectly valid, the scope check at the tool
+      // level prevents the confused deputy from exceeding her authority.
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      // Tool requires update:y — Carol only has query:x
+      const handler = middleware.wrapWithDelegation(
+        'update_y',
+        { scopeId: 'update:y', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('insufficient_scope');
+    });
+
+    it('prevents "Backup X to Z" — credential bound to Aperture cannot act at Cyberdyne', async () => {
+      // Karp's "How Bad It Can Get" scenario:
+      // Alice says "Backup X and put the result in Z" where Z is in Cyberdyne.
+      // In ACL world, Bob's backup service (running as Bluth) has Carol's
+      // permissions via federation and can clobber Carol's resource Z.
+      //
+      // With capabilities: Alice's delegation is bound to Aperture's server.
+      // Bob cannot forward it to Cyberdyne because the audience doesn't match.
+
+      const { did: apertureDid } = await createServer();
+      const { middleware: cyberdyneServer } = await createServer();
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+        audience: apertureDid,
+      });
+
+      // Bob tries to forward Alice's credential to Cyberdyne
+      const handler = cyberdyneServer.wrapWithDelegation(
+        'update_z',
+        { scopeId: 'update:y', consentUrl: 'https://cyberdyne.example/consent' },
+        async () => ({
+          content: [{ type: 'text', text: 'clobbered Z — should not reach' }],
+        }),
+      );
+
+      const result = await handler({ _mcpi_delegation: aliceToBob });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('audience');
+    });
+
+    it('prevents "Backup Z to X" — Carol cannot query Z through Bob\'s delegation', async () => {
+      // Karp's reverse confused-deputy scenario:
+      // Alice says "Backup Z to X", hoping to read Carol's resource Z
+      // via Bob's backup service. With ACLs, Bob (federated as Bluth) has
+      // query access to Carol's resources.
+      //
+      // With capabilities: Alice only granted query:x and update:y.
+      // No scope covers Z, so Carol's server rejects the request.
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+      });
+
+      const { middleware: cyberdyneServer } = await createServer();
+
+      // Try to query Z at Cyberdyne using Alice's credential
+      const handler = cyberdyneServer.wrapWithDelegation(
+        'query_z',
+        { scopeId: 'query:z', consentUrl: 'https://cyberdyne.example/consent' },
+        async () => ({
+          content: [{ type: 'text', text: 'read Z — should not reach' }],
+        }),
+      );
+
+      const result = await handler({ _mcpi_delegation: aliceToBob });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      // Either audience mismatch (if audience was set) or scope mismatch
+      // In this case, query:z is not in the delegation's scopes
+      expect(parsed.error).toBe('insufficient_scope');
+    });
+  });
+
+  // =========================================================================
+  // 5. Cascading revocation
+  // =========================================================================
+
+  describe('5. Cascading revocation (Alice revokes Bob → Carol is invalidated)', () => {
+    it('revoking Alice→Bob automatically revokes Bob→Carol and all descendants', async () => {
+      // Karp notes that with capabilities, Bob can "forget" credentials he
+      // holds after delegating to Carol. But the dual requirement is that
+      // Alice can revoke the entire chain if Bluth (or Cyberdyne) is compromised.
+
+      const graphStorage = new MemoryDelegationGraphStorage();
+      const statusListStorage = new MemoryStatusListStorage();
+
+      const graph = new DelegationGraphManager(graphStorage);
+      const crypto = new NodeCryptoProvider();
+      const keyPair = await crypto.generateKeyPair();
+
+      const mockSigningFn = async (
+        canonicalVC: string,
+        _did: string,
+        _kid: string,
+      ): Promise<Proof> => {
+        const data = new TextEncoder().encode(canonicalVC);
+        const sigBytes = await crypto.sign(data, keyPair.privateKey);
+        return {
+          type: 'Ed25519Signature2020',
+          created: new Date().toISOString(),
+          verificationMethod: _kid,
+          proofPurpose: 'assertionMethod',
+          proofValue: base64urlEncodeFromBytes(sigBytes),
+        };
+      };
+
+      const compressor = { compress: async (data: Uint8Array) => data };
+      const decompressor = { decompress: async (data: Uint8Array) => data };
+
+      const statusListManager = new StatusList2021Manager(
+        statusListStorage,
+        {
+          getDid: () => alice.did,
+          getKeyId: () => alice.kid,
+        },
+        mockSigningFn,
+        compressor,
+        decompressor,
+      );
+
+      const revocationManager = new CascadingRevocationManager(
+        graph,
+        statusListManager,
+      );
+
+      // Register Alice→Bob in the graph
+      const aliceEntry = await statusListManager.allocateStatusEntry('revocation');
+      await graph.registerDelegation({
+        id: 'del-alice-bob',
+        parentId: null,
+        issuerDid: alice.did,
+        subjectDid: bob.did,
+        credentialStatusId: aliceEntry.id,
+      });
+
+      // Register Bob→Carol in the graph
+      const bobEntry = await statusListManager.allocateStatusEntry('revocation');
+      await graph.registerDelegation({
+        id: 'del-bob-carol',
+        parentId: 'del-alice-bob',
+        issuerDid: bob.did,
+        subjectDid: carol.did,
+        credentialStatusId: bobEntry.id,
+      });
+
+      // Before revocation: both are valid
+      const preCheck = await revocationManager.isRevoked('del-bob-carol');
+      expect(preCheck.revoked).toBe(false);
+
+      // Alice revokes her delegation to Bob
+      const events = await revocationManager.revokeDelegation('del-alice-bob');
+
+      // Cascading: both Alice→Bob and Bob→Carol are revoked
+      expect(events).toHaveLength(2);
+      expect(events[0].delegationId).toBe('del-alice-bob');
+      expect(events[0].isRoot).toBe(true);
+      expect(events[1].delegationId).toBe('del-bob-carol');
+      expect(events[1].isRoot).toBe(false);
+
+      // Verify Bob→Carol is now revoked.
+      // Cascading revocation atomically sets the status bit on every
+      // descendant, so isRevoked reports it as "Directly revoked" —
+      // the bit for del-bob-carol was explicitly flipped by the cascade.
+      const postCheck = await revocationManager.isRevoked('del-bob-carol');
+      expect(postCheck.revoked).toBe(true);
+
+      // Full chain validation also fails
+      const chainCheck = await revocationManager.validateDelegation('del-bob-carol');
+      expect(chainCheck.valid).toBe(false);
+      expect(chainCheck.reason).toContain('revoked');
+    });
+
+    it('validates delegation status when checking a leaf credential', async () => {
+      // The revocation manager checks the entire chain from root to leaf.
+      // If any ancestor is revoked, the leaf is invalid.
+
+      const graphStorage = new MemoryDelegationGraphStorage();
+      const statusListStorage = new MemoryStatusListStorage();
+      const graph = new DelegationGraphManager(graphStorage);
+      const crypto = new NodeCryptoProvider();
+      const keyPair = await crypto.generateKeyPair();
+
+      const mockSigningFn = async (
+        canonicalVC: string,
+        _did: string,
+        _kid: string,
+      ): Promise<Proof> => {
+        const data = new TextEncoder().encode(canonicalVC);
+        const sigBytes = await crypto.sign(data, keyPair.privateKey);
+        return {
+          type: 'Ed25519Signature2020',
+          created: new Date().toISOString(),
+          verificationMethod: _kid,
+          proofPurpose: 'assertionMethod',
+          proofValue: base64urlEncodeFromBytes(sigBytes),
+        };
+      };
+
+      const compressor = { compress: async (data: Uint8Array) => data };
+      const decompressor = { decompress: async (data: Uint8Array) => data };
+
+      const statusListManager = new StatusList2021Manager(
+        statusListStorage,
+        { getDid: () => alice.did, getKeyId: () => alice.kid },
+        mockSigningFn,
+        compressor,
+        decompressor,
+      );
+
+      const revocationManager = new CascadingRevocationManager(
+        graph,
+        statusListManager,
+      );
+
+      // Three-hop chain: Alice → Bob → Carol → Dave
+      const dave = await createAgentIdentity();
+
+      const entry0 = await statusListManager.allocateStatusEntry('revocation');
+      await graph.registerDelegation({
+        id: 'del-a-b',
+        parentId: null,
+        issuerDid: alice.did,
+        subjectDid: bob.did,
+        credentialStatusId: entry0.id,
+      });
+
+      const entry1 = await statusListManager.allocateStatusEntry('revocation');
+      await graph.registerDelegation({
+        id: 'del-b-c',
+        parentId: 'del-a-b',
+        issuerDid: bob.did,
+        subjectDid: carol.did,
+        credentialStatusId: entry1.id,
+      });
+
+      const entry2 = await statusListManager.allocateStatusEntry('revocation');
+      await graph.registerDelegation({
+        id: 'del-c-d',
+        parentId: 'del-b-c',
+        issuerDid: carol.did,
+        subjectDid: dave.did,
+        credentialStatusId: entry2.id,
+      });
+
+      // Revoke the middle link (Bob→Carol)
+      await revocationManager.revokeDelegation('del-b-c');
+
+      // Dave's leaf is invalid because ancestor del-b-c is revoked
+      const daveCheck = await revocationManager.validateDelegation('del-c-d');
+      expect(daveCheck.valid).toBe(false);
+      expect(daveCheck.reason).toContain('revoked');
+
+      // Alice→Bob is still valid (parent of the revoked node, not a descendant)
+      const aliceCheck = await revocationManager.validateDelegation('del-a-b');
+      expect(aliceCheck.valid).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // 6. Chain integrity enforcement
+  // =========================================================================
+
+  describe('6. Chain integrity enforcement', () => {
+    it('rejects a chain with broken issuer/subject continuity', async () => {
+      // If Carol forges a credential claiming Bob delegated to her, but the
+      // chain's issuer/subject links don't match, validation must fail.
+      // This is the cryptographic enforcement of Karp's "capability
+      // certificates carry provenance" property.
+
+      // Alice delegates to Bob
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      // Eve (a fourth party) creates a credential claiming to be from Bob,
+      // but signed with Eve's key — not Bob's
+      const eve = await createAgentIdentity();
+      const eveToCarol = await issueVC({
+        from: eve, // Eve signs, but claims parentId from aliceToBob
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: eveToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      // Eve's DID ≠ Bob's DID (the parent's subject)
+      expect(parsed.reason).toContain('issued by');
+      expect(parsed.reason).toContain('parent subject');
+    });
+
+    it('rejects a chain where the leaf references a non-existent parent', async () => {
+      // Bob creates a delegation to Carol referencing a parent that doesn't
+      // exist. The chain resolver returns an empty array.
+
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: 'non-existent-parent-id',
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('empty');
+    });
+
+    it('detects circular references in the delegation chain', async () => {
+      // A malicious actor constructs a chain that loops. The circular
+      // reference detector must catch this.
+
+      const graph = new DelegationGraphManager(new MemoryDelegationGraphStorage());
+
+      // Create a valid chain: A→B→C
+      await graph.registerDelegation({
+        id: 'del-1',
+        parentId: null,
+        issuerDid: alice.did,
+        subjectDid: bob.did,
+      });
+
+      await graph.registerDelegation({
+        id: 'del-2',
+        parentId: 'del-1',
+        issuerDid: bob.did,
+        subjectDid: carol.did,
+      });
+
+      // Verify valid chain works
+      const validResult = await graph.validateChain('del-2');
+      expect(validResult.valid).toBe(true);
+
+      // Verify chain depth
+      const depth = await graph.getDepth('del-2');
+      expect(depth).toBe(1); // root=0, child=1
+
+      // Verify ancestry
+      const isAncestor = await graph.isAncestor('del-1', 'del-2');
+      expect(isAncestor).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // 7. Three-hop chain validation
+  // =========================================================================
+
+  describe('7. Three-hop chain (Alice → Bob → Carol → Dave)', () => {
+    it('validates a three-hop chain with progressive attenuation', async () => {
+      // Extended transitive scenario: four parties, three delegations,
+      // each narrowing the scope further.
+
+      const dave = await createAgentIdentity();
+
+      // Alice → Bob: [query:x, update:y, delete:y]
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y', 'delete:y'],
+      });
+
+      // Bob → Carol: [query:x, update:y] (drops delete:y)
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x', 'update:y'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      // Carol → Dave: [query:x] (drops update:y)
+      const carolToDave = await issueVC({
+        from: carol,
+        to: dave,
+        scopes: ['query:x'],
+        parentId: bobToCarol.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob, bobToCarol],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'ok from Dave' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: carolToDave });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe('ok from Dave');
+    });
+
+    it('rejects if any link in a three-hop chain widens scope', async () => {
+      const dave = await createAgentIdentity();
+
+      // Alice → Bob: [query:x]
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      // Bob → Carol: [query:x] — valid
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+      });
+
+      // Carol → Dave: [query:x, update:y] — INVALID, widens scope
+      const carolToDave = await issueVC({
+        from: carol,
+        to: dave,
+        scopes: ['query:x', 'update:y'],
+        parentId: bobToCarol.credentialSubject.delegation.id,
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          resolveDelegationChain: async () => [aliceToBob, bobToCarol],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: carolToDave });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('widens scopes');
+      expect(parsed.reason).toContain('update:y');
+    });
+  });
+
+  // =========================================================================
+  // 8. Outbound delegation propagation
+  // =========================================================================
+
+  describe('8. Outbound delegation propagation (provenance across service boundaries)', () => {
+    it('downstream service receives original agent DID and chain context in headers', async () => {
+      // Karp's key insight: the full delegation chain must be visible at
+      // every hop. MCP-I propagates this via outbound headers so downstream
+      // services can independently verify the chain.
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      const delegation = aliceToBob.credentialSubject.delegation;
+
+      const headers = await buildOutboundDelegationHeaders({
+        session: {
+          sessionId: 'mcpi_test-session',
+          audience: 'aperture.example.com',
+          nonce: 'test-nonce',
+          timestamp: Math.floor(Date.now() / 1000),
+          createdAt: Date.now(),
+          lastActivity: Date.now(),
+          ttlMinutes: 60,
+          agentDid: alice.did,
+          identityState: 'authenticated',
+        },
+        delegation: {
+          id: delegation.id,
+          issuerDid: delegation.issuerDid,
+          subjectDid: delegation.subjectDid,
+          vcId: aliceToBob.id!,
+          constraints: delegation.constraints,
+          signature: aliceToBob.proof?.proofValue ?? '',
+          status: 'active',
+        },
+        serverIdentity: {
+          did: bob.did,
+          kid: bob.kid,
+          privateKey: bob.keyPair.privateKey,
+        },
+        targetUrl: 'https://cyberdyne.example.com/api/backup',
+      });
+
+      // Headers expose the full provenance
+      expect(headers['X-Agent-DID']).toBe(alice.did);
+      expect(headers['X-Delegation-Chain']).toBe(aliceToBob.id);
+      expect(headers['X-Session-ID']).toBe('mcpi_test-session');
+      // The proof is a signed JWT that downstream can verify
+      expect(headers['X-Delegation-Proof']).toMatch(
+        /^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+      );
+    });
+  });
+
+  // =========================================================================
+  // 9. Credential theft and replay prevention
+  // =========================================================================
+
+  describe('9. Credential theft mitigation', () => {
+    it('a stolen credential cannot be used at a different server (audience binding)', async () => {
+      // MCP-I Spec §11.8: If a DelegationCredential is intercepted, the
+      // audience constraint limits where it can be replayed.
+
+      const { did: legitimateServerDid } = await createServer();
+      const { middleware: attackerServer } = await createServer();
+
+      // Legitimate delegation bound to specific server
+      const vc = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+        audience: legitimateServerDid,
+      });
+
+      // Attacker intercepts VC and tries to use it at their server
+      const handler = attackerServer.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://attacker.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'stolen data' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('audience');
+    });
+  });
+
+  // =========================================================================
+  // 10. No delegation — fail-closed behavior
+  // =========================================================================
+
+  describe('10. Fail-closed: no delegation means no access', () => {
+    it('returns needs_authorization when no delegation is presented', async () => {
+      // Karp's premise: with ACLs, the absence of an explicit deny means
+      // implicit allow in many systems. With capabilities, the absence of
+      // a capability means no access — fail-closed by default.
+
+      const { middleware } = await createServer();
+
+      const handler = middleware.wrapWithDelegation(
+        'sensitive_op',
+        {
+          scopeId: 'admin:danger',
+          consentUrl: 'https://aperture.example/consent',
+        },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      // Call without any delegation credential
+      const result = await handler({ some_arg: 'value' });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('needs_authorization');
+      expect(parsed.scopes).toContain('admin:danger');
+      expect(parsed.authorizationUrl).toBe(
+        'https://aperture.example/consent',
+      );
+    });
+  });
+
+  // =========================================================================
+  // 11. requireAudienceOnRedelegation enforcement
+  // =========================================================================
+
+  describe('11. requireAudienceOnRedelegation — strict confused-deputy prevention', () => {
+    it('rejects a re-delegation without audience when enforcement is enabled', async () => {
+      // Core fix for transitive access: re-delegations MUST carry an
+      // audience constraint so they cannot be forwarded to unintended servers.
+
+      const { middleware, did: serverDid } = await createServer({
+        delegation: {
+          requireAudienceOnRedelegation: true,
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      // Alice delegates to Bob WITH audience (root — binds to this server)
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+        audience: serverDid,
+      });
+
+      // Bob re-delegates to Carol WITHOUT audience — this is the hazard
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+        // no audience
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('re-delegation');
+      expect(parsed.reason).toContain('audience');
+    });
+
+    it('accepts a re-delegation WITH audience when enforcement is enabled', async () => {
+      const { middleware, did: serverDid } = await createServer({
+        delegation: {
+          requireAudienceOnRedelegation: true,
+          resolveDelegationChain: async (leaf) => {
+            // Dynamically return the correct parent
+            return [aliceToBobVC];
+          },
+        },
+      });
+
+      // Both delegations carry audience — compliant
+      const aliceToBobVC = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+        audience: serverDid,
+      });
+
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBobVC.credentialSubject.delegation.id,
+        audience: serverDid,
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe('ok');
+    });
+
+    it('allows re-delegations without audience when enforcement is disabled (default)', async () => {
+      // Backward compatibility: the flag defaults to false, so existing
+      // integrations that omit audience on re-delegations continue to work.
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+      });
+
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+        // no audience — allowed when flag is off
+      });
+
+      const { middleware } = await createServer({
+        delegation: {
+          // requireAudienceOnRedelegation not set (defaults to false)
+          resolveDelegationChain: async () => [aliceToBob],
+        },
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: bobToCarol });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe('ok');
+    });
+
+    it('rejects at any hop in a three-hop chain missing audience', async () => {
+      const dave = await createAgentIdentity();
+
+      const { middleware, did: serverDid } = await createServer({
+        delegation: {
+          requireAudienceOnRedelegation: true,
+          resolveDelegationChain: async () => [aliceToBobVC, bobToCarolVC],
+        },
+      });
+
+      const aliceToBobVC = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x'],
+        audience: serverDid,
+      });
+
+      // Bob → Carol has audience — OK
+      const bobToCarolVC = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBobVC.credentialSubject.delegation.id,
+        audience: serverDid,
+      });
+
+      // Carol → Dave is missing audience — should fail
+      const carolToDave = await issueVC({
+        from: carol,
+        to: dave,
+        scopes: ['query:x'],
+        parentId: bobToCarolVC.credentialSubject.delegation.id,
+        // no audience
+      });
+
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _mcpi_delegation: carolToDave });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('re-delegation');
+      expect(parsed.reason).toContain('audience');
+    });
+  });
+});

--- a/src/middleware/with-mcpi.ts
+++ b/src/middleware/with-mcpi.ts
@@ -86,6 +86,20 @@ export interface MCPIDelegationConfig {
     leafCredential: DelegationCredential,
   ) => Promise<DelegationCredential[]>;
   /**
+   * When true, re-delegations (credentials with a `parentId`) MUST include
+   * an `audience` constraint binding them to the verifying server's DID.
+   *
+   * This prevents confused-deputy attacks where a delegated credential is
+   * forwarded to an unintended server. Without audience binding, any server
+   * that receives the credential will accept it.
+   *
+   * Recommended for production. See: Alan Karp's transitive access analysis
+   * and MCP-I §11.6 (Confused Deputy Attacks).
+   *
+   * Default is false for backward compatibility.
+   */
+  requireAudienceOnRedelegation?: boolean;
+  /**
    * Compatibility mode for legacy integrations that cannot yet provide
    * full delegation-chain and status-list resolvers.
    *
@@ -786,6 +800,21 @@ export function createMCPIMiddleware(
           return {
             valid: false,
             reason: `Delegation ${delegation.id} audience does not include server DID ${identity.did}`,
+          };
+        }
+
+        // When requireAudienceOnRedelegation is enabled, every non-root
+        // credential in the chain MUST have an audience constraint.
+        // This prevents confused-deputy attacks where re-delegated
+        // credentials are forwarded to unintended servers.
+        if (
+          delegationConfig?.requireAudienceOnRedelegation &&
+          delegation.parentId &&
+          !delegation.constraints.audience
+        ) {
+          return {
+            valid: false,
+            reason: `Delegation ${delegation.id} is a re-delegation (parentId: ${delegation.parentId}) but has no audience constraint. Re-delegations must include an audience when requireAudienceOnRedelegation is enabled`,
           };
         }
 


### PR DESCRIPTION
## Summary

Addresses the transitive access analysis raised by Alan Karp in the DIF MCP-I TaskForce ([UseCases.pdf](https://alanhkarp.com/UseCases.pdf)).

- **23 scenario tests** in `src/delegation/__tests__/transitive-access.test.ts` mapping 1:1 to Karp's transitive access attack cases (Alice/Aperture → Bob/Bluth → Carol/Cyberdyne). All tests use real Ed25519 key pairs — no mocked signing.
- **`requireAudienceOnRedelegation`** config flag added to `MCPIDelegationConfig`. When enabled, re-delegations (credentials with `parentId`) MUST include an `audience` constraint binding them to the verifying server's DID. This closes the confused-deputy gap where delegated credentials can be forwarded to unintended servers. Defaults to `false` for backward compatibility.

### Scenarios tested

| # | Karp Scenario | Mechanism |
|---|---|---|
| 1 | Valid two-hop chain (Alice→Bob→Carol) | Chain validation + scope check |
| 2 | Provenance visibility (Carol's DID visible, not hidden behind Bob) | Credential structure |
| 3a-c | Scope attenuation: narrowing accepted, widening/injection rejected | `validateScopeAttenuation()` |
| 4a-d | Confused deputy: wrong server, wrong scope, "Backup X to Z", "Backup Z to X" | Audience binding + scope enforcement |
| 5a-b | Cascading revocation: root revocation invalidates all descendants | `CascadingRevocationManager` |
| 6a-c | Chain integrity: issuer/subject mismatch, missing parent, circular refs | Chain walk validation |
| 7a-b | Three-hop chain: valid progressive attenuation + escalation rejection | Full chain validation |
| 8 | Outbound delegation propagation (headers carry provenance) | `buildOutboundDelegationHeaders()` |
| 9 | Credential theft: stolen credential rejected at different server | Audience binding |
| 10 | Fail-closed: no delegation = `needs_authorization` | `wrapWithDelegation()` |
| 11a-d | `requireAudienceOnRedelegation` enforcement and backward compat | New config flag |

### Open discussion items for taskforce

Two additional gaps identified during analysis (not addressed in this PR — require spec discussion):

1. **Jurisdiction metadata**: `DelegationConstraints` doesn't carry issuer/subject organization fields. `did:web` implies org affiliation, `did:key` does not. Karp recommends delegation certificates carry "Carol is in Cyberdyne."
2. **CRISP resource-level enforcement**: CRISP constraint structure exists but the middleware only evaluates scope ID membership, not resource-level patterns. Enforcement semantics need spec agreement before implementation.

## Test plan

- [x] All 23 new scenario tests pass with real Ed25519 crypto
- [x] Full test suite: 779/779 passing, zero regressions
- [x] `requireAudienceOnRedelegation: false` (default) preserves backward compat
- [x] `requireAudienceOnRedelegation: true` rejects re-delegations missing audience at any chain depth