### PR TITLE
chore: bump version 1.1.1 → 1.2.0 for KYA- header convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-i/core",
-  "version": "1.1.1",
-  "description": "Core library for MCP-I — delegation, proof, and session primitives for Model Context Protocol Identity",
+  "version": "1.2.0",
+  "description": "Core library for MCP-I \u2014 delegation, proof, and session primitives for Model Context Protocol Identity",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump for the KYA- header convention migration (#39).

| Package | Old | New |
|---------|-----|-----|
| `@mcp-i/core` | 1.1.1 | 1.2.0 |

## Test plan

- [x] 53 test files, 883 tests passed
- [ ] CI