### PR TITLE
fix: serialize StatusList2021 updates to prevent concurrent revocation race

### DIFF
--- a/src/__tests__/audit/graph-revocation-roundtrip.test.ts
+++ b/src/__tests__/audit/graph-revocation-roundtrip.test.ts
@@ -232,11 +232,7 @@ describe('Graph-Revocation Round-Trip Audit', () => {
   // ── Concurrent Revocation ─────────────────────────────────────
 
   describe('concurrent revocation', () => {
-    // BUG: StatusList2021Manager.updateStatus does read-modify-write without
-    // atomicity. Concurrent calls both read the same bitstring, each sets their
-    // own bit, then the second write overwrites the first — losing a revocation.
-    // See: https://github.com/modelcontextprotocol-identity/mcp-i-core/issues/31
-    it.skip('should handle concurrent revocation of sibling subtrees — see #31', async () => {
+    it('should handle concurrent revocation of sibling subtrees', async () => {
       await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
       await registerWithStatus('del-child1', 'del-root', agentA.did, agentB.did);
       await registerWithStatus('del-gc1', 'del-child1', agentB.did, agentC.did);

--- a/src/delegation/statuslist-manager.ts
+++ b/src/delegation/statuslist-manager.ts
@@ -28,6 +28,8 @@ export interface StatusListIdentityProvider {
 export class StatusList2021Manager {
   private statusListBaseUrl: string;
   private defaultListSize: number;
+  /** Per-status-list mutex to serialize updateStatus calls and prevent race conditions. */
+  private updateLocks = new Map<string, Promise<void>>();
 
   constructor(
     private storage: StatusListStorageProvider,
@@ -63,6 +65,21 @@ export class StatusList2021Manager {
   }
 
   async updateStatus(credentialStatus: CredentialStatus, revoked: boolean): Promise<void> {
+    const { statusListCredential } = credentialStatus;
+
+    // Serialize updates per status list to prevent concurrent read-modify-write races.
+    // Each call chains on the previous operation for the same list.
+    const previous = this.updateLocks.get(statusListCredential) ?? Promise.resolve();
+    const operation = previous.then(() => this.doUpdateStatus(credentialStatus, revoked));
+
+    // Store a non-rejecting version so the chain continues even if one update fails
+    this.updateLocks.set(statusListCredential, operation.catch(() => {}));
+
+    // Propagate the actual error to the caller
+    await operation;
+  }
+
+  private async doUpdateStatus(credentialStatus: CredentialStatus, revoked: boolean): Promise<void> {
     const { statusListCredential, statusListIndex } = credentialStatus;
 
     const statusList = await this.storage.getStatusList(statusListCredential);


### PR DESCRIPTION
## Summary

- Adds a per-status-list mutex (promise chain) to `StatusList2021Manager.updateStatus()` so concurrent calls targeting the same status list are serialized
- Unskips the audit test from #32 that exposed this bug — it now passes as a regression test

## The bug

`updateStatus()` does a non-atomic read-modify-write: read bitstring → set bit → encode → sign → write back. When two concurrent calls operate on the same status list, the second write overwrites the first — **silently losing a revocation**.

## The fix

A `Map<string, Promise<void>>` chains operations per status list ID. Each `updateStatus` call waits for the previous operation on the same list to complete before starting its own read-modify-write. Different status lists can still update concurrently.

```typescript
const previous = this.updateLocks.get(statusListCredential) ?? Promise.resolve();
const operation = previous.then(() => this.doUpdateStatus(credentialStatus, revoked));
this.updateLocks.set(statusListCredential, operation.catch(() => {}));
await operation;
```

Closes #31

## Test plan

- [x] Previously-skipped audit test now passes: "should handle concurrent revocation of sibling subtrees"
- [x] Full suite: 815 passed, 1 skipped (816 total)
- [x] All existing statuslist-manager tests pass unchanged