### PR TITLE
docs(readme): lead with KYA-OS framing, drop MCP-I-as-actor copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 </p>
 
 <p align="center">
-  <em><code>@kya-os/mcp</code> is the reference implementation of <strong>MCP-I</strong>, the identity surface of <strong>KYA-OS</strong> (Know Your Agent Operating System). KYA-OS is the umbrella protocol for agent identity, authorization, and observability; MCP-I is its first surface, binding those primitives to Model Context Protocol servers.</em>
+  <em><code>@kya-os/mcp</code> is the reference implementation of the <strong>KYA-OS</strong> (Know Your Agent Operating System) protocol for Model Context Protocol servers — binding KYA-OS's identity, delegation, and proof primitives into MCP. KYA-OS is the agent identity, authorization, and observability protocol.</em>
 </p>
 
 ---
 
-AI agents call tools on your behalf. But today, there's no way to know *who* called, *whether they were allowed to*, or *what actually happened*. MCP-I fixes that for Model Context Protocol servers.
+AI agents call tools on your behalf. But today, there's no way to know *who* called, *whether they were allowed to*, or *what actually happened*. `@kya-os/mcp` fixes that for Model Context Protocol servers.
 
 - **Every server gets a cryptographic identity** (DID) — no accounts, no API keys, no central registry
 - **Every tool call gets a signed proof** — a tamper-evident receipt the agent can't forge or deny
@@ -73,7 +73,7 @@ That's it. `withMCPI` auto-generates an Ed25519 identity, registers the `_mcpi` 
 
 ## Protect Tools with Human Consent
 
-Some tools shouldn't run without a human saying "yes." MCP-I adds per-tool authorization using W3C Verifiable Credentials:
+Some tools shouldn't run without a human saying "yes." KYA-OS MCP adds per-tool authorization using W3C Verifiable Credentials:
 
 ```typescript
 const checkout = mcpi.wrapWithDelegation(


### PR DESCRIPTION
README copy still spoke of MCP-I as the thing that "fixes" identity for
MCP / "adds" per-tool consent. With the donation, the framing inverts:
`@kya-os/mcp` is the implementation of the KYA-OS protocol's MCP
binding, and the package (or KYA-OS itself) is the actor.

## Edits

| Line | Was | Now |
| --- | --- | --- |
| 22 (umbrella paragraph) | "reference implementation of **MCP-I**, the identity surface of **KYA-OS**..." | "reference implementation of the **KYA-OS** (Know Your Agent Operating System) protocol for Model Context Protocol servers — binding KYA-OS's identity, delegation, and proof primitives into MCP" |
| 27 | "MCP-I fixes that for Model Context Protocol servers" | "`@kya-os/mcp` fixes that for Model Context Protocol servers" |
| 76 | "MCP-I adds per-tool authorization..." | "KYA-OS MCP adds per-tool authorization..." (your exact phrasing) |

The umbrella/surface taxonomy moves out of the README header. It's
still in `SPEC.md` and `GOVERNANCE.md` where it has room to be precise;
the README leads with the simpler "KYA-OS protocol for MCP" framing.

## Out of scope

- **Line 5 logo alt-text** still reads `MCP-I` because the logo image
  itself depicts that brand mark (hosted at
  `modelcontextprotocol-identity.io`). Update together with the image
  once the domain transfers to DIF.
- Line 27 wasn't in your explicit request but follows the same
  pattern — if you wanted only the two specific lines reframed, let
  me know and I'll narrow.
- `SPEC.md` / `CONFORMANCE.md` / `CONTRIBUTING.md` deliberately keep
  the MCP-I naming where it points at the spec / surface as a
  technical artifact. That's the right place for it.