### PR TITLE
docs: graduate spec + conformance to 1.0.0 for donation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Versioning: https://semver.org/spec/v2.0.0.html
   identity, authorization, and observability. Version stays at 1.2.0 —
   the wire format, exports (`MCPI*`), and behavior are unchanged. The
   old `@mcp-i/core` package is deprecated and points at this one.
+- **Spec cut to `1.0.0`** (was `0.1.0-draft` in `SPEC.md`, `1.0.0-draft`
+  in `CONFORMANCE.md`). The wire format was already pinned at `1.0.0`
+  in the handshake protocol-version field; the spec docs now match.
+  Status: Stable — donated to DIF TAAWG for ratification review. Spec
+  semver is independent of package semver: the spec describes the wire
+  protocol, the package describes the implementation shipping it.
 - Delegation middleware remains strict by default for chain and status-list validation.
 - Added `delegation.allowLegacyUnsafeDelegation` to `createMCPIMiddleware` as a temporary migration escape hatch for legacy integrations.
 - Added middleware tests covering legacy-compatibility behavior for parent-linked and status-list credentials.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -2,8 +2,8 @@
 
 **Model Context Protocol Identity Extension — Compliance Levels**
 
-Version: 1.0.0-draft
-Status: Draft
+Version: 1.0.0
+Status: Stable
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,8 +2,8 @@
 
 **Model Context Protocol Identity Extension**
 
-Version: 0.1.0-draft
-Status: Draft
+Version: 1.0.0
+Status: Stable
 Editors: MCP-I Working Group
 Repository: https://github.com/modelcontextprotocol-identity/mcp-i-core
 
@@ -23,7 +23,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Status
 
-**Draft** — Submitted to DIF TAAWG (Decentralized Identity Foundation, Trust and Authorization for AI Agents Working Group) for review. Not yet a standard.
+**Stable 1.0.0** — Donated to DIF TAAWG (Decentralized Identity Foundation, Trust and Authorization for AI Agents Working Group). Under review for ratification as a DIF standard. The wire format is stable: any future change that breaks compatibility with this version will require a major version bump.
 
 ---
 


### PR DESCRIPTION
Final spec-doc cleanup before the v1.2.0 tag + DIF transfer.

## What changes

| File | Was | Now |
| --- | --- | --- |
| `SPEC.md` header | `Version: 0.1.0-draft` / `Status: Draft` | `Version: 1.0.0` / `Status: Stable` |
| `CONFORMANCE.md` header | `Version: 1.0.0-draft` / `Status: Draft` | `Version: 1.0.0` / `Status: Stable` |
| `SPEC.md §22 Status` | "Draft — submitted to DIF TAAWG for review. Not yet a standard." | "Stable 1.0.0 — donated to DIF TAAWG, under review for ratification" |
| `CHANGELOG.md` `[Unreleased]` | — | Entry noting the spec cut and the spec/package semver split |

The handshake's wire `protocolVersion` field was already pinned at `1.0.0` (see SPEC.md §5.1 and line 635). The doc headers were the only thing lagging.

## Package version stays at `1.2.0`

Spec semver describes the wire protocol; package semver describes the implementation shipping it. Same split as `@modelcontextprotocol/sdk` shipping its own semver under MCP spec 1.0.0. Resetting the package to 1.0.0 would break the test-and-review lineage.

## Verification

- 884/884 unit tests pass (no source changes; sanity)
- Spec / conformance / wire-protocol versions now consistent at `1.0.0`; package at `1.2.0`
- No `-draft` suffix in `SPEC.md` or `CONFORMANCE.md` headers