### PR TITLE
chore(publish): fix tarball shape before v1.2.0 — drop tests, ship schemas, promote zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,16 @@
     "./middleware": {
       "types": "./dist/middleware/index.d.ts",
       "default": "./dist/middleware/index.js"
-    }
+    },
+    "./schemas/*.json": "./schemas/*.json",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
-    "src",
+    "schemas",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc",
@@ -58,13 +61,15 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
     "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
     "demo": "bash scripts/demo.sh",
     "example:server": "npx tsx examples/node-server/server.ts",
     "example:inspector": "npx @modelcontextprotocol/inspector npx tsx examples/node-server/server.ts --stdio"
   },
   "dependencies": {
     "jose": "^5.6.3",
-    "json-canonicalize": "^2.0.0"
+    "json-canonicalize": "^2.0.0",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.0.0"
@@ -88,8 +93,7 @@
     "express": "^5.2.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.57.0",
-    "vitest": "^2.0.0",
-    "zod": "^4.3.6"
+    "vitest": "^2.0.0"
   },
   "keywords": [
     "mcp-i",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       json-canonicalize:
         specifier: ^2.0.0
         version: 2.0.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -57,9 +60,6 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.37)
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
 
 packages:
 


### PR DESCRIPTION
## Summary

An end-to-end install probe (tarball → fresh node_modules → import)
caught four real publish-shape bugs. All four are publish-config only — no source code changes.

## What was wrong

| # | Bug | Effect on consumers |
| --- | --- | --- |
| 1 | `src/` in `files` globbed in every `__tests__/` subtree | 47 test files (~120 KB) shipped to every consumer's node_modules |
| 2 | `zod` was a devDependency but imported at runtime in `middleware/with-mcpi-server.ts` | `require('@kya-os/mcp')` failed: `Cannot find package 'zod'` |
| 3 | `schemas/` was not in `files`, and even if it were, the `exports` field has no subpath for it | Implementers couldn't `require('@kya-os/mcp/schemas/detached-proof.json')` |
| 4 | No `prepublishOnly` script | `npm publish` would ship whatever was on disk — possibly stale or unbuilt `dist/` |

## Fix

```diff
   "files": [
     "dist",
-    "src",
+    "schemas",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "exports": {
     …
+    "./schemas/*.json": "./schemas/*.json",
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "jose": "^5.6.3",
-    "json-canonicalize": "^2.0.0"
+    "json-canonicalize": "^2.0.0",
+    "zod": "^4.3.6"
   },
   "scripts": {
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
     …
   }
```

(`zod` removed from `devDependencies` — same version, promoted not duplicated.)

## Verification

End-to-end probe against a fresh `/tmp/kya-mcp-install-check` consumer:

- ✓ Root entry imports (91 named exports)
- ✓ `@kya-os/mcp/middleware` resolves, `withMCPI` is a function
- ✓ `@kya-os/mcp/providers` resolves, `NodeCryptoProvider` is a function
- ✓ `@kya-os/mcp/schemas/detached-proof.json` resolves and parses (title: "MCP-I Detached Proof")
- ✓ `@kya-os/mcp/package.json` resolves (for tooling that inspects the manifest)
- ✓ `zod` is in the consumer's `node_modules` transitively
- ✓ 884/884 unit tests pass
- ✓ `pnpm typecheck` clean

Tarball: **234 KB → 116 KB**, **265 files → 182 files**, **0 test files**.
