### PR TITLE
fix: detect ancestor revocation in isRevoked() chain walk

### DIFF
--- a/src/__tests__/audit/graph-revocation-roundtrip.test.ts
+++ b/src/__tests__/audit/graph-revocation-roundtrip.test.ts
@@ -133,11 +133,7 @@ describe('Graph-Revocation Round-Trip Audit', () => {
       expect(root.revoked).toBe(false);
     });
 
-    // BUG: isRevoked() can't distinguish "directly revoked" from "cascade revoked"
-    // because cascading revocation sets bits on ALL descendants. chain.reverse()
-    // finds the child's own bit first, so revokedAncestor is never populated.
-    // See: https://github.com/modelcontextprotocol-identity/mcp-i-core/issues/30
-    it.skip('should detect ancestor revocation through chain walk — see #30', async () => {
+    it('should detect ancestor revocation through chain walk', async () => {
       await registerWithStatus('del-root', null, issuerIdentity.did, agentA.did);
       await registerWithStatus('del-child', 'del-root', agentA.did, agentB.did);
 

--- a/src/delegation/cascading-revocation.ts
+++ b/src/delegation/cascading-revocation.ts
@@ -140,9 +140,11 @@ export class CascadingRevocationManager {
     reason?: string;
     revokedAncestor?: string;
   }> {
+    // Walk root → target so ancestor revocation is detected before the
+    // target's own (cascade-set) bit. getChain() already returns root-first order.
     const chain = await this.graph.getChain(delegationId);
 
-    for (const node of chain.reverse()) {
+    for (const node of chain) {
       if (node.credentialStatusId) {
         const credentialStatus = this.parseCredentialStatus(node.credentialStatusId);
         if (credentialStatus) {


### PR DESCRIPTION
## Summary

- Fixes `isRevoked()` to correctly populate `revokedAncestor` after cascading revocation
- One-line fix: remove `.reverse()` from the chain iteration
- Unskips the last remaining audit test from #32 — **all audit tests now pass, 0 skipped**

## The bug

`isRevoked()` called `chain.reverse()` to walk target → root. Since cascading revocation sets StatusList bits on ALL descendants, the target's own bit was always found first, returning `"Directly revoked"` with `revokedAncestor: undefined` — even when the revocation was caused by an ancestor.

## The fix

Remove `.reverse()`. `getChain()` already returns root-first order, so walking root → target finds the ancestor's revocation before the target's cascade-set bit.

| Scenario | Before | After |
|----------|--------|-------|
| Cascade-revoke root, check child | `{ revoked: true, reason: "Directly revoked", revokedAncestor: undefined }` | `{ revoked: true, reason: "Ancestor revoked", revokedAncestor: "root-id" }` |
| Directly revoke child (no cascade) | `{ revoked: true, reason: "Directly revoked" }` | Same (unchanged) |
| Check root that was directly revoked | `{ revoked: true, reason: "Directly revoked" }` | Same (unchanged) |

Closes #30

## Test plan

- [x] Previously-skipped audit test now passes: "should detect ancestor revocation through chain walk"
- [x] Full suite: **816 passed, 0 skipped**
- [x] All existing cascading-revocation tests pass unchanged