### PR TITLE
refactor: normalize spec headers to KYA- convention

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -548,11 +548,11 @@ When an MCP server calls downstream services (APIs, other MCP servers), it MUST 
 
 | Header | Value |
 |--------|-------|
-| `X-Agent-DID` | Original agent's DID |
-| `X-Delegation-Chain` | Comma-separated list of delegation IDs from root to current |
-| `X-Session-ID` | MCP-I session ID |
-| `X-Delegation-Proof` | Signed JWT proving delegation authority |
-| `X-Scopes` | Comma-separated list of granted scopes |
+| `KYA-Agent-DID` | Original agent's DID |
+| `KYA-Delegation-Chain` | Comma-separated list of delegation IDs from root to current |
+| `KYA-Session-Id` | MCP-I session ID |
+| `KYA-Delegation-Proof` | Signed JWT proving delegation authority |
+| `KYA-Granted-Scopes` | Comma-separated list of granted scopes |
 
 ### 8.2 Delegation Proof JWT
 
@@ -736,7 +736,7 @@ Session IDs (`mcpi_*`) appear in detached proofs. Within a session, all tool cal
 
 ### 12.3 Delegation Chain Disclosure
 
-Outbound `X-Agent-DID` and `X-Delegation-Chain` headers reveal the agent's identity and delegation provenance to downstream services. Implementations SHOULD only propagate delegation headers to trusted downstream services.
+Outbound `KYA-Agent-DID` and `KYA-Delegation-Chain` headers reveal the agent's identity and delegation provenance to downstream services. Implementations SHOULD only propagate delegation headers to trusted downstream services.
 
 ### 12.4 Proof Retention and Right to Erasure
 

--- a/examples/outbound-delegation/README.md
+++ b/examples/outbound-delegation/README.md
@@ -29,14 +29,14 @@ With outbound delegation propagation:
 
 | Header | Description | Example |
 |--------|-------------|---------|
-| `X-Agent-DID` | The original agent's DID | `did:key:z6Mk...` |
-| `X-Delegation-Chain` | The delegation chain ID (vcId of the root delegation) | `urn:uuid:abc-123` |
-| `X-Session-ID` | The current MCP-I session ID | `mcpi_xyz789` |
-| `X-Delegation-Proof` | Signed JWT proving the delegation is being forwarded | `eyJhbGciOiJFZERTQS...` |
+| `KYA-Agent-DID` | The original agent's DID | `did:key:z6Mk...` |
+| `KYA-Delegation-Chain` | The delegation chain ID (vcId of the root delegation) | `urn:uuid:abc-123` |
+| `KYA-Session-Id` | The current MCP-I session ID | `mcpi_xyz789` |
+| `KYA-Delegation-Proof` | Signed JWT proving the delegation is being forwarded | `eyJhbGciOiJFZERTQS...` |
 
 ## The Delegation Proof JWT
 
-The `X-Delegation-Proof` header contains a signed JWT with these claims:
+The `KYA-Delegation-Proof` header contains a signed JWT with these claims:
 
 ```json
 {
@@ -54,17 +54,17 @@ The `X-Delegation-Proof` header contains a signed JWT with these claims:
 
 Server B should:
 
-1. **Extract the JWT** from `X-Delegation-Proof`
+1. **Extract the JWT** from `KYA-Delegation-Proof`
 2. **Verify the signature** using the public key from the `iss` DID (Server A)
 3. **Check timing**: `iat` should be recent, `exp` should not have passed
 4. **Check audience**: `aud` should match Server B's hostname
 5. **Check scope**: should be `delegation:propagate`
-6. **Match DIDs**: `sub` should match `X-Agent-DID` header
+6. **Match DIDs**: `sub` should match `KYA-Agent-DID` header
 
 If all checks pass, Server B knows:
 - Server A is legitimately forwarding this request
-- The original agent is identified by `X-Agent-DID`
-- The delegation chain in `X-Delegation-Chain` can be fetched and verified
+- The original agent is identified by `KYA-Agent-DID`
+- The delegation chain in `KYA-Delegation-Chain` can be fetched and verified
 
 ## Running the Demo
 

--- a/examples/outbound-delegation/demo.ts
+++ b/examples/outbound-delegation/demo.ts
@@ -222,19 +222,19 @@ async function main() {
   });
 
   console.log('Outbound Headers:');
-  console.log(`  X-Agent-DID:        ${headers['X-Agent-DID'].slice(0, 40)}...`);
-  console.log(`  X-Delegation-Chain: ${headers['X-Delegation-Chain']}`);
-  console.log(`  X-Session-ID:       ${headers['X-Session-ID']}`);
-  console.log(`  X-Delegation-Proof: ${headers['X-Delegation-Proof'].slice(0, 40)}...`);
+  console.log(`  KYA-Agent-DID:        ${headers['KYA-Agent-DID'].slice(0, 40)}...`);
+  console.log(`  KYA-Delegation-Chain: ${headers['KYA-Delegation-Chain']}`);
+  console.log(`  KYA-Session-Id:       ${headers['KYA-Session-Id']}`);
+  console.log(`  KYA-Delegation-Proof: ${headers['KYA-Delegation-Proof'].slice(0, 40)}...`);
   console.log();
 
   // -------------------------------------------------------------------------
-  // Step 5: Decode the X-Delegation-Proof JWT
+  // Step 5: Decode the KYA-Delegation-Proof JWT
   // -------------------------------------------------------------------------
-  console.log('Step 5: Decoding the X-Delegation-Proof JWT...');
+  console.log('Step 5: Decoding the KYA-Delegation-Proof JWT...');
   console.log('-'.repeat(70));
 
-  const jwt = headers['X-Delegation-Proof'];
+  const jwt = headers['KYA-Delegation-Proof'];
   const jwtHeader = decodeProtectedHeader(jwt);
   const jwtPayload = decodeJwt(jwt);
 
@@ -261,7 +261,7 @@ async function main() {
 
   console.log('Server B receives the request with these headers and should:');
   console.log();
-  console.log('  1. Extract X-Delegation-Proof JWT');
+  console.log('  1. Extract KYA-Delegation-Proof JWT');
   console.log('  2. Verify JWT signature using iss DID public key');
   console.log(`     - iss (${(jwtPayload.iss as string).slice(0, 30)}...) resolves to public key`);
   console.log('  3. Check timing:');
@@ -272,11 +272,11 @@ async function main() {
   console.log('  5. Check scope:');
   console.log(`     - scope is "delegation:propagate"`);
   console.log('  6. Match DIDs:');
-  console.log(`     - sub (${(jwtPayload.sub as string).slice(0, 30)}...) matches X-Agent-DID header`);
+  console.log(`     - sub (${(jwtPayload.sub as string).slice(0, 30)}...) matches KYA-Agent-DID header`);
   console.log();
 
-  const subMatchesHeader = jwtPayload.sub === headers['X-Agent-DID'];
-  console.log(`  Verification: sub matches X-Agent-DID? ${subMatchesHeader ? 'YES' : 'NO'}`);
+  const subMatchesHeader = jwtPayload.sub === headers['KYA-Agent-DID'];
+  console.log(`  Verification: sub matches KYA-Agent-DID? ${subMatchesHeader ? 'YES' : 'NO'}`);
   console.log();
 
   console.log('='.repeat(70));

--- a/src/delegation/__tests__/outbound-headers.test.ts
+++ b/src/delegation/__tests__/outbound-headers.test.ts
@@ -90,38 +90,38 @@ describe('buildOutboundDelegationHeaders', () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    expect(headers).toHaveProperty('X-Agent-DID');
-    expect(headers).toHaveProperty('X-Delegation-Chain');
-    expect(headers).toHaveProperty('X-Session-ID');
-    expect(headers).toHaveProperty('X-Delegation-Proof');
+    expect(headers).toHaveProperty('KYA-Agent-DID');
+    expect(headers).toHaveProperty('KYA-Delegation-Chain');
+    expect(headers).toHaveProperty('KYA-Session-Id');
+    expect(headers).toHaveProperty('KYA-Delegation-Proof');
   });
 
-  it('X-Agent-DID matches session.agentDid', async () => {
+  it('KYA-Agent-DID matches session.agentDid', async () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    expect(headers['X-Agent-DID']).toBe(context.session.agentDid);
+    expect(headers['KYA-Agent-DID']).toBe(context.session.agentDid);
   });
 
-  it('X-Delegation-Chain matches delegation.vcId', async () => {
+  it('KYA-Delegation-Chain matches delegation.vcId', async () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    expect(headers['X-Delegation-Chain']).toBe(context.delegation.vcId);
+    expect(headers['KYA-Delegation-Chain']).toBe(context.delegation.vcId);
   });
 
-  it('X-Session-ID matches session.sessionId', async () => {
+  it('KYA-Session-Id matches session.sessionId', async () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    expect(headers['X-Session-ID']).toBe(context.session.sessionId);
+    expect(headers['KYA-Session-Id']).toBe(context.session.sessionId);
   });
 
-  it('X-Delegation-Proof is a valid JWT with correct claims', async () => {
+  it('KYA-Delegation-Proof is a valid JWT with correct claims', async () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    const jwt = headers['X-Delegation-Proof'];
+    const jwt = headers['KYA-Delegation-Proof'];
 
     // Verify it's a valid JWT format (3 parts)
     expect(jwt.split('.')).toHaveLength(3);
@@ -148,7 +148,7 @@ describe('buildOutboundDelegationHeaders', () => {
     });
     const headers = await buildOutboundDelegationHeaders(context);
 
-    const payload = decodeJwt(headers['X-Delegation-Proof']);
+    const payload = decodeJwt(headers['KYA-Delegation-Proof']);
     expect(payload.aud).toBe('api.service.example.com');
   });
 
@@ -158,7 +158,7 @@ describe('buildOutboundDelegationHeaders', () => {
     });
     const headers = await buildOutboundDelegationHeaders(context);
 
-    const payload = decodeJwt(headers['X-Delegation-Proof']);
+    const payload = decodeJwt(headers['KYA-Delegation-Proof']);
     expect(payload.aud).toBe('internal-service.local');
   });
 
@@ -168,7 +168,7 @@ describe('buildOutboundDelegationHeaders', () => {
     });
     const headers = await buildOutboundDelegationHeaders(context);
 
-    const payload = decodeJwt(headers['X-Delegation-Proof']);
+    const payload = decodeJwt(headers['KYA-Delegation-Proof']);
     expect(payload.aud).toBe('secure.example.org');
   });
 
@@ -176,7 +176,7 @@ describe('buildOutboundDelegationHeaders', () => {
     const context = createTestContext();
     const headers = await buildOutboundDelegationHeaders(context);
 
-    const payload = decodeJwt(headers['X-Delegation-Proof']);
+    const payload = decodeJwt(headers['KYA-Delegation-Proof']);
     expect((payload.exp as number) - (payload.iat as number)).toBe(60);
   });
 

--- a/src/delegation/__tests__/transitive-access.test.ts
+++ b/src/delegation/__tests__/transitive-access.test.ts
@@ -979,11 +979,11 @@ describe('Transitive Access — Karp Use Cases', () => {
       });
 
       // Headers expose the full provenance
-      expect(headers['X-Agent-DID']).toBe(alice.did);
-      expect(headers['X-Delegation-Chain']).toBe(aliceToBob.id);
-      expect(headers['X-Session-ID']).toBe('mcpi_test-session');
+      expect(headers['KYA-Agent-DID']).toBe(alice.did);
+      expect(headers['KYA-Delegation-Chain']).toBe(aliceToBob.id);
+      expect(headers['KYA-Session-Id']).toBe('mcpi_test-session');
       // The proof is a signed JWT that downstream can verify
-      expect(headers['X-Delegation-Proof']).toMatch(
+      expect(headers['KYA-Delegation-Proof']).toMatch(
         /^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
       );
     });

--- a/src/delegation/outbound-headers.ts
+++ b/src/delegation/outbound-headers.ts
@@ -5,10 +5,10 @@
  * delegation context to downstream services.
  *
  * Headers (MCP-I §7):
- * - X-Agent-DID: the original agent's DID
- * - X-Delegation-Chain: the delegation chain ID (vcId of the root delegation)
- * - X-Session-ID: the current session ID
- * - X-Delegation-Proof: a signed JWT proving the delegation is being forwarded
+ * - KYA-Agent-DID: the original agent's DID
+ * - KYA-Delegation-Chain: the delegation chain ID (vcId of the root delegation)
+ * - KYA-Session-Id: the current session ID
+ * - KYA-Delegation-Proof: a signed JWT proving the delegation is being forwarded
  *
  * Related Spec: MCP-I §7 — Outbound Delegation Propagation
  */
@@ -23,10 +23,10 @@ import { logger } from '../logging/index.js';
  * Header names for outbound delegation propagation
  */
 export const OUTBOUND_HEADER_NAMES = {
-  AGENT_DID: 'X-Agent-DID',
-  DELEGATION_CHAIN: 'X-Delegation-Chain',
-  SESSION_ID: 'X-Session-ID',
-  DELEGATION_PROOF: 'X-Delegation-Proof',
+  AGENT_DID: 'KYA-Agent-DID',
+  DELEGATION_CHAIN: 'KYA-Delegation-Chain',
+  SESSION_ID: 'KYA-Session-Id',
+  DELEGATION_PROOF: 'KYA-Delegation-Proof',
 } as const;
 
 /**
@@ -51,10 +51,10 @@ export interface OutboundDelegationContext {
  * Outbound delegation headers to attach to downstream requests
  */
 export interface OutboundDelegationHeaders {
-  'X-Agent-DID': string;
-  'X-Delegation-Chain': string;
-  'X-Session-ID': string;
-  'X-Delegation-Proof': string;
+  'KYA-Agent-DID': string;
+  'KYA-Delegation-Chain': string;
+  'KYA-Session-Id': string;
+  'KYA-Delegation-Proof': string;
 }
 
 /**
@@ -182,9 +182,9 @@ export async function buildOutboundDelegationHeaders(
   });
 
   return {
-    'X-Agent-DID': session.agentDid,
-    'X-Delegation-Chain': delegation.vcId,
-    'X-Session-ID': session.sessionId,
-    'X-Delegation-Proof': jwt,
+    'KYA-Agent-DID': session.agentDid,
+    'KYA-Delegation-Chain': delegation.vcId,
+    'KYA-Session-Id': session.sessionId,
+    'KYA-Delegation-Proof': jwt,
   };
 }

--- a/src/delegation/outbound-proof.ts
+++ b/src/delegation/outbound-proof.ts
@@ -5,7 +5,7 @@
  * Enables downstream services to independently verify the delegation chain.
  *
  * Wire format: signed compact EdDSA JWT (60s TTL, per-call jti)
- * Header injection: X-Delegation-Id, X-Delegation-Chain, X-Delegation-Proof, X-Scopes
+ * Header injection: KYA-Delegation-Id, KYA-Delegation-Chain, KYA-Delegation-Proof, KYA-Granted-Scopes
  *
  * Related Spec: MCP-I §2 — Outbound Delegation Propagation
  */


### PR DESCRIPTION
## Summary

- **Rename 6 normative HTTP headers** in SPEC.md §8 (Outbound Delegation Propagation) from `X-` prefix to `KYA-` namespace per [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648)
- Updates `OUTBOUND_HEADER_NAMES` constants, `OutboundDelegationHeaders` interface, and `buildOutboundDelegationHeaders()` implementation
- 7 files, 63 lines changed with zero net additions

### Headers renamed in spec

| Old (SPEC.md §8.1) | New |
|---|---|
| `X-Agent-DID` | `KYA-Agent-DID` |
| `X-Delegation-Chain` | `KYA-Delegation-Chain` |
| `X-Session-ID` | `KYA-Session-Id` |
| `X-Delegation-Proof` | `KYA-Delegation-Proof` |
| `X-Scopes` | `KYA-Granted-Scopes` |
| `X-Delegation-Id` | `KYA-Delegation-Id` |

Companion to agent-shield#1900, xmcp-i#408, know-that-ai#443 (all merged).
Refs Know-That-Ai/agent-shield#1873

## Test plan

- [x] 53 test files, 883 tests passed (including outbound-headers and transitive-access tests)
- [x] Final grep confirms zero remaining old patterns in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)