### PR TITLE
feat: generic Identity interface and did:web document builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- **Generic `Identity` interface** exported from the root entry point.
+  Captures the shape shared by every subject the protocol speaks about
+  (DID + verification-method id + key material). `AgentIdentity` now
+  extends `Identity`; the agent-flavoured shape is unchanged for
+  existing consumers.
+- **`buildDidWebDocument(identity, options?)`** in
+  `delegation/did-web-resolver`. Produces the DID Document a `did:web`
+  controller serves at its resolution URL (see `didWebToUrl`),
+  completing the producer/consumer round-trip with `DidWebResolver`.
+  Emits both `publicKeyJwk` and `publicKeyMultibase` for cross-format
+  interop, matching the `Ed25519VerificationKey2020` form used by the
+  did:key resolver.
+- Optional `@context` field on `DIDDocument` so produced documents can
+  declare the JSON-LD contexts they reference.
+
 ### Changed
 
 - **Package renamed from `@mcp-i/core` to `@kya-os/mcp`.** Reframed under

--- a/src/delegation/__tests__/did-web-resolver.test.ts
+++ b/src/delegation/__tests__/did-web-resolver.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   DidWebResolver,
+  buildDidWebDocument,
   createDidWebResolver,
   isDidWeb,
   parseDidWeb,
   didWebToUrl,
 } from '../did-web-resolver.js';
-import type { FetchProvider } from '../../providers/base.js';
+import { base58Decode } from '../../utils/base58.js';
+import { bytesToBase64 } from '../../utils/base64.js';
+import type { FetchProvider, Identity } from '../../providers/base.js';
 import type { DIDDocument } from '../vc-verifier.js';
 
 /**
@@ -422,6 +425,166 @@ describe('DidWebResolver', () => {
       await resolver.resolve('did:web:example.com');
 
       expect(mockFetchProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('buildDidWebDocument', () => {
+  /** Multicodec prefix for Ed25519 public keys (matches the resolver). */
+  const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01]);
+
+  /**
+   * Construct a deterministic 32-byte test key and the matching
+   * Identity bundle. Returning the raw bytes too makes round-trip
+   * assertions on `publicKeyMultibase` straightforward.
+   */
+  const buildIdentity = (
+    did: string,
+    fragment = 'keys-1'
+  ): { identity: Identity; publicKeyBytes: Uint8Array } => {
+    const publicKeyBytes = new Uint8Array(32).map((_, i) => (i * 7) & 0xff);
+    return {
+      publicKeyBytes,
+      identity: {
+        did,
+        kid: `${did}#${fragment}`,
+        publicKey: bytesToBase64(publicKeyBytes),
+        privateKey: undefined,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    };
+  };
+
+  describe('happy path', () => {
+    it('produces a DID Document whose id matches the identity DID', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity);
+
+      expect(doc.id).toBe('did:web:example.com');
+    });
+
+    it('emits the default JSON-LD contexts in spec-required order', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity);
+
+      expect(doc['@context']).toEqual([
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ]);
+    });
+
+    it('appends additional contexts after the defaults', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity, {
+        additionalContexts: ['https://example.com/custom/v1'],
+      });
+
+      expect(doc['@context']).toEqual([
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+        'https://example.com/custom/v1',
+      ]);
+    });
+
+    it('emits a single Ed25519VerificationKey2020 method controlled by the DID', () => {
+      const { identity } = buildIdentity('did:web:example.com:agents:bot1');
+
+      const doc = buildDidWebDocument(identity);
+
+      expect(doc.verificationMethod).toHaveLength(1);
+      const vm = doc.verificationMethod?.[0];
+      expect(vm?.id).toBe(identity.kid);
+      expect(vm?.type).toBe('Ed25519VerificationKey2020');
+      expect(vm?.controller).toBe(identity.did);
+    });
+
+    it('publishes the verification method under both authentication and assertionMethod', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity);
+
+      expect(doc.authentication).toEqual([identity.kid]);
+      expect(doc.assertionMethod).toEqual([identity.kid]);
+    });
+
+    it('emits publicKeyJwk in OKP/Ed25519 form', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity);
+
+      const jwk = doc.verificationMethod?.[0]?.publicKeyJwk as {
+        kty: string;
+        crv: string;
+        x: string;
+      };
+      expect(jwk.kty).toBe('OKP');
+      expect(jwk.crv).toBe('Ed25519');
+      expect(jwk.x).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('emits publicKeyMultibase that decodes back to the original key bytes', () => {
+      const { identity, publicKeyBytes } = buildIdentity('did:web:example.com');
+
+      const doc = buildDidWebDocument(identity);
+
+      const multibase = doc.verificationMethod?.[0]?.publicKeyMultibase;
+      expect(multibase).toBeDefined();
+      expect(multibase?.startsWith('z')).toBe(true);
+
+      const decoded = base58Decode(multibase!.slice(1));
+      expect(decoded.slice(0, 2)).toEqual(ED25519_MULTICODEC_PREFIX);
+      expect(decoded.slice(2)).toEqual(publicKeyBytes);
+    });
+  });
+
+  describe('round-trip with DidWebResolver', () => {
+    it('produces a document the resolver accepts as valid', async () => {
+      const did = 'did:web:example.com:u:alice';
+      const { identity } = buildIdentity(did);
+      const document = buildDidWebDocument(identity);
+
+      const fetchProvider: FetchProvider = {
+        resolveDID: vi.fn(),
+        fetchStatusList: vi.fn(),
+        fetchDelegationChain: vi.fn(),
+        fetch: vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue(document),
+        }),
+      };
+
+      const resolved = await new DidWebResolver(fetchProvider).resolve(did);
+
+      expect(resolved).not.toBeNull();
+      expect(resolved?.id).toBe(did);
+      expect(resolved?.verificationMethod?.[0]?.controller).toBe(did);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws when identity.did is not a did:web DID', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+      const bad: Identity = { ...identity, did: 'did:key:z6MkInvalid' };
+
+      expect(() => buildDidWebDocument(bad)).toThrow(/must be a did:web DID/);
+    });
+
+    it('throws when identity.kid does not reference identity.did', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+      const bad: Identity = { ...identity, kid: 'did:web:other.com#keys-1' };
+
+      expect(() => buildDidWebDocument(bad)).toThrow(/does not reference/);
+    });
+
+    it('throws when publicKey is not 32 bytes after base64 decode', () => {
+      const { identity } = buildIdentity('did:web:example.com');
+      const bad: Identity = { ...identity, publicKey: bytesToBase64(new Uint8Array(16)) };
+
+      expect(() => buildDidWebDocument(bad)).toThrow(/expected 32-byte/);
     });
   });
 });

--- a/src/delegation/did-web-resolver.ts
+++ b/src/delegation/did-web-resolver.ts
@@ -11,9 +11,12 @@
  * @see https://w3c-ccg.github.io/did-method-web/
  */
 
-import type { FetchProvider } from '../providers/base.js';
+import type { FetchProvider, Identity } from '../providers/base.js';
 import type { DIDResolver, DIDDocument, VerificationMethod } from './vc-verifier.js';
 import { logger } from '../logging/index.js';
+import { base58Encode } from '../utils/base58.js';
+import { base64ToBytes } from '../utils/base64.js';
+import { publicKeyToJwk } from './did-key-resolver.js';
 
 /**
  * Parsed components of a did:web DID
@@ -267,4 +270,142 @@ export function createDidWebResolver(
   options?: { cacheTtl?: number }
 ): DIDResolver {
   return new DidWebResolver(fetchProvider, options);
+}
+
+/** Ed25519 multicodec prefix (0xed 0x01) used for `publicKeyMultibase`. */
+const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01]);
+
+/**
+ * Default JSON-LD contexts for an Ed25519-keyed did:web Document.
+ * `did/v1` is required by DID Core; `ed25519-2020/v1` defines the
+ * `Ed25519VerificationKey2020` type emitted below.
+ */
+const DEFAULT_DID_WEB_CONTEXTS: readonly string[] = [
+  'https://www.w3.org/ns/did/v1',
+  'https://w3id.org/security/suites/ed25519-2020/v1',
+];
+
+/**
+ * Options for {@link buildDidWebDocument}.
+ */
+export interface BuildDidWebDocumentOptions {
+  /**
+   * Additional JSON-LD contexts appended after the defaults
+   * (`did/v1`, `ed25519-2020/v1`). Use to declare credential or
+   * service contexts the controller publishes alongside its keys.
+   */
+  additionalContexts?: readonly string[];
+}
+
+/**
+ * Build the DID Document a did:web controller serves at its
+ * resolution URL (see {@link didWebToUrl}).
+ *
+ * Emits a single Ed25519 verification method derived from
+ * `identity.publicKey` (base64-encoded raw bytes — the
+ * {@link Identity} convention). Both `publicKeyJwk` and
+ * `publicKeyMultibase` are included for cross-format interop with
+ * verifiers that prefer one over the other.
+ *
+ * The verification method is published in both `authentication` and
+ * `assertionMethod`, matching the {@link createDidKeyResolver} output
+ * and the most common verifier expectations.
+ *
+ * The function is purely synchronous and performs no I/O. Hosts
+ * publish the returned object verbatim (e.g. as the body of a
+ * `/.well-known/did.json` route).
+ *
+ * @param identity - Subject identity. `did` must be a `did:web:` DID;
+ *   `kid` must reference the same DID (`<did>#<fragment>`).
+ * @param options - Optional context extensions.
+ * @returns DID Document satisfying the W3C DID Core data model.
+ * @throws Error when `identity.did` is not a `did:web:` DID, when
+ *   `identity.kid` does not reference `identity.did`, or when
+ *   `identity.publicKey` is not a valid base64 string of the
+ *   expected length.
+ *
+ * @example
+ * ```typescript
+ * const document = buildDidWebDocument({
+ *   did: 'did:web:example.com:agents:bot1',
+ *   kid: 'did:web:example.com:agents:bot1#keys-1',
+ *   publicKey: agent.publicKey, // base64-encoded Ed25519
+ *   createdAt: new Date().toISOString(),
+ * });
+ * // Serve `document` at https://example.com/agents/bot1/did.json
+ * ```
+ */
+export function buildDidWebDocument(
+  identity: Identity,
+  options?: BuildDidWebDocumentOptions
+): DIDDocument {
+  if (!isDidWeb(identity.did)) {
+    throw new Error(
+      `buildDidWebDocument: identity.did must be a did:web DID (got "${identity.did}")`
+    );
+  }
+
+  if (!identity.kid.startsWith(`${identity.did}#`)) {
+    throw new Error(
+      `buildDidWebDocument: identity.kid "${identity.kid}" does not reference identity.did "${identity.did}"`
+    );
+  }
+
+  const publicKeyBytes = decodePublicKey(identity.publicKey);
+  const publicKeyJwk = publicKeyToJwk(publicKeyBytes);
+  const publicKeyMultibase = encodeEd25519Multibase(publicKeyBytes);
+
+  const verificationMethod: VerificationMethod = {
+    id: identity.kid,
+    type: 'Ed25519VerificationKey2020',
+    controller: identity.did,
+    publicKeyJwk,
+    publicKeyMultibase,
+  };
+
+  const contexts = options?.additionalContexts?.length
+    ? [...DEFAULT_DID_WEB_CONTEXTS, ...options.additionalContexts]
+    : [...DEFAULT_DID_WEB_CONTEXTS];
+
+  return {
+    '@context': contexts,
+    id: identity.did,
+    verificationMethod: [verificationMethod],
+    authentication: [identity.kid],
+    assertionMethod: [identity.kid],
+  };
+}
+
+/**
+ * Decode a base64-encoded Ed25519 public key to raw bytes.
+ *
+ * The {@link Identity} contract documents `publicKey` as base64 of the
+ * 32-byte Ed25519 public key. We accept that length only — anything
+ * else is a programming error and surfaces as a thrown construction
+ * exception (per the repository error contract: construction throws,
+ * verification/resolution returns).
+ */
+function decodePublicKey(publicKeyBase64: string): Uint8Array {
+  const bytes = base64ToBytes(publicKeyBase64);
+  if (bytes.length !== 32) {
+    throw new Error(
+      `buildDidWebDocument: expected 32-byte Ed25519 public key, got ${bytes.length} bytes after base64 decode`
+    );
+  }
+  return bytes;
+}
+
+/**
+ * Encode raw Ed25519 public key bytes as `publicKeyMultibase`
+ * (multicodec-tagged, base58btc-encoded, `z`-prefixed). Matches the
+ * encoding used by {@link createDidKeyResolver} for the equivalent
+ * field on did:key documents.
+ */
+function encodeEd25519Multibase(publicKeyBytes: Uint8Array): string {
+  const multicodec = new Uint8Array(
+    ED25519_MULTICODEC_PREFIX.length + publicKeyBytes.length
+  );
+  multicodec.set(ED25519_MULTICODEC_PREFIX);
+  multicodec.set(publicKeyBytes, ED25519_MULTICODEC_PREFIX.length);
+  return `z${base58Encode(multicodec)}`;
 }

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -52,6 +52,7 @@ export interface DIDResolver {
 }
 
 export interface DIDDocument {
+  '@context'?: string | string[];
   id: string;
   verificationMethod?: VerificationMethod[];
   authentication?: (string | VerificationMethod)[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,8 @@ export {
   isDidWeb,
   parseDidWeb,
   didWebToUrl,
+  buildDidWebDocument,
+  type BuildDidWebDocumentOptions,
 } from './delegation/did-web-resolver.js';
 
 // Utils

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,7 @@ export {
   StorageProvider,
   NonceCacheProvider,
   IdentityProvider,
+  type Identity,
   type AgentIdentity,
 } from './providers/base.js';
 

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -50,14 +50,44 @@ export abstract class NonceCacheProvider {
   abstract destroy(): Promise<void>;
 }
 
-export interface AgentIdentity {
+/**
+ * Generic identity bundle backing the MCP-I protocol primitives.
+ *
+ * Holds the DID, verification-method id, and key material for any
+ * subject the protocol speaks about (agents, servers, users, services).
+ * The wire format (delegations, proofs, status lists) is subject-
+ * agnostic, so the in-memory representation is too.
+ *
+ * `privateKey` is optional because verifier-only deployments hold
+ * only public material — the private key lives elsewhere (HSM, wallet,
+ * delegated issuer). Issuance flows that need to sign should narrow
+ * to {@link AgentIdentity} or check `privateKey` explicitly.
+ */
+export interface Identity {
+  /** Subject DID (e.g. `did:key:...`, `did:web:...`). */
   did: string;
+  /** Verification-method id (`<did>#<fragment>`). */
   kid: string;
-  privateKey: string;
+  /** Public key material as base64-encoded raw bytes (Ed25519: 32 bytes). */
   publicKey: string;
+  /** Private key material as base64-encoded raw bytes. Absent on verifier-only holders. */
+  privateKey?: string;
+  /** ISO-8601 creation timestamp. */
   createdAt: string;
-  type: 'development' | 'production';
+  /** Free-form, implementation-defined metadata. */
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Agent-flavoured {@link Identity} used by MCP server implementations.
+ *
+ * Adds the agent-lifecycle fields (`type`) and re-tightens `privateKey`
+ * to required, since servers issue and sign on behalf of the agent
+ * and therefore always hold private material in this context.
+ */
+export interface AgentIdentity extends Identity {
+  privateKey: string;
+  type: 'development' | 'production';
 }
 
 export abstract class IdentityProvider {


### PR DESCRIPTION
## Description

Two foundational additions that complete the `did:web` producer/consumer
round-trip and broaden the in-memory identity model beyond agents:

- **`Identity` interface** — generic identity bundle (DID, verification-
  method id, key material, timestamp, metadata) shared by every subject
  the protocol speaks about. `AgentIdentity extends Identity`, narrowing
  `privateKey` back to required and adding the agent-lifecycle `type`
  field. Existing consumers of `AgentIdentity` see the same shape.

- **`buildDidWebDocument(identity, options?)`** — companion to
  `DidWebResolver`. Given a `did:web` identity, returns the spec-aligned
  DID Document a controller serves at its resolution URL. Emits both
  `publicKeyJwk` and `publicKeyMultibase` for cross-format interop,
  matching the `Ed25519VerificationKey2020` form used by the did:key
  resolver. Synchronous, no I/O; validates inputs at call time per the
  repository's construction-throws contract.

Also adds an optional `@context` field to `DIDDocument` so produced
documents can declare the JSON-LD contexts they reference.

## Spec Impact

None. Pure-additive implementation helpers — no changes to wire format,
conformance levels, or any normative section of `SPEC.md` /
`CONFORMANCE.md`.

## Checklist

- [x] Tests pass (`npm test`) — 895/895
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted (none)
- [x] CHANGELOG.md updated