### PR TITLE
docs: sweep MCP-I references in contributor/example docs + add DIF membership note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,14 @@
 # Contributing to @kya-os/mcp
 
-Thank you for your interest in contributing to `@kya-os/mcp` — the reference implementation of MCP-I, the identity surface of KYA-OS (Know Your Agent Operating System), submitted to the [DIF Trust and Authorization for AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/agent-and-authorization.html). KYA-OS is the umbrella protocol for agent identity, authorization, and observability; MCP-I binds those primitives to Model Context Protocol servers.
+Thank you for your interest in contributing to `@kya-os/mcp` — the reference implementation of the KYA-OS (Know Your Agent Operating System) protocol for Model Context Protocol servers, submitted to the [DIF Trust and Authorization for AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/agent-and-authorization.html). KYA-OS is the agent identity, authorization, and observability protocol; this package binds its primitives into MCP.
 
 All contributions are welcome: bug fixes, protocol clarifications, new examples, test improvements, and documentation.
+
+---
+
+## DIF Membership
+
+Contributing to this repository requires [**DIF Membership**](https://identity.foundation/join). DIF (the Decentralized Identity Foundation) is the standards body where the KYA-OS protocol is being developed and ratified; membership is the licensing-and-IPR vehicle that lets your contributions land in a DIF-owned spec without ambiguity. Please join at <https://identity.foundation/join> before opening a pull request.
 
 ---
 
@@ -27,8 +33,8 @@ Commits without a DCO sign-off will not be merged.
 ## Getting Started
 
 ```bash
-git clone https://github.com/modelcontextprotocol-identity/mcp-i-core.git
-cd mcp-i-core
+git clone https://github.com/modelcontextprotocol-identity/kya-os-mcp.git
+cd kya-os-mcp
 npm install
 npm test
 npx tsx examples/node-server/server.ts

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 ## Project Role
 
-This repository is the **DIF TAAWG protocol reference implementation** for MCP-I (Model Context Protocol Identity), the identity surface of KYA-OS (Know Your Agent Operating System). KYA-OS is the umbrella protocol for agent identity, authorization, and observability; MCP-I binds those primitives to Model Context Protocol servers. This repo provides the TypeScript implementation of the MCP-I specification — cryptographic identity, delegation chains, and non-repudiation proofs over MCP.
+This repository is the **DIF TAAWG protocol reference implementation** for the KYA-OS (Know Your Agent Operating System) protocol's MCP binding. KYA-OS is the agent identity, authorization, and observability protocol; this repo provides the TypeScript implementation of its MCP binding — cryptographic identity, delegation chains, and non-repudiation proofs over Model Context Protocol. The wire format is specified in [`SPEC.md`](./SPEC.md) (the MCP-I specification, version 1.0.0).
 
 ## Maintainers
 
@@ -31,7 +31,7 @@ Breaking changes to the specification require **explicit vote**:
 
 ## Relationship to DIF TAAWG
 
-This repository implements the MCP-I specification under development in the **Decentralized Identity Foundation (DIF) Trust and Authorization for AI Working Group (TAAWG)**.
+This repository implements the MCP-I specification (the MCP binding of KYA-OS), donated to the **Decentralized Identity Foundation (DIF) Trust and Authorization for AI Working Group (TAAWG)** and under review there for ratification as a DIF standard.
 
 - **Spec decisions** are made in the working group
 - **Implementation decisions** are made here

--- a/PLAN-consent-full.md
+++ b/PLAN-consent-full.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `examples/consent-branded/` — the same MCP-I consent flow as consent-basic, but using `@kya-os/consent` for the consent page. Demonstrates branded UI, multi-mode auth (consent-only by default, credentials via env var), config resolution, and production-grade HTML with loading skeleton and no-JS fallback. The example justifies `@kya-os/consent` by showing the DX leap: less code in the consent server, richer UI, configurable auth modes — all from a single `generateInlineConsentShell()` call.
+Add `examples/consent-branded/` — the same `@kya-os/mcp` consent flow as consent-basic, but using `@kya-os/consent` for the consent page. Demonstrates branded UI, multi-mode auth (consent-only by default, credentials via env var), config resolution, and production-grade HTML with loading skeleton and no-JS fallback. The example justifies `@kya-os/consent` by showing the DX leap: less code in the consent server, richer UI, configurable auth modes — all from a single `generateInlineConsentShell()` call.
 
 ## Decision Log
 

--- a/examples/consent-basic/README.md
+++ b/examples/consent-basic/README.md
@@ -1,6 +1,6 @@
 # consent-basic
 
-Human-in-the-loop consent flow for MCP-I. An AI agent calls a protected tool, the human approves via a consent page, and the agent retries with a signed delegation credential.
+Human-in-the-loop consent flow for `@kya-os/mcp`. An AI agent calls a protected tool, the human approves via a consent page, and the agent retries with a signed delegation credential.
 
 ```
 Agent calls checkout → needs_authorization → Human approves → Agent retries with VC → Tool executes

--- a/examples/consent-full/README.md
+++ b/examples/consent-full/README.md
@@ -1,6 +1,6 @@
 # consent-full
 
-Same MCP-I consent flow as [consent-basic](../consent-basic/) — but the consent page is rendered by [`@kya-os/consent`](https://www.npmjs.com/package/@kya-os/consent). One `generateConsentShell()` call replaces 200+ lines of hand-rolled HTML with a production-grade consent UI: multi-mode auth, configurable branding, loading skeleton, and no-JS fallback.
+Same `@kya-os/mcp` consent flow as [consent-basic](../consent-basic/) — but the consent page is rendered by [`@kya-os/consent`](https://www.npmjs.com/package/@kya-os/consent). One `generateConsentShell()` call replaces 200+ lines of hand-rolled HTML with a production-grade consent UI: multi-mode auth, configurable branding, loading skeleton, and no-JS fallback.
 
 ## Quick Start
 
@@ -56,7 +56,7 @@ If your server doesn't need delegation (just proofs + handshake), use `withMCPI`
 |---------|---------|-------------|
 | `AUTH_MODE` | `consent-only` | Auth mode: `consent-only` or `credentials` |
 | `BRAND_COLOR` | `#2563EB` | Primary brand color (hex) |
-| `COMPANY_NAME` | `MCP-I Demo` | Company name shown on consent page |
+| `COMPANY_NAME` | `KYA-OS Demo` | Company name shown on consent page |
 | `PORT` | `3002` | MCP server HTTP port |
 | `CONSENT_PORT` | `3001` | Consent server HTTP port |
 

--- a/examples/node-server/README.md
+++ b/examples/node-server/README.md
@@ -1,10 +1,10 @@
-# MCP-I Example Server
+# `@kya-os/mcp` Example Server
 
 A minimal MCP server demonstrating cryptographic identity, proof generation, and tool protection.
 
 ## Quick Start
 
-From the **repository root** (`mcp-i-core/`):
+From the **repository root** (`kya-os-mcp/`):
 
 ```bash
 # Install dependencies

--- a/examples/verify-proof/README.md
+++ b/examples/verify-proof/README.md
@@ -1,4 +1,4 @@
-# MCP-I Proof Verification
+# `@kya-os/mcp` Proof Verification
 
 Verifies a DetachedProof JSON using did:key resolution.
 


### PR DESCRIPTION
Follow-up to PR #46 (README) caught in the DIF meeting review: a few
docs still spoke of MCP-I as the subject of sentences about what the
codebase does. Reframes those under KYA-OS-first wording. 

Also adds a DIF Membership requirement note to CONTRIBUTING.md so
new contributors know to join before opening a PR; this is the
licensing-and-IPR vehicle that lets contributions land in a
DIF-owned spec without ambiguity.

## Changes

- **CONTRIBUTING.md**
  - Opener reframed to match the README pattern (lead with KYA-OS,
    drop the umbrella/surface taxonomy from the welcome paragraph).
  - New `## DIF Membership` section pointing at
    https://identity.foundation/join.
  - Clone URL + `cd` path updated from `mcp-i-core` to `kya-os-mcp`
    now that the repo has been renamed.

- **GOVERNANCE.md**
  - Project Role paragraph reframed; MCP-I retained parenthetically
    as the spec's technical name in the new last sentence.
  - Relationship-to-TAAWG paragraph updated from "under development"
    to "donated, under review for ratification" (the spec graduated
    to 1.0.0 in PR #45).

- **Example READMEs**
  - `consent-basic`, `consent-full`, `node-server`, `verify-proof`:
    "MCP-I consent flow" / "# MCP-I Example Server" /
    "# MCP-I Proof Verification" reframed to lead with the package
    name `@kya-os/mcp`.
  - `consent-full` env-var default `COMPANY_NAME: MCP-I Demo` →
    `KYA-OS Demo`.
  - `node-server` repository-root path updated `mcp-i-core` →
    `kya-os-mcp`.

- **PLAN-consent-full.md**
  - One reference to "the same MCP-I consent flow" updated to use
    the package name.

## Untouched (intentional)

- `SPEC.md`, `CONFORMANCE.md`, `schemas/README.md` — "MCP-I" is the
  spec/protocol name; these docs reference it as a technical
  artifact, not as a marketing subject. Same reason
  `outbound-delegation/README.md` keeps its "MCP-I §7" spec pointers.
- `CHANGELOG.md` — historical entries.
- `README.md` line 5 logo alt-text — image-tied, separate follow-up
  when the brand mark can be swapped.
- `node-server/README.md` line 47 "MCP-I-aware clients" — describes
  a class of client that implements the protocol; technical
  category, not branding voice.