### PR TITLE
test: add real-crypto integration tests for critical modules

### DIFF
--- a/src/delegation/__tests__/vc-issuer.integration.test.ts
+++ b/src/delegation/__tests__/vc-issuer.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * VC Issuer Integration Tests (Real Crypto)
+ *
+ * Companion to vc-issuer.test.ts — these tests use real Ed25519 signing
+ * instead of mocking wrapDelegationAsVC and canonicalizeJSON.
+ *
+ * The mocked unit tests verify argument passing and error propagation.
+ * These integration tests verify that issued VCs are structurally valid
+ * and cryptographically verifiable.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  DelegationCredentialIssuer,
+  createDelegationIssuer,
+} from '../vc-issuer.js';
+import { DelegationCredentialVerifier } from '../vc-verifier.js';
+import { createDidKeyResolver } from '../did-key-resolver.js';
+import { canonicalizeJSON } from '../utils.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import type { DelegationRecord } from '../../types/protocol.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealSigningFunction,
+  createRealSignatureVerifier,
+} from '../../__tests__/audit/helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+
+describe('DelegationCredentialIssuer (real crypto)', () => {
+  let crypto: NodeCryptoProvider;
+  let issuerIdentity: AgentIdentity;
+  let subjectIdentity: AgentIdentity;
+  let issuer: DelegationCredentialIssuer;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    issuerIdentity = await createRealIdentity(crypto);
+    subjectIdentity = await createRealIdentity(crypto);
+
+    issuer = createDelegationIssuer(
+      {
+        getDid: () => issuerIdentity.did,
+        getKeyId: () => issuerIdentity.kid,
+        getPrivateKey: () => issuerIdentity.privateKey,
+      },
+      createRealSigningFunction(crypto, issuerIdentity)
+    );
+  });
+
+  function makeDelegation(overrides?: Partial<DelegationRecord>): DelegationRecord {
+    return {
+      id: 'del-integration-001',
+      issuerDid: issuerIdentity.did,
+      subjectDid: subjectIdentity.did,
+      vcId: 'urn:uuid:integration-vc-001',
+      constraints: { scopes: ['tools:read'] },
+      signature: '',
+      status: 'active',
+      createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  it('should produce a VC with valid W3C structure', async () => {
+    const vc = await issuer.issueDelegationCredential(makeDelegation());
+
+    expect(vc['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+    expect(vc.type).toContain('VerifiableCredential');
+    expect(vc.type).toContain('DelegationCredential');
+    expect(vc.issuer).toBe(issuerIdentity.did);
+    expect(vc.credentialSubject.id).toBe(subjectIdentity.did);
+    expect(vc.proof).toBeDefined();
+    expect(vc.proof?.type).toBe('Ed25519Signature2020');
+    expect(vc.proof?.proofValue).toBeTruthy();
+  });
+
+  it('should produce a VC that passes real signature verification', async () => {
+    const vc = await issuer.issueDelegationCredential(makeDelegation());
+
+    const verifier = new DelegationCredentialVerifier({
+      didResolver: createDidKeyResolver(),
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
+  it('should produce deterministic canonicalization for the same input', async () => {
+    const delegation = makeDelegation();
+    const vc1 = await issuer.issueDelegationCredential(delegation);
+    const vc2 = await issuer.issueDelegationCredential(delegation);
+
+    const strip = (vc: Record<string, unknown>) => {
+      const copy = { ...vc };
+      delete copy['proof'];
+      return copy;
+    };
+
+    expect(canonicalizeJSON(strip(vc1))).toBe(canonicalizeJSON(strip(vc2)));
+  });
+
+  it('should produce different signatures for different delegations', async () => {
+    const vc1 = await issuer.issueDelegationCredential(makeDelegation({ id: 'del-A' }));
+    const vc2 = await issuer.issueDelegationCredential(makeDelegation({ id: 'del-B' }));
+
+    expect(vc1.proof?.proofValue).not.toBe(vc2.proof?.proofValue);
+  });
+
+  it('createAndIssueDelegation should produce a verifiable VC', async () => {
+    const vc = await issuer.createAndIssueDelegation({
+      id: 'del-create-issue',
+      issuerDid: issuerIdentity.did,
+      subjectDid: subjectIdentity.did,
+      constraints: { scopes: ['tools:write'] },
+    });
+
+    const verifier = new DelegationCredentialVerifier({
+      didResolver: createDidKeyResolver(),
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/delegation/__tests__/vc-verifier.integration.test.ts
+++ b/src/delegation/__tests__/vc-verifier.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * VC Verifier Integration Tests (Real Crypto)
+ *
+ * Companion to vc-verifier.test.ts — these tests use real Ed25519 signatures
+ * and real validation functions instead of mocking the verification pipeline.
+ *
+ * The mocked unit tests verify pipeline logic and error paths.
+ * These integration tests verify that real VCs are correctly accepted/rejected.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  DelegationCredentialVerifier,
+  type DIDResolver,
+} from '../vc-verifier.js';
+import { DelegationCredentialIssuer } from '../vc-issuer.js';
+import { createDidKeyResolver } from '../did-key-resolver.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import type { DelegationRecord, DelegationCredential } from '../../types/protocol.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealSigningFunction,
+  createRealSignatureVerifier,
+} from '../../__tests__/audit/helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+
+describe('DelegationCredentialVerifier (real crypto)', () => {
+  let crypto: NodeCryptoProvider;
+  let issuerIdentity: AgentIdentity;
+  let subjectIdentity: AgentIdentity;
+  let issuer: DelegationCredentialIssuer;
+  let verifier: DelegationCredentialVerifier;
+  let didResolver: DIDResolver;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    issuerIdentity = await createRealIdentity(crypto);
+    subjectIdentity = await createRealIdentity(crypto);
+
+    didResolver = createDidKeyResolver();
+
+    issuer = new DelegationCredentialIssuer(
+      {
+        getDid: () => issuerIdentity.did,
+        getKeyId: () => issuerIdentity.kid,
+        getPrivateKey: () => issuerIdentity.privateKey,
+      },
+      createRealSigningFunction(crypto, issuerIdentity)
+    );
+
+    verifier = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+  });
+
+  async function issueVC(overrides?: Partial<DelegationRecord>): Promise<DelegationCredential> {
+    return issuer.issueDelegationCredential({
+      id: 'del-verifier-test',
+      issuerDid: issuerIdentity.did,
+      subjectDid: subjectIdentity.did,
+      vcId: `urn:uuid:verifier-test-${Date.now()}`,
+      constraints: {
+        scopes: ['tools:read'],
+        notBefore: Math.floor(Date.now() / 1000) - 3600,
+        notAfter: Math.floor(Date.now() / 1000) + 3600,
+      },
+      signature: '',
+      status: 'active',
+      createdAt: Date.now(),
+      ...overrides,
+    });
+  }
+
+  // ── Basic Validation (real validateDelegationCredential) ──────
+
+  it('should accept a valid VC through all stages', async () => {
+    const vc = await issueVC();
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.stage).toBe('complete');
+    expect(result.checks?.basicValid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
+  it('should reject an expired VC via real expiry check', async () => {
+    const vc = await issueVC({
+      constraints: {
+        scopes: ['tools:read'],
+        notAfter: Math.floor(Date.now() / 1000) - 60, // expired 1 minute ago
+      },
+    });
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe('basic');
+    expect(result.reason).toContain('expired');
+  });
+
+  it('should reject a VC with revoked status field', async () => {
+    const vc = await issueVC({ status: 'revoked' });
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('revoked');
+  });
+
+  // ── Signature Verification (real Ed25519) ─────────────────────
+
+  it('should reject a tampered VC via real signature verification', async () => {
+    const vc = await issueVC();
+    const tampered = structuredClone(vc);
+    tampered.credentialSubject.delegation.scopes = ['admin:*'];
+
+    const result = await verifier.verifyDelegationCredential(tampered, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.checks?.signatureValid).toBe(false);
+  });
+
+  it('should reject when issuer DID is swapped', async () => {
+    const vc = await issueVC();
+    const tampered = structuredClone(vc);
+    tampered.issuer = subjectIdentity.did;
+
+    const result = await verifier.verifyDelegationCredential(tampered, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject when DID resolver cannot find issuer', async () => {
+    const vc = await issueVC();
+
+    const nullVerifier = new DelegationCredentialVerifier({
+      didResolver: { resolve: async () => null },
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+
+    const result = await nullVerifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('resolve');
+  });
+
+  // ── Missing Proof ─────────────────────────────────────────────
+
+  it('should reject VC without proof at basic stage', async () => {
+    const vc = await issueVC();
+    const noProof = { ...vc } as Record<string, unknown>;
+    delete noProof['proof'];
+
+    const result = await verifier.verifyDelegationCredential(
+      noProof as DelegationCredential,
+      { skipStatus: true, skipCache: true }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe('basic');
+  });
+
+  // ── Metrics ───────────────────────────────────────────────────
+
+  it('should report timing metrics for all stages', async () => {
+    const vc = await issueVC();
+
+    const result = await verifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+
+    expect(result.metrics).toBeDefined();
+    expect(result.metrics?.totalMs).toBeGreaterThanOrEqual(0);
+    expect(result.metrics?.basicCheckMs).toBeGreaterThanOrEqual(0);
+    expect(result.metrics?.signatureCheckMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/proof/__tests__/verifier.integration.test.ts
+++ b/src/proof/__tests__/verifier.integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * ProofVerifier Integration Tests (Real Crypto)
+ *
+ * Companion to verifier.test.ts — these tests use real Ed25519 signing,
+ * real nonce caching, and real clock providers instead of mocking.
+ *
+ * The mocked unit tests verify pipeline logic and error code propagation.
+ * These integration tests verify that real proofs are correctly verified
+ * and that security properties hold with actual cryptographic operations.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { ProofGenerator } from '../generator.js';
+import { ProofVerifier } from '../verifier.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import { extractPublicKeyFromDidKey, publicKeyToJwk } from '../../delegation/did-key-resolver.js';
+import type { Ed25519JWK } from '../../utils/crypto-service.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  RealClockProvider,
+  RealFetchProvider,
+  MemoryNonceCacheProvider,
+} from '../../__tests__/audit/helpers/crypto-helpers.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+
+describe('ProofVerifier (real crypto)', () => {
+  let crypto: NodeCryptoProvider;
+  let agent: AgentIdentity;
+  let otherAgent: AgentIdentity;
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    agent = await createRealIdentity(crypto);
+    otherAgent = await createRealIdentity(crypto);
+  });
+
+  function makeVerifier(): { verifier: ProofVerifier; nonceCache: MemoryNonceCacheProvider } {
+    const nonceCache = new MemoryNonceCacheProvider();
+    const verifier = new ProofVerifier({
+      cryptoProvider: crypto,
+      clockProvider: new RealClockProvider(),
+      nonceCacheProvider: nonceCache,
+      fetchProvider: new RealFetchProvider(),
+      timestampSkewSeconds: 300,
+    });
+    return { verifier, nonceCache };
+  }
+
+  function getJwk(identity: AgentIdentity): Ed25519JWK {
+    const raw = extractPublicKeyFromDidKey(identity.did);
+    const jwk = publicKeyToJwk(raw!);
+    jwk.kid = identity.kid;
+    return jwk as Ed25519JWK;
+  }
+
+  async function generateProof(identity: AgentIdentity) {
+    const gen = new ProofGenerator(
+      { did: identity.did, kid: identity.kid, privateKey: identity.privateKey, publicKey: identity.publicKey },
+      crypto
+    );
+    return gen.generateProof(
+      { method: 'tools/call', params: { name: 'test-tool' } },
+      { data: { output: 'result' } },
+      {
+        sessionId: 'sess_integration',
+        audience: 'did:web:server.example.com',
+        nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        timestamp: Math.floor(Date.now() / 1000),
+        createdAt: Math.floor(Date.now() / 1000),
+        lastActivity: Math.floor(Date.now() / 1000),
+        ttlMinutes: 30,
+        identityState: 'anonymous',
+      }
+    );
+  }
+
+  // ── Core Verification ─────────────────────────────────────────
+
+  it('should verify a valid proof with real Ed25519 signature', async () => {
+    const { verifier } = makeVerifier();
+    const proof = await generateProof(agent);
+    const jwk = getJwk(agent);
+
+    const result = await verifier.verifyProof(proof, jwk);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject proof signed by a different key', async () => {
+    const { verifier } = makeVerifier();
+    const proof = await generateProof(agent);
+    const wrongJwk = getJwk(otherAgent);
+
+    const result = await verifier.verifyProof(proof, wrongJwk);
+
+    expect(result.valid).toBe(false);
+  });
+
+  // ── Nonce Replay (real cache) ─────────────────────────────────
+
+  it('should prevent nonce replay with real MemoryNonceCacheProvider', async () => {
+    const { verifier } = makeVerifier();
+    const proof = await generateProof(agent);
+    const jwk = getJwk(agent);
+
+    const first = await verifier.verifyProof(proof, jwk);
+    expect(first.valid).toBe(true);
+
+    const replay = await verifier.verifyProof(proof, jwk);
+    expect(replay.valid).toBe(false);
+    expect(replay.reason).toContain('replay');
+  });
+
+  it('should scope nonces per agent DID', async () => {
+    const { verifier } = makeVerifier();
+
+    const proofA = await generateProof(agent);
+    const proofB = await generateProof(otherAgent);
+    const jwkA = getJwk(agent);
+    const jwkB = getJwk(otherAgent);
+
+    const resultA = await verifier.verifyProof(proofA, jwkA);
+    const resultB = await verifier.verifyProof(proofB, jwkB);
+
+    expect(resultA.valid).toBe(true);
+    expect(resultB.valid).toBe(true);
+  });
+
+  // ── Detached Verification ─────────────────────────────────────
+
+  it('should verify proof via verifyProofDetached with string payload', async () => {
+    const { verifier } = makeVerifier();
+    const proof = await generateProof(agent);
+    const jwk = getJwk(agent);
+    const canonical = verifier.buildCanonicalPayload(proof.meta);
+
+    const result = await verifier.verifyProofDetached(proof, canonical, jwk);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should verify proof via verifyProofDetached with Uint8Array payload', async () => {
+    const { verifier } = makeVerifier();
+    const proof = await generateProof(agent);
+    const jwk = getJwk(agent);
+    const canonical = new TextEncoder().encode(verifier.buildCanonicalPayload(proof.meta));
+
+    const result = await verifier.verifyProofDetached(proof, canonical, jwk);
+
+    expect(result.valid).toBe(true);
+  });
+
+  // ── Proof Structure Rejection ─────────────────────────────────
+
+  it('should reject malformed proof structure', async () => {
+    const { verifier } = makeVerifier();
+    const jwk = getJwk(agent);
+
+    const result = await verifier.verifyProof(
+      { jws: 'not-valid', meta: { did: 'x' } } as any,
+      jwk
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Invalid proof structure');
+  });
+
+  // ── fetchPublicKeyFromDID (real DID resolution) ───────────────
+
+  it('should resolve a real did:key to a valid Ed25519 JWK', async () => {
+    const { verifier } = makeVerifier();
+
+    const jwk = await verifier.fetchPublicKeyFromDID(agent.did);
+
+    expect(jwk).toBeDefined();
+    expect(jwk!.kty).toBe('OKP');
+    expect(jwk!.crv).toBe('Ed25519');
+    expect(jwk!.x).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds companion `.integration.test.ts` files alongside the three most over-mocked test files, using real Ed25519 crypto via `NodeCryptoProvider` and the shared `crypto-helpers.ts` from the audit.

| File | Tests | What it replaces |
|------|-------|-----------------|
| `vc-issuer.integration.test.ts` | 5 | Mocked `wrapDelegationAsVC` + `canonicalizeJSON` → real issuance with signature verification |
| `vc-verifier.integration.test.ts` | 8 | Mocked `validateDelegationCredential` + signature verifier → real 3-stage pipeline |
| `verifier.integration.test.ts` | 8 | Mocked `cryptoProvider.verify` (always true) → real Ed25519 verification + nonce caching |

### Why companion files instead of modifying existing tests?

The existing test files use top-level `vi.mock()` which affects every test in the file. Real-crypto tests can't coexist with those module-level mocks. The mocked tests are still valuable for error path testing (e.g., "what if DID resolver throws?"), so we keep both.

Now when someone modifies `vc-issuer.ts`, `vc-verifier.ts`, or `proof/verifier.ts`, both the mocked unit tests AND the real-crypto integration tests run — catching both argument-passing regressions and actual behavioral bugs.

## Test plan

- [x] Full suite: **837 passed, 0 skipped**
- [x] No existing tests modified or broken
- [x] All 3 integration test files pass independently