### PR TITLE
ci: add PR coverage report with delta comparison

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -28,15 +28,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # Run coverage on the PR branch
+      # Run coverage on the PR branch (json reporter gives us test counts for free)
       - name: Run coverage (PR)
-        run: npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportOnFailure
+        run: npx vitest run --coverage --coverage.reporter=json-summary --reporter=json --coverage.reportOnFailure > /tmp/pr-vitest-output.json 2>/dev/null
         continue-on-error: true
 
       - name: Save PR coverage and test count
         run: |
           cp coverage/coverage-summary.json /tmp/pr-coverage.json
-          npx vitest run --reporter=json 2>/dev/null | jq '{numTotalTests: .numTotalTests, numPassedTests: .numPassedTests, numFailedTests: .numFailedTests, numTotalTestSuites: .numTotalTestSuites}' > /tmp/pr-test-results.json 2>/dev/null || echo '{}' > /tmp/pr-test-results.json
+          cat /tmp/pr-vitest-output.json | jq '{numTotalTests: .numTotalTests, numPassedTests: .numPassedTests, numFailedTests: .numFailedTests, numTotalTestSuites: .numTotalTestSuites}' > /tmp/pr-test-results.json 2>/dev/null || echo '{}' > /tmp/pr-test-results.json
 
       # Run coverage on the base branch for comparison
       - name: Checkout base branch

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -33,8 +33,10 @@ jobs:
         run: npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportOnFailure
         continue-on-error: true
 
-      - name: Save PR coverage
-        run: cp coverage/coverage-summary.json /tmp/pr-coverage.json
+      - name: Save PR coverage and test count
+        run: |
+          cp coverage/coverage-summary.json /tmp/pr-coverage.json
+          npx vitest run --reporter=json 2>/dev/null | jq '{numTotalTests: .numTotalTests, numPassedTests: .numPassedTests, numFailedTests: .numFailedTests, numTotalTestSuites: .numTotalTestSuites}' > /tmp/pr-test-results.json 2>/dev/null || echo '{}' > /tmp/pr-test-results.json
 
       # Run coverage on the base branch for comparison
       - name: Checkout base branch
@@ -125,15 +127,23 @@ jobs:
               }
             }
 
-            // Test counts from coverage data
-            const covered = pr.total.statements?.covered ?? 0;
-            const total = pr.total.statements?.total ?? 0;
+            // Load test results
+            let testResults = {};
+            try {
+              testResults = JSON.parse(fs.readFileSync('/tmp/pr-test-results.json', 'utf8'));
+            } catch {}
+
+            const totalTests = testResults.numTotalTests ?? 0;
+            const passedTests = testResults.numPassedTests ?? 0;
+            const failedTests = testResults.numFailedTests ?? 0;
+            const testSuites = testResults.numTotalTestSuites ?? 0;
+            const overallPct = pr.total.statements?.pct ?? 0;
 
             let body = `## Coverage Report\n\n`;
             body += table + '\n';
 
             if (decreased.length > 0) {
-              body += `### ⚠️ Files with decreased coverage\n\n`;
+              body += `### Files with decreased coverage\n\n`;
               body += '| File | Before | After | Change |\n';
               body += '|------|--------|-------|--------|\n';
               for (const d of decreased) {
@@ -142,8 +152,9 @@ jobs:
               body += '\n';
             }
 
-            body += `\n<details><summary>Coverage details</summary>\n\n`;
-            body += `- **Statements**: ${covered} / ${total} covered\n`;
+            body += `\n<details><summary>Details</summary>\n\n`;
+            body += `- **Tests**: ${passedTests} passed` + (failedTests > 0 ? `, ${failedTests} failed` : '') + ` (${totalTests} total across ${testSuites} suites)\n`;
+            body += `- **Overall coverage**: ${fmt(overallPct)} statements\n`;
             body += `- **Config**: vitest + v8, thresholds enforced in \`vitest.config.mts\`\n`;
             body += `</details>\n`;
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,183 @@
+name: Coverage Report
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Run coverage on the PR branch
+      - name: Run coverage (PR)
+        run: npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportOnFailure
+        continue-on-error: true
+
+      - name: Save PR coverage
+        run: cp coverage/coverage-summary.json /tmp/pr-coverage.json
+
+      # Run coverage on the base branch for comparison
+      - name: Checkout base branch
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Install dependencies (base)
+        run: pnpm install
+
+      - name: Run coverage (base)
+        run: npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportOnFailure
+        continue-on-error: true
+
+      - name: Save base coverage
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            cp coverage/coverage-summary.json /tmp/base-coverage.json
+          else
+            echo '{}' > /tmp/base-coverage.json
+          fi
+
+      # Generate the comment
+      - name: Generate coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let pr, base;
+            try {
+              pr = JSON.parse(fs.readFileSync('/tmp/pr-coverage.json', 'utf8'));
+            } catch {
+              pr = null;
+            }
+            try {
+              base = JSON.parse(fs.readFileSync('/tmp/base-coverage.json', 'utf8'));
+            } catch {
+              base = null;
+            }
+
+            if (!pr || !pr.total) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '⚠️ Coverage report unavailable — tests may have failed.',
+              });
+              return;
+            }
+
+            const metrics = ['statements', 'branches', 'functions', 'lines'];
+            const thresholds = { lines: 80, branches: 75, functions: 80, statements: 80 };
+
+            function fmt(pct) {
+              return pct.toFixed(2) + '%';
+            }
+
+            function delta(prPct, basePct) {
+              if (basePct == null) return '';
+              const d = prPct - basePct;
+              if (Math.abs(d) < 0.005) return '±0';
+              const arrow = d > 0 ? '▲' : '▼';
+              return `${arrow} ${d > 0 ? '+' : ''}${d.toFixed(2)}%`;
+            }
+
+            function status(pct, metric) {
+              const threshold = thresholds[metric];
+              if (pct >= threshold) return '✅';
+              return '⚠️';
+            }
+
+            // Build summary table
+            let table = '| Metric | Coverage | Delta | Threshold | Status |\n';
+            table += '|--------|----------|-------|-----------|--------|\n';
+
+            for (const m of metrics) {
+              const prPct = pr.total[m]?.pct ?? 0;
+              const basePct = base?.total?.[m]?.pct;
+              table += `| **${m.charAt(0).toUpperCase() + m.slice(1)}** `;
+              table += `| ${fmt(prPct)} `;
+              table += `| ${delta(prPct, basePct)} `;
+              table += `| ${thresholds[m]}% `;
+              table += `| ${status(prPct, m)} |\n`;
+            }
+
+            // Find files with decreased coverage
+            const decreased = [];
+            if (base && base.total) {
+              for (const [file, prData] of Object.entries(pr)) {
+                if (file === 'total') continue;
+                const baseData = base[file];
+                if (!baseData) continue;
+                const prPct = prData.statements?.pct ?? 0;
+                const basePct = baseData.statements?.pct ?? 0;
+                if (basePct - prPct >= 0.5) {
+                  decreased.push({ file: file.replace(/^.*\/src\//, 'src/'), prPct, basePct });
+                }
+              }
+            }
+
+            // Test counts from coverage data
+            const covered = pr.total.statements?.covered ?? 0;
+            const total = pr.total.statements?.total ?? 0;
+
+            let body = `## 📊 Coverage Report\n\n`;
+            body += table + '\n';
+
+            if (decreased.length > 0) {
+              body += `### ⚠️ Files with decreased coverage\n\n`;
+              body += '| File | Before | After | Change |\n';
+              body += '|------|--------|-------|--------|\n';
+              for (const d of decreased) {
+                body += `| \`${d.file}\` | ${fmt(d.basePct)} | ${fmt(d.prPct)} | ${delta(d.prPct, d.basePct)} |\n`;
+              }
+              body += '\n';
+            }
+
+            body += `\n<details><summary>Coverage details</summary>\n\n`;
+            body += `- **Statements**: ${covered} / ${total} covered\n`;
+            body += `- **Config**: vitest + v8, thresholds enforced in \`vitest.config.mts\`\n`;
+            body += `</details>\n`;
+
+            // Find and update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '## 📊 Coverage Report';
+            const existing = comments.find(c => c.body?.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -85,7 +85,6 @@ jobs:
             }
 
             const metrics = ['statements', 'branches', 'functions', 'lines'];
-            const thresholds = { lines: 80, branches: 75, functions: 80, statements: 80 };
 
             function fmt(pct) {
               return pct.toFixed(2) + '%';
@@ -99,24 +98,16 @@ jobs:
               return `${arrow} ${d > 0 ? '+' : ''}${d.toFixed(2)}%`;
             }
 
-            function status(pct, metric) {
-              const threshold = thresholds[metric];
-              if (pct >= threshold) return '✅';
-              return '⚠️';
-            }
-
             // Build summary table
-            let table = '| Metric | Coverage | Delta | Threshold | Status |\n';
-            table += '|--------|----------|-------|-----------|--------|\n';
+            let table = '| Metric | Coverage | Delta |\n';
+            table += '|--------|----------|-------|\n';
 
             for (const m of metrics) {
               const prPct = pr.total[m]?.pct ?? 0;
               const basePct = base?.total?.[m]?.pct;
               table += `| **${m.charAt(0).toUpperCase() + m.slice(1)}** `;
               table += `| ${fmt(prPct)} `;
-              table += `| ${delta(prPct, basePct)} `;
-              table += `| ${thresholds[m]}% `;
-              table += `| ${status(prPct, m)} |\n`;
+              table += `| ${delta(prPct, basePct)} |\n`;
             }
 
             // Find files with decreased coverage
@@ -138,7 +129,7 @@ jobs:
             const covered = pr.total.statements?.covered ?? 0;
             const total = pr.total.statements?.total ?? 0;
 
-            let body = `## 📊 Coverage Report\n\n`;
+            let body = `## Coverage Report\n\n`;
             body += table + '\n';
 
             if (decreased.length > 0) {
@@ -163,7 +154,7 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const marker = '## 📊 Coverage Report';
+            const marker = '## Coverage Report';
             const existing = comments.find(c => c.body?.startsWith(marker));
 
             if (existing) {


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically comments on PRs with a coverage report showing how the PR affects test coverage compared to main.

### What the comment looks like

| Metric | Coverage | Delta |
|--------|----------|-------|
| **Statements** | 89.42% | ▲ +0.74% |
| **Branches** | 86.50% | ▲ +0.55% |
| **Functions** | 93.60% | ±0 |
| **Lines** | 89.42% | ▲ +0.74% |

If any files have decreased coverage (>0.5%), they're flagged in a separate table.

### How it works

1. Runs `vitest --coverage` with `json-summary` reporter on the PR branch
2. Checks out the base branch and runs coverage there too
3. Computes deltas and generates a markdown comment via `actions/github-script`
4. Updates the existing comment on subsequent pushes (no comment spam)

Runs as a separate workflow from CI so it doesn't slow down the build matrix.

## Test plan

- [x] This PR itself will trigger the workflow — check the comments below to see it in action