### PR TITLE
test: Phase 1 test quality audit — round-trip and boundary tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_audit_finding.md
+++ b/.github/ISSUE_TEMPLATE/test_audit_finding.md
@@ -1,0 +1,34 @@
+---
+name: Test Audit Finding
+about: A bug or logic gap discovered during Phase 1 test quality audit
+labels: bug, test-audit
+---
+
+**Module**: <!-- e.g., delegation/vc-verifier.ts -->
+
+**Audit Test**: <!-- e.g., src/__tests__/audit/vc-roundtrip.test.ts -->
+
+**Test Name**: <!-- e.g., "reject VC with tampered credentialSubject" -->
+
+**Describe the finding**
+<!-- What does the test expect vs. what actually happens? -->
+
+**Severity**: <!-- Critical / High / Medium / Low -->
+<!-- Critical = security bypass; High = incorrect behavior in security path; Medium = logic gap; Low = cosmetic/spec compliance -->
+
+**Root Cause Analysis**
+<!-- Where in the source code is the bug? Include file + line number if possible. -->
+
+**Reproduction**
+```typescript
+// Minimal test code that demonstrates the issue
+```
+
+**Expected behavior**
+<!-- What should happen per the spec/design? -->
+
+**Actual behavior**
+<!-- What happens currently? -->
+
+**Spec Reference**
+<!-- Which section of SPEC.md or W3C spec is violated? -->

--- a/src/__tests__/audit/canonicalization-integrity.test.ts
+++ b/src/__tests__/audit/canonicalization-integrity.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Canonicalization Integrity Audit Tests
+ *
+ * Verifies that JSON canonicalization (RFC 8785 JCS) produces deterministic
+ * output, that assertJsonSafe rejects dangerous inputs, and that
+ * canonicalization is consistent across modules.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { canonicalizeJSON } from '../../delegation/utils.js';
+import { canonicalize } from 'json-canonicalize';
+import { ProofGenerator } from '../../proof/generator.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+import { MemoryIdentityProvider } from '../../providers/memory.js';
+
+describe('Canonicalization Integrity Audit', () => {
+  // ── Determinism ───────────────────────────────────────────────
+
+  describe('deterministic output', () => {
+    it('should produce identical output regardless of key insertion order', () => {
+      const a = canonicalizeJSON({ b: 1, a: 2 });
+      const b = canonicalizeJSON({ a: 2, b: 1 });
+      expect(a).toBe(b);
+    });
+
+    it('should produce identical output for nested objects with different key orders', () => {
+      const a = canonicalizeJSON({
+        z: { y: 1, x: 2 },
+        a: { c: 3, b: 4 },
+      });
+      const b = canonicalizeJSON({
+        a: { b: 4, c: 3 },
+        z: { x: 2, y: 1 },
+      });
+      expect(a).toBe(b);
+    });
+
+    it('should handle arrays with objects in deterministic order', () => {
+      const a = canonicalizeJSON([
+        { z: 1, a: 2 },
+        { b: 3, a: 4 },
+      ]);
+      const b = canonicalizeJSON([
+        { a: 2, z: 1 },
+        { a: 4, b: 3 },
+      ]);
+      expect(a).toBe(b);
+    });
+
+    it('should handle deeply nested structures deterministically', () => {
+      const a = canonicalizeJSON({
+        level1: {
+          level2: {
+            level3: { c: 3, b: 2, a: 1 },
+          },
+        },
+      });
+      const b = canonicalizeJSON({
+        level1: {
+          level2: {
+            level3: { a: 1, b: 2, c: 3 },
+          },
+        },
+      });
+      expect(a).toBe(b);
+    });
+  });
+
+  // ── assertJsonSafe Guards ─────────────────────────────────────
+
+  describe('assertJsonSafe rejection of non-JSON values', () => {
+    it('should reject Infinity', () => {
+      expect(() => canonicalizeJSON({ val: Infinity })).toThrow(TypeError);
+    });
+
+    it('should reject -Infinity', () => {
+      expect(() => canonicalizeJSON({ val: -Infinity })).toThrow(TypeError);
+    });
+
+    it('should reject NaN', () => {
+      expect(() => canonicalizeJSON({ val: NaN })).toThrow(TypeError);
+    });
+
+    it('should reject undefined', () => {
+      expect(() => canonicalizeJSON(undefined)).toThrow(TypeError);
+    });
+
+    it('should reject functions', () => {
+      expect(() => canonicalizeJSON({ fn: () => {} })).toThrow(TypeError);
+    });
+
+    it('should reject symbols', () => {
+      expect(() => canonicalizeJSON({ sym: Symbol('test') })).toThrow(TypeError);
+    });
+
+    it('should reject bigint', () => {
+      expect(() => canonicalizeJSON({ big: BigInt(42) })).toThrow(TypeError);
+    });
+
+    it('should reject nested non-finite values', () => {
+      expect(() =>
+        canonicalizeJSON({ nested: { deep: { val: NaN } } })
+      ).toThrow(TypeError);
+    });
+
+    it('should reject non-finite values in arrays', () => {
+      expect(() => canonicalizeJSON([1, 2, Infinity])).toThrow(TypeError);
+    });
+  });
+
+  // ── Valid JSON Values ─────────────────────────────────────────
+
+  describe('valid JSON values are accepted', () => {
+    it('should accept null', () => {
+      expect(() => canonicalizeJSON(null)).not.toThrow();
+    });
+
+    it('should accept booleans', () => {
+      expect(() => canonicalizeJSON(true)).not.toThrow();
+      expect(() => canonicalizeJSON(false)).not.toThrow();
+    });
+
+    it('should accept finite numbers', () => {
+      expect(() => canonicalizeJSON(42)).not.toThrow();
+      expect(() => canonicalizeJSON(-0.5)).not.toThrow();
+      expect(() => canonicalizeJSON(0)).not.toThrow();
+    });
+
+    it('should accept strings', () => {
+      expect(() => canonicalizeJSON('hello')).not.toThrow();
+    });
+
+    it('should accept empty objects and arrays', () => {
+      expect(() => canonicalizeJSON({})).not.toThrow();
+      expect(() => canonicalizeJSON([])).not.toThrow();
+    });
+  });
+
+  // ── Cross-Module Consistency ──────────────────────────────────
+
+  describe('cross-module consistency', () => {
+    it('should match json-canonicalize output for safe inputs', () => {
+      const input = {
+        method: 'tools/call',
+        params: { name: 'test-tool', arguments: { x: 1, y: 'hello' } },
+      };
+
+      const fromUtils = canonicalizeJSON(input);
+      const fromLib = canonicalize(input);
+
+      expect(fromUtils).toBe(fromLib);
+    });
+
+    it('should match for VC-like structures', () => {
+      const vcLike = {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        type: ['VerifiableCredential', 'DelegationCredential'],
+        issuer: 'did:key:z6MkTest',
+        credentialSubject: {
+          id: 'did:key:z6MkSubject',
+          delegation: {
+            scopes: ['tools:read'],
+            constraints: { notAfter: 1234567890 },
+          },
+        },
+      };
+
+      expect(canonicalizeJSON(vcLike)).toBe(canonicalize(vcLike));
+    });
+  });
+
+  // ── ProofGenerator Hash Determinism ───────────────────────────
+
+  describe('ProofGenerator hash determinism across key orderings', () => {
+    it('should produce same requestHash for objects with different key orders', async () => {
+      const crypto = new NodeCryptoProvider();
+      const identityProvider = new MemoryIdentityProvider(crypto);
+      const agent = await identityProvider.getIdentity();
+
+      const gen = new ProofGenerator(
+        { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+        crypto
+      );
+
+      const session = {
+        sessionId: 'sess_canon_test',
+        audience: 'did:web:server.example.com',
+        nonce: 'test-nonce-canon',
+        timestamp: Math.floor(Date.now() / 1000),
+        createdAt: Math.floor(Date.now() / 1000),
+        lastActivity: Math.floor(Date.now() / 1000),
+        ttlMinutes: 30,
+        identityState: 'anonymous' as const,
+      };
+
+      const request1 = { method: 'tools/call', params: { x: 1, y: 2, z: 3 } };
+      const request2 = { method: 'tools/call', params: { z: 3, x: 1, y: 2 } };
+      const response = { data: { result: 'ok' } };
+
+      const proof1 = await gen.generateProof(request1, response, session);
+      const proof2 = await gen.generateProof(request2, response, session);
+
+      expect(proof1.meta.requestHash).toBe(proof2.meta.requestHash);
+    });
+
+    it('should produce different hashes for genuinely different inputs', async () => {
+      const crypto = new NodeCryptoProvider();
+      const identityProvider = new MemoryIdentityProvider(crypto);
+      const agent = await identityProvider.getIdentity();
+
+      const gen = new ProofGenerator(
+        { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+        crypto
+      );
+
+      const session = {
+        sessionId: 'sess_diff_test',
+        audience: 'did:web:server.example.com',
+        nonce: 'test-nonce-diff',
+        timestamp: Math.floor(Date.now() / 1000),
+        createdAt: Math.floor(Date.now() / 1000),
+        lastActivity: Math.floor(Date.now() / 1000),
+        ttlMinutes: 30,
+        identityState: 'anonymous' as const,
+      };
+
+      const response = { data: { result: 'ok' } };
+
+      const proof1 = await gen.generateProof(
+        { method: 'tools/call', params: { input: 'alice' } },
+        response,
+        session
+      );
+      const proof2 = await gen.generateProof(
+        { method: 'tools/call', params: { input: 'bob' } },
+        response,
+        session
+      );
+
+      expect(proof1.meta.requestHash).not.toBe(proof2.meta.requestHash);
+    });
+  });
+});

--- a/src/__tests__/audit/graph-revocation-roundtrip.test.ts
+++ b/src/__tests__/audit/graph-revocation-roundtrip.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Graph-Revocation Round-Trip Audit Tests
+ *
+ * Tests the delegation graph → cascading revocation pipeline with real
+ * StatusList2021 bitstring encoding/decoding and real gzip compression.
+ * No mocking of graph storage, status lists, or compression.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { DelegationGraphManager } from '../../delegation/delegation-graph.js';
+import { CascadingRevocationManager } from '../../delegation/cascading-revocation.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealStatusListManager,
+  MemoryDelegationGraphStorage,
+  type RealStatusListSetup,
+} from './helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+
+describe('Graph-Revocation Round-Trip Audit', () => {
+  let crypto: NodeCryptoProvider;
+  let issuerIdentity: AgentIdentity;
+  let graph: DelegationGraphManager;
+  let graphStorage: MemoryDelegationGraphStorage;
+  let statusListSetup: RealStatusListSetup;
+  let revocationManager: CascadingRevocationManager;
+
+  // Create identities for chain: issuer -> agentA -> agentB -> agentC
+  let agentA: AgentIdentity;
+  let agentB: AgentIdentity;
+  let agentC: AgentIdentity;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    issuerIdentity = await createRealIdentity(crypto);
+    agentA = await createRealIdentity(crypto);
+    agentB = await createRealIdentity(crypto);
+    agentC = await createRealIdentity(crypto);
+  });
+
+  beforeEach(async () => {
+    graphStorage = new MemoryDelegationGraphStorage();
+    graph = new DelegationGraphManager(graphStorage);
+
+    statusListSetup = createRealStatusListManager(crypto, issuerIdentity, {
+      statusListBaseUrl: 'https://status.test.example.com',
+    });
+
+    revocationManager = new CascadingRevocationManager(graph, statusListSetup.manager);
+  });
+
+  // Helper: register a delegation and allocate a status entry
+  async function registerWithStatus(
+    id: string,
+    parentId: string | null,
+    issuerDid: string,
+    subjectDid: string
+  ): Promise<string> {
+    const statusEntry = await statusListSetup.manager.allocateStatusEntry('revocation');
+    await graph.registerDelegation({
+      id,
+      parentId,
+      issuerDid,
+      subjectDid,
+      credentialStatusId: statusEntry.id,
+    });
+    return statusEntry.id;
+  }
+
+  // ── Chain Validation ──────────────────────────────────────────
+
+  describe('chain validation with real graph', () => {
+    it('should validate a correctly chained delegation', async () => {
+      // issuer -> agentA -> agentB -> agentC
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+      await registerWithStatus('del-grandchild', 'del-child', agentB.did, agentC.did);
+
+      const result = await graph.validateChain('del-grandchild');
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject chain with issuer/subject mismatch', async () => {
+      // root: issuer -> agentA, child: agentC -> agentB (mismatch: agentC != agentA)
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentC.did, agentB.did);
+
+      const result = await graph.validateChain('del-child');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+  });
+
+  // ── Cascading Revocation ──────────────────────────────────────
+
+  describe('cascading revocation with real StatusList2021', () => {
+    it('should revoke root and cascade to all descendants via StatusList', async () => {
+      const rootStatusId = await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      const childStatusId = await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+      const grandchildStatusId = await registerWithStatus('del-gc', 'del-child', agentB.did, agentC.did);
+
+      const events = await revocationManager.revokeDelegation('del-root');
+
+      expect(events.length).toBe(3);
+      expect(events[0]!.isRoot).toBe(true);
+
+      // Verify via real StatusList that all are revoked
+      const rootRevoked = await revocationManager.isRevoked('del-root');
+      const childRevoked = await revocationManager.isRevoked('del-child');
+      const gcRevoked = await revocationManager.isRevoked('del-gc');
+
+      expect(rootRevoked.revoked).toBe(true);
+      expect(childRevoked.revoked).toBe(true);
+      expect(gcRevoked.revoked).toBe(true);
+    });
+
+    it('should only revoke descendants, not siblings or ancestors', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child1', 'del-root', agentA.did, agentB.did);
+      await registerWithStatus('del-child2', 'del-root', agentA.did, agentC.did);
+
+      // Revoke child1 only
+      await revocationManager.revokeDelegation('del-child1');
+
+      const child1 = await revocationManager.isRevoked('del-child1');
+      const child2 = await revocationManager.isRevoked('del-child2');
+      const root = await revocationManager.isRevoked('del-root');
+
+      expect(child1.revoked).toBe(true);
+      expect(child2.revoked).toBe(false);
+      expect(root.revoked).toBe(false);
+    });
+
+    // BUG: isRevoked() can't distinguish "directly revoked" from "cascade revoked"
+    // because cascading revocation sets bits on ALL descendants. chain.reverse()
+    // finds the child's own bit first, so revokedAncestor is never populated.
+    // See: https://github.com/modelcontextprotocol-identity/mcp-i-core/issues/30
+    it.skip('should detect ancestor revocation through chain walk — see #30', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+
+      await revocationManager.revokeDelegation('del-root');
+
+      const childStatus = await revocationManager.isRevoked('del-child');
+      expect(childStatus.revoked).toBe(true);
+      expect(childStatus.revokedAncestor).toBe('del-root');
+    });
+  });
+
+  // ── Restore Behavior ──────────────────────────────────────────
+
+  describe('restore delegation', () => {
+    it('should restore root but NOT restore cascaded children', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+
+      // Revoke root (cascades to child)
+      await revocationManager.revokeDelegation('del-root');
+
+      const rootBefore = await revocationManager.isRevoked('del-root');
+      const childBefore = await revocationManager.isRevoked('del-child');
+      expect(rootBefore.revoked).toBe(true);
+      expect(childBefore.revoked).toBe(true);
+
+      // Restore root only
+      await revocationManager.restoreDelegation('del-root');
+
+      const rootAfter = await revocationManager.isRevoked('del-root');
+      const childAfter = await revocationManager.isRevoked('del-child');
+
+      expect(rootAfter.revoked).toBe(false);
+      // Child should STILL be revoked — restore is not recursive
+      expect(childAfter.revoked).toBe(true);
+    });
+  });
+
+  // ── Dry-Run ───────────────────────────────────────────────────
+
+  describe('dry-run mode', () => {
+    it('should not modify StatusList bits in dry-run', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+
+      const events = await revocationManager.revokeDelegation('del-root', { dryRun: true });
+
+      expect(events.length).toBe(2);
+
+      // Nothing should actually be revoked
+      const root = await revocationManager.isRevoked('del-root');
+      const child = await revocationManager.isRevoked('del-child');
+
+      expect(root.revoked).toBe(false);
+      expect(child.revoked).toBe(false);
+    });
+  });
+
+  // ── Deep Chain ────────────────────────────────────────────────
+
+  describe('deep chain cascading', () => {
+    it('should cascade through a depth-10 chain', async () => {
+      // Build chain of depth 10
+      const dids = [issuerIdentity, agentA, agentB, agentC];
+      let parentId: string | null = null;
+
+      for (let i = 0; i < 10; i++) {
+        const issuerIdx = i % dids.length;
+        const subjectIdx = (i + 1) % dids.length;
+        const id = `del-depth-${i}`;
+
+        await registerWithStatus(
+          id,
+          parentId,
+          dids[issuerIdx]!.did,
+          dids[subjectIdx]!.did
+        );
+        parentId = id;
+      }
+
+      // Revoke root — all 9 descendants should be revoked
+      const events = await revocationManager.revokeDelegation('del-depth-0');
+      expect(events.length).toBe(10);
+
+      for (let i = 0; i < 10; i++) {
+        const status = await revocationManager.isRevoked(`del-depth-${i}`);
+        expect(status.revoked).toBe(true);
+      }
+    });
+  });
+
+  // ── Concurrent Revocation ─────────────────────────────────────
+
+  describe('concurrent revocation', () => {
+    // BUG: StatusList2021Manager.updateStatus does read-modify-write without
+    // atomicity. Concurrent calls both read the same bitstring, each sets their
+    // own bit, then the second write overwrites the first — losing a revocation.
+    // See: https://github.com/modelcontextprotocol-identity/mcp-i-core/issues/31
+    it.skip('should handle concurrent revocation of sibling subtrees — see #31', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child1', 'del-root', agentA.did, agentB.did);
+      await registerWithStatus('del-gc1', 'del-child1', agentB.did, agentC.did);
+      await registerWithStatus('del-child2', 'del-root', agentA.did, agentC.did);
+      await registerWithStatus('del-gc2', 'del-child2', agentC.did, agentB.did);
+
+      // Revoke both subtrees concurrently
+      const [events1, events2] = await Promise.all([
+        revocationManager.revokeDelegation('del-child1'),
+        revocationManager.revokeDelegation('del-child2'),
+      ]);
+
+      expect(events1.length).toBeGreaterThanOrEqual(2);
+      expect(events2.length).toBeGreaterThanOrEqual(2);
+
+      // All 4 nodes should be revoked
+      for (const id of ['del-child1', 'del-gc1', 'del-child2', 'del-gc2']) {
+        const status = await revocationManager.isRevoked(id);
+        expect(status.revoked).toBe(true);
+      }
+
+      // Root should not be revoked
+      const root = await revocationManager.isRevoked('del-root');
+      expect(root.revoked).toBe(false);
+    });
+  });
+
+  // ── validateDelegation ────────────────────────────────────────
+
+  describe('validateDelegation', () => {
+    it('should return valid for non-revoked, well-formed chain', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+
+      const result = await revocationManager.validateDelegation('del-child');
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid after ancestor revocation', async () => {
+      await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
+      await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
+
+      await revocationManager.revokeDelegation('del-root');
+
+      const result = await revocationManager.validateDelegation('del-child');
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/audit/helpers/crypto-helpers.ts
+++ b/src/__tests__/audit/helpers/crypto-helpers.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared Test Helpers for Audit Tests
+ *
+ * Provides real (non-mocked) crypto, clock, and signing utilities
+ * for round-trip and boundary testing. All helpers use NodeCryptoProvider
+ * for actual Ed25519 operations.
+ */
+
+import * as zlib from 'node:zlib';
+import { NodeCryptoProvider } from '../../utils/node-crypto-provider.js';
+import { MemoryIdentityProvider, MemoryNonceCacheProvider } from '../../../providers/memory.js';
+import { ClockProvider, FetchProvider } from '../../../providers/base.js';
+import type { AgentIdentity } from '../../../providers/base.js';
+import type { Proof, StatusList2021Credential, DelegationRecord } from '../../../types/protocol.js';
+import type { VCSigningFunction } from '../../../delegation/vc-issuer.js';
+import type { SignatureVerificationFunction, DIDDocument } from '../../../delegation/vc-verifier.js';
+import { canonicalizeJSON } from '../../../delegation/utils.js';
+import { createDidKeyResolver } from '../../../delegation/did-key-resolver.js';
+import type { CompressionFunction, DecompressionFunction } from '../../../delegation/bitstring.js';
+import { StatusList2021Manager } from '../../../delegation/statuslist-manager.js';
+import { MemoryStatusListStorage } from '../../../delegation/storage/memory-statuslist-storage.js';
+
+// ── Crypto ──────────────────────────────────────────────────────
+
+export function createRealCryptoProvider(): NodeCryptoProvider {
+  return new NodeCryptoProvider();
+}
+
+export async function createRealIdentity(crypto: NodeCryptoProvider): Promise<AgentIdentity> {
+  const provider = new MemoryIdentityProvider(crypto);
+  return provider.getIdentity();
+}
+
+// ── Clock Providers ─────────────────────────────────────────────
+
+export class RealClockProvider extends ClockProvider {
+  now(): number {
+    return Date.now();
+  }
+  isWithinSkew(timestampMs: number, skewSeconds: number): boolean {
+    return Math.abs(Date.now() - timestampMs) <= skewSeconds * 1000;
+  }
+  hasExpired(expiresAt: number): boolean {
+    return Date.now() > expiresAt;
+  }
+  calculateExpiry(ttlSeconds: number): number {
+    return Date.now() + ttlSeconds * 1000;
+  }
+  format(timestamp: number): string {
+    return new Date(timestamp).toISOString();
+  }
+}
+
+/**
+ * Clock provider with a controllable "now" for precise boundary testing.
+ * `setNow(ms)` moves the clock to an exact millisecond.
+ */
+export class ControllableClockProvider extends ClockProvider {
+  private currentMs: number;
+
+  constructor(nowMs: number = Date.now()) {
+    super();
+    this.currentMs = nowMs;
+  }
+
+  setNow(ms: number): void {
+    this.currentMs = ms;
+  }
+
+  advance(ms: number): void {
+    this.currentMs += ms;
+  }
+
+  now(): number {
+    return this.currentMs;
+  }
+
+  isWithinSkew(timestampMs: number, skewSeconds: number): boolean {
+    return Math.abs(this.currentMs - timestampMs) <= skewSeconds * 1000;
+  }
+
+  hasExpired(expiresAt: number): boolean {
+    return this.currentMs > expiresAt;
+  }
+
+  calculateExpiry(ttlSeconds: number): number {
+    return this.currentMs + ttlSeconds * 1000;
+  }
+
+  format(timestamp: number): string {
+    return new Date(timestamp).toISOString();
+  }
+}
+
+// ── Fetch Provider ──────────────────────────────────────────────
+
+export class RealFetchProvider extends FetchProvider {
+  private didResolver = createDidKeyResolver();
+
+  async resolveDID(did: string): Promise<DIDDocument | null> {
+    return this.didResolver.resolve(did);
+  }
+
+  async fetchStatusList(_url: string): Promise<StatusList2021Credential | null> {
+    return null;
+  }
+
+  async fetchDelegationChain(_id: string): Promise<DelegationRecord[]> {
+    return [];
+  }
+
+  async fetch(_url: string, _options?: unknown): Promise<Response> {
+    throw new Error('Not implemented');
+  }
+}
+
+// ── Signing & Verification ──────────────────────────────────────
+
+/**
+ * Creates a real VCSigningFunction that produces Ed25519Signature2020 proofs.
+ * The signature is over the canonicalized VC (the `canonicalVC` string passed in).
+ */
+export function createRealSigningFunction(
+  crypto: NodeCryptoProvider,
+  identity: AgentIdentity
+): VCSigningFunction {
+  return async (canonicalVC: string, issuerDid: string, kid: string): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const signature = await crypto.sign(data, identity.privateKey);
+    const proofValue = Buffer.from(signature).toString('base64url');
+
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+}
+
+/**
+ * Creates a real SignatureVerificationFunction for the VC verifier.
+ * Strips `proof`, canonicalizes, and verifies the Ed25519 signature.
+ */
+export function createRealSignatureVerifier(
+  crypto: NodeCryptoProvider
+): SignatureVerificationFunction {
+  return async (vc, publicKeyJwk) => {
+    try {
+      const jwk = publicKeyJwk as { x?: string };
+      if (!jwk.x) {
+        return { valid: false, reason: 'Missing public key x coordinate' };
+      }
+
+      // Decode the public key from base64url (JWK x parameter)
+      const publicKeyBase64 = Buffer.from(jwk.x, 'base64url').toString('base64');
+
+      // Strip proof and canonicalize
+      const vcWithoutProof = { ...vc } as Record<string, unknown>;
+      delete vcWithoutProof['proof'];
+      const canonicalVC = canonicalizeJSON(vcWithoutProof);
+      const data = new TextEncoder().encode(canonicalVC);
+
+      // Extract signature from proof
+      const proofValue = vc.proof?.proofValue;
+      if (!proofValue) {
+        return { valid: false, reason: 'Missing proofValue' };
+      }
+
+      const signature = Buffer.from(proofValue as string, 'base64url');
+      const isValid = await crypto.verify(data, new Uint8Array(signature), publicKeyBase64);
+
+      return { valid: isValid, reason: isValid ? undefined : 'Signature verification failed' };
+    } catch (error) {
+      return {
+        valid: false,
+        reason: `Verification error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  };
+}
+
+// ── Compression (real gzip via Node.js zlib) ────────────────────
+
+export const nodeCompressor: CompressionFunction = {
+  compress(data: Uint8Array): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      zlib.gzip(Buffer.from(data), (err, result) => {
+        if (err) reject(err);
+        else resolve(new Uint8Array(result));
+      });
+    });
+  },
+};
+
+export const nodeDecompressor: DecompressionFunction = {
+  decompress(data: Uint8Array): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      zlib.gunzip(Buffer.from(data), (err, result) => {
+        if (err) reject(err);
+        else resolve(new Uint8Array(result));
+      });
+    });
+  },
+};
+
+// ── StatusList2021 Manager (real) ───────────────────────────────
+
+export interface RealStatusListSetup {
+  manager: StatusList2021Manager;
+  storage: MemoryStatusListStorage;
+}
+
+export function createRealStatusListManager(
+  crypto: NodeCryptoProvider,
+  identity: AgentIdentity,
+  options?: { statusListBaseUrl?: string; defaultListSize?: number }
+): RealStatusListSetup {
+  const storage = new MemoryStatusListStorage();
+  const signingFunction = createRealSigningFunction(crypto, identity);
+
+  const identityProvider = {
+    getDid: () => identity.did,
+    getKeyId: () => identity.kid,
+  };
+
+  const manager = new StatusList2021Manager(
+    storage,
+    identityProvider,
+    signingFunction,
+    nodeCompressor,
+    nodeDecompressor,
+    options
+  );
+
+  return { manager, storage };
+}
+
+// ── Re-exports for convenience ──────────────────────────────────
+
+export { MemoryNonceCacheProvider } from '../../../providers/memory.js';
+export { MemoryIdentityProvider } from '../../../providers/memory.js';
+export { MemoryDelegationGraphStorage } from '../../../delegation/storage/memory-graph-storage.js';
+export { MemoryStatusListStorage } from '../../../delegation/storage/memory-statuslist-storage.js';

--- a/src/__tests__/audit/proof-boundary.test.ts
+++ b/src/__tests__/audit/proof-boundary.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Proof Boundary Audit Tests
+ *
+ * Tests the proof generation → verification pipeline at exact boundary
+ * conditions: timestamp skew thresholds, nonce scoping, malformed proofs.
+ * Uses ControllableClockProvider for deterministic timestamp testing.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { ProofGenerator } from '../../proof/generator.js';
+import { ProofVerifier } from '../../proof/verifier.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import type { DetachedProof } from '../../types/protocol.js';
+import { extractPublicKeyFromDidKey, publicKeyToJwk } from '../../delegation/did-key-resolver.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  ControllableClockProvider,
+  RealFetchProvider,
+  MemoryNonceCacheProvider,
+} from './helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+import type { Ed25519JWK } from '../../utils/crypto-service.js';
+
+describe('Proof Boundary Audit', () => {
+  let crypto: NodeCryptoProvider;
+  let agentA: AgentIdentity;
+  let agentB: AgentIdentity;
+  const SKEW_SECONDS = 300; // default 5 minutes
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    agentA = await createRealIdentity(crypto);
+    agentB = await createRealIdentity(crypto);
+  });
+
+  function makeGenerator(identity: AgentIdentity): ProofGenerator {
+    return new ProofGenerator(
+      { did: identity.did, kid: identity.kid, privateKey: identity.privateKey, publicKey: identity.publicKey },
+      crypto
+    );
+  }
+
+  function makeVerifier(clock: ControllableClockProvider): {
+    verifier: ProofVerifier;
+    nonceCache: MemoryNonceCacheProvider;
+  } {
+    const nonceCache = new MemoryNonceCacheProvider();
+    const verifier = new ProofVerifier({
+      cryptoProvider: crypto,
+      clockProvider: clock,
+      nonceCacheProvider: nonceCache,
+      fetchProvider: new RealFetchProvider(),
+      timestampSkewSeconds: SKEW_SECONDS,
+    });
+    return { verifier, nonceCache };
+  }
+
+  function getPublicKeyJwk(identity: AgentIdentity): Ed25519JWK {
+    const rawPublicKey = extractPublicKeyFromDidKey(identity.did);
+    const jwk = publicKeyToJwk(rawPublicKey!);
+    jwk.kid = identity.kid;
+    return jwk as Ed25519JWK;
+  }
+
+  async function generateProof(identity: AgentIdentity): Promise<DetachedProof> {
+    const gen = makeGenerator(identity);
+    return gen.generateProof(
+      { method: 'tools/call', params: { name: 'test-tool', arguments: { input: 'hello' } } },
+      { data: { output: 'world' } },
+      {
+        sessionId: 'sess_test_boundary',
+        audience: 'did:web:test-server.example.com',
+        nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        timestamp: Math.floor(Date.now() / 1000),
+        createdAt: Math.floor(Date.now() / 1000),
+        lastActivity: Math.floor(Date.now() / 1000),
+        ttlMinutes: 30,
+        identityState: 'anonymous',
+      }
+    );
+  }
+
+  // ── Timestamp Skew Boundary Tests ─────────────────────────────
+
+  describe('timestamp skew boundaries', () => {
+    it('should accept proof at exactly the skew boundary (300s)', async () => {
+      const proofTimestampSec = Math.floor(Date.now() / 1000);
+      const proofTimestampMs = proofTimestampSec * 1000;
+
+      // Clock is exactly SKEW_SECONDS * 1000 ms ahead of the proof timestamp
+      const clock = new ControllableClockProvider(proofTimestampMs + SKEW_SECONDS * 1000);
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      // Override the proof timestamp to be our controlled value
+      proof.meta.ts = proofTimestampSec;
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject proof 1ms beyond the skew boundary', async () => {
+      const proofTimestampSec = Math.floor(Date.now() / 1000);
+      const proofTimestampMs = proofTimestampSec * 1000;
+
+      // Clock is 1ms beyond the skew window
+      const clock = new ControllableClockProvider(proofTimestampMs + SKEW_SECONDS * 1000 + 1);
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      proof.meta.ts = proofTimestampSec;
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('skew');
+    });
+
+    it('should accept proof when verifier clock is behind by exactly the skew boundary', async () => {
+      // Generate proof with real timestamp (meta.ts ≈ now)
+      const proof = await generateProof(agentA);
+      const proofTimestampMs = proof.meta.ts * 1000;
+
+      // Set verifier clock to be exactly SKEW_SECONDS behind the proof
+      // This simulates verifying a proof from a clock-ahead agent
+      const clock = new ControllableClockProvider(proofTimestampMs - SKEW_SECONDS * 1000);
+      const { verifier } = makeVerifier(clock);
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject proof when verifier clock is behind beyond the skew boundary', async () => {
+      const proof = await generateProof(agentA);
+      const proofTimestampMs = proof.meta.ts * 1000;
+
+      // Set verifier clock 1ms further than the boundary
+      const clock = new ControllableClockProvider(proofTimestampMs - SKEW_SECONDS * 1000 - 1);
+      const { verifier } = makeVerifier(clock);
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('skew');
+    });
+  });
+
+  // ── Nonce Scoping Tests ───────────────────────────────────────
+
+  describe('nonce scoping', () => {
+    it('should allow same nonce value from different agents (no cross-agent collision)', async () => {
+      const sharedNonce = 'shared-nonce-value-12345';
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      // Generate proofs for both agents with the same nonce
+      const genA = makeGenerator(agentA);
+      const genB = makeGenerator(agentB);
+
+      const session = {
+        sessionId: 'sess_nonce_test',
+        audience: 'did:web:server.example.com',
+        nonce: sharedNonce,
+        timestamp: Math.floor(Date.now() / 1000),
+        createdAt: Math.floor(Date.now() / 1000),
+        lastActivity: Math.floor(Date.now() / 1000),
+        ttlMinutes: 30,
+        identityState: 'anonymous' as const,
+      };
+
+      const request = { method: 'tools/call', params: { name: 'test' } };
+      const response = { data: { result: 'ok' } };
+
+      const proofA = await genA.generateProof(request, response, session);
+      const proofB = await genB.generateProof(request, response, session);
+
+      const jwkA = getPublicKeyJwk(agentA);
+      const jwkB = getPublicKeyJwk(agentB);
+
+      const resultA = await verifier.verifyProof(proofA, jwkA);
+      expect(resultA.valid).toBe(true);
+
+      // Same nonce, different agent — should also succeed
+      const resultB = await verifier.verifyProof(proofB, jwkB);
+      expect(resultB.valid).toBe(true);
+    });
+
+    it('should reject replay of same nonce from same agent', async () => {
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      const jwk = getPublicKeyJwk(agentA);
+
+      const result1 = await verifier.verifyProof(proof, jwk);
+      expect(result1.valid).toBe(true);
+
+      // Same exact proof (same nonce, same agent) — should be rejected as replay
+      const result2 = await verifier.verifyProof(proof, jwk);
+      expect(result2.valid).toBe(false);
+      expect(result2.reason).toContain('replay');
+    });
+  });
+
+  // ── Wrong Key Tests ───────────────────────────────────────────
+
+  describe('signature verification with wrong key', () => {
+    it('should reject proof verified with wrong public key', async () => {
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      // Generate proof with agent A
+      const proof = await generateProof(agentA);
+
+      // Try to verify with agent B's public key
+      const wrongJwk = getPublicKeyJwk(agentB);
+
+      const result = await verifier.verifyProof(proof, wrongJwk);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // ── Malformed Proof Tests ─────────────────────────────────────
+
+  describe('malformed proof rejection', () => {
+    it('should reject proof with empty nonce', async () => {
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      proof.meta.nonce = '';
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject proof with malformed requestHash', async () => {
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      proof.meta.requestHash = 'md5:abc123';
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject proof with ts=0', async () => {
+      const clock = new ControllableClockProvider(Date.now());
+      const { verifier } = makeVerifier(clock);
+
+      const proof = await generateProof(agentA);
+      proof.meta.ts = 0;
+
+      const jwk = getPublicKeyJwk(agentA);
+      const result = await verifier.verifyProof(proof, jwk);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/audit/proof-boundary.test.ts
+++ b/src/__tests__/audit/proof-boundary.test.ts
@@ -85,16 +85,16 @@ describe('Proof Boundary Audit', () => {
 
   describe('timestamp skew boundaries', () => {
     it('should accept proof at exactly the skew boundary (300s)', async () => {
-      const proofTimestampSec = Math.floor(Date.now() / 1000);
-      const proofTimestampMs = proofTimestampSec * 1000;
+      // Generate proof first, then use its actual meta.ts to set the clock.
+      // This avoids a race where a second boundary is crossed between
+      // capturing the timestamp and generating the proof (which would
+      // cause a JWS signature mismatch).
+      const proof = await generateProof(agentA);
+      const proofTimestampMs = proof.meta.ts * 1000;
 
       // Clock is exactly SKEW_SECONDS * 1000 ms ahead of the proof timestamp
       const clock = new ControllableClockProvider(proofTimestampMs + SKEW_SECONDS * 1000);
       const { verifier } = makeVerifier(clock);
-
-      const proof = await generateProof(agentA);
-      // Override the proof timestamp to be our controlled value
-      proof.meta.ts = proofTimestampSec;
 
       const jwk = getPublicKeyJwk(agentA);
       const result = await verifier.verifyProof(proof, jwk);
@@ -103,15 +103,12 @@ describe('Proof Boundary Audit', () => {
     });
 
     it('should reject proof 1ms beyond the skew boundary', async () => {
-      const proofTimestampSec = Math.floor(Date.now() / 1000);
-      const proofTimestampMs = proofTimestampSec * 1000;
+      const proof = await generateProof(agentA);
+      const proofTimestampMs = proof.meta.ts * 1000;
 
       // Clock is 1ms beyond the skew window
       const clock = new ControllableClockProvider(proofTimestampMs + SKEW_SECONDS * 1000 + 1);
       const { verifier } = makeVerifier(clock);
-
-      const proof = await generateProof(agentA);
-      proof.meta.ts = proofTimestampSec;
 
       const jwk = getPublicKeyJwk(agentA);
       const result = await verifier.verifyProof(proof, jwk);

--- a/src/__tests__/audit/statuslist-bitstring-roundtrip.test.ts
+++ b/src/__tests__/audit/statuslist-bitstring-roundtrip.test.ts
@@ -1,0 +1,135 @@
+/**
+ * StatusList2021 + Bitstring Round-Trip Audit Tests
+ *
+ * Tests the full lifecycle: allocate status entry → check (not revoked) →
+ * revoke → check (revoked), using real gzip compression and bitstring encoding.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import type { AgentIdentity } from '../../providers/base.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealStatusListManager,
+  type RealStatusListSetup,
+} from './helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+
+describe('StatusList Bitstring Round-Trip Audit', () => {
+  let crypto: NodeCryptoProvider;
+  let identity: AgentIdentity;
+  let setup: RealStatusListSetup;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    identity = await createRealIdentity(crypto);
+  });
+
+  beforeEach(() => {
+    setup = createRealStatusListManager(crypto, identity);
+  });
+
+  it('should allocate, check not revoked, revoke, then check revoked', async () => {
+    const statusEntry = await setup.manager.allocateStatusEntry('revocation');
+
+    // Initially not revoked
+    const beforeRevoke = await setup.manager.checkStatus(statusEntry);
+    expect(beforeRevoke).toBe(false);
+
+    // Revoke
+    await setup.manager.updateStatus(statusEntry, true);
+
+    // Now revoked
+    const afterRevoke = await setup.manager.checkStatus(statusEntry);
+    expect(afterRevoke).toBe(true);
+  });
+
+  it('should selectively revoke entries in the same status list', async () => {
+    // Allocate 5 entries
+    const entries = [];
+    for (let i = 0; i < 5; i++) {
+      entries.push(await setup.manager.allocateStatusEntry('revocation'));
+    }
+
+    // Revoke entries at index 1 and 3
+    await setup.manager.updateStatus(entries[1]!, true);
+    await setup.manager.updateStatus(entries[3]!, true);
+
+    // Check all 5
+    const statuses = await Promise.all(
+      entries.map((e) => setup.manager.checkStatus(e))
+    );
+
+    expect(statuses[0]).toBe(false);
+    expect(statuses[1]).toBe(true);
+    expect(statuses[2]).toBe(false);
+    expect(statuses[3]).toBe(true);
+    expect(statuses[4]).toBe(false);
+  });
+
+  it('should report revoked indices correctly via getRevokedIndices', async () => {
+    const entries = [];
+    for (let i = 0; i < 6; i++) {
+      entries.push(await setup.manager.allocateStatusEntry('revocation'));
+    }
+
+    // Revoke indices 0, 2, 5
+    await setup.manager.updateStatus(entries[0]!, true);
+    await setup.manager.updateStatus(entries[2]!, true);
+    await setup.manager.updateStatus(entries[5]!, true);
+
+    const statusListId = `${setup.manager.getStatusListBaseUrl()}/revocation/v1`;
+    const revoked = await setup.manager.getRevokedIndices(statusListId);
+
+    expect(revoked).toContain(0);
+    expect(revoked).toContain(2);
+    expect(revoked).toContain(5);
+    expect(revoked).not.toContain(1);
+    expect(revoked).not.toContain(3);
+    expect(revoked).not.toContain(4);
+  });
+
+  it('should re-sign the status list credential after update', async () => {
+    const entry = await setup.manager.allocateStatusEntry('revocation');
+
+    const statusListId = `${setup.manager.getStatusListBaseUrl()}/revocation/v1`;
+    const credBefore = await setup.storage.getStatusList(statusListId);
+    const proofBefore = credBefore?.proof?.proofValue;
+
+    // Revoke — triggers re-signing
+    await setup.manager.updateStatus(entry, true);
+
+    const credAfter = await setup.storage.getStatusList(statusListId);
+    const proofAfter = credAfter?.proof?.proofValue;
+
+    expect(proofBefore).toBeDefined();
+    expect(proofAfter).toBeDefined();
+    expect(proofAfter).not.toBe(proofBefore);
+  });
+
+  it('should handle bits at byte boundaries correctly (index 7 and 8)', async () => {
+    // Allocate enough entries to reach index 7 and 8
+    const entries = [];
+    for (let i = 0; i < 9; i++) {
+      entries.push(await setup.manager.allocateStatusEntry('revocation'));
+    }
+
+    // Index 7 = last bit of byte 0, Index 8 = first bit of byte 1
+    await setup.manager.updateStatus(entries[7]!, true);
+    await setup.manager.updateStatus(entries[8]!, true);
+
+    expect(await setup.manager.checkStatus(entries[6]!)).toBe(false);
+    expect(await setup.manager.checkStatus(entries[7]!)).toBe(true);
+    expect(await setup.manager.checkStatus(entries[8]!)).toBe(true);
+  });
+
+  it('should un-revoke (restore) an entry by setting status to false', async () => {
+    const entry = await setup.manager.allocateStatusEntry('revocation');
+
+    await setup.manager.updateStatus(entry, true);
+    expect(await setup.manager.checkStatus(entry)).toBe(true);
+
+    await setup.manager.updateStatus(entry, false);
+    expect(await setup.manager.checkStatus(entry)).toBe(false);
+  });
+});

--- a/src/__tests__/audit/vc-roundtrip.test.ts
+++ b/src/__tests__/audit/vc-roundtrip.test.ts
@@ -1,0 +1,290 @@
+/**
+ * VC Round-Trip Audit Tests
+ *
+ * Tests the full lifecycle: issue a DelegationCredential with real Ed25519
+ * signing, then verify it through the 3-stage verification pipeline.
+ * No mocks on crypto, canonicalization, or signing.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import {
+  DelegationCredentialVerifier,
+  type DIDResolver,
+} from '../../delegation/vc-verifier.js';
+import { createDidKeyResolver } from '../../delegation/did-key-resolver.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import type { DelegationRecord, DelegationCredential } from '../../types/protocol.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealSigningFunction,
+  createRealSignatureVerifier,
+} from './helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+
+describe('VC Round-Trip Audit', () => {
+  let crypto: NodeCryptoProvider;
+  let issuerIdentity: AgentIdentity;
+  let subjectIdentity: AgentIdentity;
+  let issuer: DelegationCredentialIssuer;
+  let verifier: DelegationCredentialVerifier;
+  let didResolver: DIDResolver;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    issuerIdentity = await createRealIdentity(crypto);
+    subjectIdentity = await createRealIdentity(crypto);
+
+    const signingFunction = createRealSigningFunction(crypto, issuerIdentity);
+    const signatureVerifier = createRealSignatureVerifier(crypto);
+    didResolver = createDidKeyResolver();
+
+    const issuerIdProvider = {
+      getDid: () => issuerIdentity.did,
+      getKeyId: () => issuerIdentity.kid,
+      getPrivateKey: () => issuerIdentity.privateKey,
+    };
+
+    issuer = new DelegationCredentialIssuer(issuerIdProvider, signingFunction);
+
+    verifier = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier,
+    });
+  });
+
+  function makeDelegationRecord(overrides?: Partial<DelegationRecord>): DelegationRecord {
+    return {
+      id: 'test-delegation-001',
+      issuerDid: issuerIdentity.did,
+      subjectDid: subjectIdentity.did,
+      vcId: 'urn:uuid:test-vc-001',
+      constraints: {
+        scopes: ['tools:read', 'tools:write'],
+        notBefore: Math.floor(Date.now() / 1000) - 3600,
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+      signature: '',
+      status: 'active',
+      createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  // ── Round-Trip Tests ──────────────────────────────────────────
+
+  it('should issue and verify a delegation credential round-trip', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.stage).toBe('complete');
+    expect(result.checks?.basicValid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('should reject VC with tampered credentialSubject', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    // Tamper with the scopes after signing
+    const tampered = structuredClone(vc);
+    tampered.credentialSubject.delegation.scopes = ['admin:*'];
+
+    const result = await verifier.verifyDelegationCredential(tampered, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.checks?.signatureValid).toBe(false);
+  });
+
+  it('should reject VC with swapped issuer DID', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    // Swap issuer to subject's DID — resolver will return subject's key,
+    // which won't match the issuer's signature
+    const tampered = structuredClone(vc);
+    tampered.issuer = subjectIdentity.did;
+
+    const result = await verifier.verifyDelegationCredential(tampered, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject expired VC', async () => {
+    const delegation = makeDelegationRecord({
+      constraints: {
+        scopes: ['tools:read'],
+        notAfter: Math.floor(Date.now() / 1000) - 1, // 1 second in the past
+      },
+    });
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe('basic');
+    expect(result.reason).toContain('expired');
+  });
+
+  it('should reject VC with revoked status field', async () => {
+    const delegation = makeDelegationRecord({ status: 'revoked' });
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe('basic');
+    expect(result.reason).toContain('revoked');
+  });
+
+  it('should reject VC without proof field', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    // Remove proof entirely
+    const noProof = { ...vc } as Record<string, unknown>;
+    delete noProof['proof'];
+
+    const result = await verifier.verifyDelegationCredential(
+      noProof as DelegationCredential,
+      { skipStatus: true, skipCache: true }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe('basic');
+    expect(result.reason).toContain('proof');
+  });
+
+  it('should reject VC when DID resolver returns null', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    const nullResolver: DIDResolver = {
+      resolve: async () => null,
+    };
+
+    const strictVerifier = new DelegationCredentialVerifier({
+      didResolver: nullResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+
+    const result = await strictVerifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('resolve');
+  });
+
+  // ── Caching Tests ─────────────────────────────────────────────
+
+  it('should return cached result on second verification', async () => {
+    const delegation = makeDelegationRecord();
+    const vc = await issuer.issueDelegationCredential(delegation);
+
+    const cachingVerifier = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+      cacheTtl: 60_000,
+    });
+
+    const first = await cachingVerifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+    });
+    expect(first.valid).toBe(true);
+    expect(first.cached).toBeUndefined();
+
+    const second = await cachingVerifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+    });
+    expect(second.valid).toBe(true);
+    expect(second.cached).toBe(true);
+  });
+
+  it('should evict oldest cache entry when maxCacheSize is exceeded', async () => {
+    const cachingVerifier = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+      cacheTtl: 60_000,
+      maxCacheSize: 2,
+    });
+
+    // Issue 3 distinct VCs
+    const vcs: DelegationCredential[] = [];
+    for (let i = 0; i < 3; i++) {
+      const delegation = makeDelegationRecord({
+        id: `cache-test-${i}`,
+        vcId: `urn:uuid:cache-test-${i}`,
+      });
+      vcs.push(await issuer.issueDelegationCredential(delegation));
+    }
+
+    // Verify all 3 — first should be evicted
+    for (const vc of vcs) {
+      await cachingVerifier.verifyDelegationCredential(vc, { skipStatus: true });
+    }
+
+    // First VC should NOT be cached (evicted)
+    const first = await cachingVerifier.verifyDelegationCredential(vcs[0]!, {
+      skipStatus: true,
+    });
+    expect(first.cached).toBeUndefined();
+
+    // Third VC should still be cached
+    const third = await cachingVerifier.verifyDelegationCredential(vcs[2]!, {
+      skipStatus: true,
+    });
+    expect(third.cached).toBe(true);
+  });
+
+  // ── Signature Integrity ───────────────────────────────────────
+
+  it('should produce different signatures for different delegations', async () => {
+    const vc1 = await issuer.issueDelegationCredential(
+      makeDelegationRecord({ id: 'del-A' })
+    );
+    const vc2 = await issuer.issueDelegationCredential(
+      makeDelegationRecord({ id: 'del-B' })
+    );
+
+    expect(vc1.proof?.proofValue).not.toBe(vc2.proof?.proofValue);
+  });
+
+  it('should produce identical canonicalization for same delegation regardless of field order', async () => {
+    const delegation = makeDelegationRecord();
+    const vc1 = await issuer.issueDelegationCredential(delegation);
+    const vc2 = await issuer.issueDelegationCredential(delegation);
+
+    // Same input should produce same unsigned VC structure
+    // (proof timestamps differ, but the unsigned portion should canonicalize the same)
+    const strip = (vc: DelegationCredential) => {
+      const copy = { ...vc } as Record<string, unknown>;
+      delete copy['proof'];
+      return copy;
+    };
+
+    const { canonicalizeJSON } = await import('../../delegation/utils.js');
+    expect(canonicalizeJSON(strip(vc1))).toBe(canonicalizeJSON(strip(vc2)));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **60 audit tests** across 5 test files that verify real behavioral correctness using actual Ed25519 crypto (no mocked signing/verification)
- Adds shared `crypto-helpers.ts` with reusable factories for real crypto providers, controllable clocks, signing functions, and StatusList2021 managers
- Adds `.github/ISSUE_TEMPLATE/test_audit_finding.md` for tracking discovered bugs
- Discovered **2 real bugs** (tests marked `it.skip` with issue references)

### Test Files

| File | Tests | What it covers |
|------|-------|----------------|
| `vc-roundtrip.test.ts` | 11 | Issue VC with real Ed25519 → verify through 3-stage pipeline, tamper detection, expiry, caching |
| `proof-boundary.test.ts` | 10 | Timestamp skew at exact boundaries, nonce scoping per agent DID, wrong-key rejection, malformed proofs |
| `graph-revocation-roundtrip.test.ts` | 11 (2 skipped) | Delegation chain validation, cascading revocation with real StatusList2021 bitstring + gzip |
| `statuslist-bitstring-roundtrip.test.ts` | 6 | Allocate → revoke → check round-trip, byte boundary handling, selective revocation |
| `canonicalization-integrity.test.ts` | 22 | RFC 8785 determinism, `assertJsonSafe` guards, cross-module consistency, ProofGenerator hash determinism |

### Bugs Discovered

1. **#30** (Medium): `isRevoked()` cannot distinguish direct vs cascade revocation — `revokedAncestor` is never populated after cascading revocation
2. **#31** (High): Race condition in `StatusList2021Manager.updateStatus()` — concurrent revocations can silently lose a revocation due to non-atomic read-modify-write

## Test plan

- [x] All 58 passing audit tests verified with `npx vitest run src/__tests__/audit/`
- [x] Full suite passes: 814 passed, 2 skipped (816 total)
- [x] No existing tests broken
- [x] 2 skipped tests reference filed GitHub issues