### PR TITLE
fix: meta.requestHash example matches schema constraint + JWS payload (#41)

### DIFF
--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -89,7 +89,7 @@
         "nonce": "k7Hy9mNpQrStUvWxYz01Aa",
         "audience": "did:web:example.com",
         "sessionId": "sess_abc123xyz",
-        "requestHash": "sha256:72b80a4aa6ab9f53ae8fe727b67b9cb7f49997f36217989927125832c3265bfb1c",
+        "requestHash": "sha256:72b80a4aa6ab9f53ae8fe727b67b9cb7f49997f362179899271258c3265bfb1c",
         "responseHash": "sha256:1b4f0a1ee7708d4c398ff9a4937b2421a6d3a4824b6a6f1a6be8bacb7ef279da"
       }
     }


### PR DESCRIPTION
Closes #41.

## Summary

The `meta.requestHash` example in `schemas/detached-proof.json` is 66
hex chars, violating the schema's own `^sha256:[a-f0-9]{64}$` pattern.
The fix drops the two extraneous chars (`32`) inserted near position
51 of the hex, bringing it down to a clean 64.

## Why this fix differs from the issue's suggestion

The issue suggested dropping the trailing `1c`. That would fix the
length but leave a second inconsistency the issue didn't catch:

The same example's `jws` field is a base64-encoded payload that
already carries a (different, correct) 64-char `requestHash`. The
broken meta was therefore also internally inconsistent with the JWS
it was supposed to mirror. Aligning meta to the JWS fixes both
problems at once — the meta now validates against the schema **and**
encodes the same hash the JWS does.

Decoded JWS payload (already in the example, unchanged here):

```
"requestHash": "sha256:72b80a4aa6ab9f53ae8fe727b67b9cb7f49997f362179899271258c3265bfb1c"
```

That's what meta now reads too.

## Verification

```sh
$ pnpm test
Test Files  53 passed (53)
     Tests  884 passed (884)
```

`SPEC.md` Appendix C.1's worked example was already clean (different
test vector) — no doc change needed. No other references to the
broken hash anywhere in the repo (`git grep` confirmed).