### PR TITLE
feat: createDidKeyIdentity and createDidWebIdentity provisioning helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ Versioning: https://semver.org/spec/v2.0.0.html
   did:key resolver.
 - Optional `@context` field on `DIDDocument` so produced documents can
   declare the JSON-LD contexts they reference.
+- **`createIdentity(crypto, request)`** — discriminated-union
+  dispatching surface that selects the DID method at call time
+  (`{ method: 'did:key', ... }` or
+  `{ method: 'did:web', domain, path?, ... }`). Per-method options
+  (e.g. `kidFragment` on did:web only) live on the request itself so
+  cross-method misuse fails at compile time rather than at runtime.
+  Future `did:jwk` / `did:peer` / `did:ion` helpers extend the union
+  without growing the top-level export footprint.
+- **`createDidKeyIdentity(crypto, options?)`** and
+  **`createDidWebIdentity(crypto, args, options?)`** in
+  `providers/identity-factory`. Single-call provisioning helpers that
+  compose a `CryptoProvider` with the appropriate DID method to mint a
+  fresh `Identity`. Both return `ProvisionedIdentity` (the narrowed
+  `Identity & { privateKey: string }`) and accept an optional
+  `ClockProvider` for deterministic `createdAt` stamping. The did:web
+  helper validates `domain` and `path` segments per the construction-
+  throws contract.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kya-os/mcp",
   "version": "1.2.0",
-  "description": "Core library for MCP-I \u2014 delegation, proof, and session primitives for Model Context Protocol Identity",
+  "description": "Core library for MCP-I — delegation, proof, and session primitives for Model Context Protocol Identity",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -91,6 +91,7 @@
     "commander": "^14.0.3",
     "eslint": "^10.0.3",
     "express": "^5.2.1",
+    "fast-check": "^3.23.2",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.57.0",
     "vitest": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      fast-check:
+        specifier: ^3.23.2
+        version: 3.23.2
       typescript:
         specifier: ^5.5.3
         version: 5.9.3
@@ -868,6 +871,10 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1225,6 +1232,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -2293,6 +2303,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -2615,6 +2629,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qs@6.15.0:
     dependencies:

--- a/src/__tests__/providers/identity-factory.test.ts
+++ b/src/__tests__/providers/identity-factory.test.ts
@@ -1,0 +1,1192 @@
+/**
+ * Tests for identity provisioning helpers
+ *
+ * Covers did:key + did:web provisioning, option propagation
+ * (clock, metadata, kidFragment), did:web argument validation, and
+ * end-to-end round-trips with `resolveDidKeySync` and
+ * `buildDidWebDocument` to lock the produced shape against the
+ * resolvers that consume it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  createDidKeyIdentity,
+  createDidWebIdentity,
+  createIdentity,
+} from '../../providers/identity-factory.js';
+import type {
+  CreateIdentityRequest,
+  ProvisionedIdentity,
+} from '../../providers/identity-factory.js';
+import { NodeCryptoProvider } from '../../providers/node-crypto.js';
+import { ClockProvider, CryptoProvider } from '../../providers/base.js';
+import type { Identity } from '../../providers/base.js';
+import {
+  resolveDidKeySync,
+  extractPublicKeyFromDidKey,
+} from '../../delegation/did-key-resolver.js';
+import {
+  buildDidWebDocument,
+  parseDidWeb,
+  didWebToUrl,
+} from '../../delegation/did-web-resolver.js';
+import { bytesToBase64 } from '../../utils/base64.js';
+
+const crypto = new NodeCryptoProvider();
+
+/** Fixed-instant clock used to assert deterministic `createdAt` stamping. */
+class FixedClock extends ClockProvider {
+  constructor(private readonly fixedMs: number) {
+    super();
+  }
+  now(): number {
+    return this.fixedMs;
+  }
+  isWithinSkew(_timestamp: number, _skewSeconds: number): boolean {
+    return true;
+  }
+  hasExpired(_expiresAt: number): boolean {
+    return false;
+  }
+  calculateExpiry(ttlSeconds: number): number {
+    return this.fixedMs + ttlSeconds * 1000;
+  }
+  format(timestamp: number): string {
+    return new Date(timestamp).toISOString();
+  }
+}
+
+describe('createDidKeyIdentity', () => {
+  it('produces an Identity whose DID is a valid Ed25519 did:key', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+
+    expect(identity.did.startsWith('did:key:z6Mk')).toBe(true);
+  });
+
+  it('produces a kid that references the produced DID', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+
+    expect(identity.kid.startsWith(`${identity.did}#`)).toBe(true);
+  });
+
+  it('returns the private key alongside the public key', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+
+    expect(identity.privateKey.length).toBeGreaterThan(0);
+    expect(identity.publicKey.length).toBeGreaterThan(0);
+  });
+
+  it('stamps createdAt with an ISO-8601 timestamp from the host clock by default', async () => {
+    const before = Date.now();
+    const identity = await createDidKeyIdentity(crypto);
+    const after = Date.now();
+
+    const parsed = Date.parse(identity.createdAt);
+    expect(Number.isFinite(parsed)).toBe(true);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+
+  it('honours an injected clock for deterministic createdAt', async () => {
+    const fixedMs = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const identity = await createDidKeyIdentity(crypto, {
+      clock: new FixedClock(fixedMs),
+    });
+
+    expect(identity.createdAt).toBe(new Date(fixedMs).toISOString());
+  });
+
+  it('attaches metadata when supplied and omits the field otherwise', async () => {
+    const withMetadata = await createDidKeyIdentity(crypto, {
+      metadata: { source: 'unit-test' },
+    });
+    const withoutMetadata = await createDidKeyIdentity(crypto);
+
+    expect(withMetadata.metadata).toEqual({ source: 'unit-test' });
+    expect(Object.prototype.hasOwnProperty.call(withoutMetadata, 'metadata')).toBe(false);
+  });
+
+  it('produces a DID that resolves via resolveDidKeySync', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+
+    const document = resolveDidKeySync(identity.did);
+
+    expect(document).not.toBeNull();
+    expect(document?.id).toBe(identity.did);
+    expect(document?.verificationMethod?.[0]?.controller).toBe(identity.did);
+  });
+
+  it('produces a public key that extracts back to 32 raw Ed25519 bytes', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+
+    const extracted = extractPublicKeyFromDidKey(identity.did);
+    expect(extracted).not.toBeNull();
+    expect(extracted?.length).toBe(32);
+
+    // The extracted bytes, re-encoded as base64, must match the identity's publicKey.
+    expect(bytesToBase64(extracted!)).toBe(identity.publicKey);
+  });
+});
+
+describe('createDidWebIdentity', () => {
+  describe('happy path', () => {
+    it('produces did:web:<domain> when no path is supplied', async () => {
+      const identity = await createDidWebIdentity(crypto, { domain: 'example.com' });
+
+      expect(identity.did).toBe('did:web:example.com');
+      expect(identity.kid).toBe('did:web:example.com#keys-1');
+    });
+
+    it('joins path segments with ":" to form the DID', async () => {
+      const identity = await createDidWebIdentity(crypto, {
+        domain: 'example.com',
+        path: ['users', 'alice'],
+      });
+
+      expect(identity.did).toBe('did:web:example.com:users:alice');
+      expect(identity.kid).toBe('did:web:example.com:users:alice#keys-1');
+    });
+
+    it('preserves percent-encoded ports in the authority component', async () => {
+      const identity = await createDidWebIdentity(crypto, {
+        domain: 'example.com%3A8080',
+        path: ['agents', 'bot1'],
+      });
+
+      expect(identity.did).toBe('did:web:example.com%3A8080:agents:bot1');
+    });
+
+    it('honours a custom kidFragment', async () => {
+      const identity = await createDidWebIdentity(
+        crypto,
+        { domain: 'example.com' },
+        { kidFragment: 'primary' }
+      );
+
+      expect(identity.kid).toBe('did:web:example.com#primary');
+    });
+
+    it('honours an injected clock for deterministic createdAt', async () => {
+      const fixedMs = Date.UTC(2026, 0, 1, 12, 0, 0);
+      const identity = await createDidWebIdentity(
+        crypto,
+        { domain: 'example.com' },
+        { clock: new FixedClock(fixedMs) }
+      );
+
+      expect(identity.createdAt).toBe(new Date(fixedMs).toISOString());
+    });
+
+    it('returns the private key alongside the public key', async () => {
+      const identity = await createDidWebIdentity(crypto, { domain: 'example.com' });
+
+      expect(identity.privateKey.length).toBeGreaterThan(0);
+      expect(identity.publicKey.length).toBeGreaterThan(0);
+    });
+
+    it('attaches metadata when supplied and omits the field otherwise', async () => {
+      const withMetadata = await createDidWebIdentity(
+        crypto,
+        { domain: 'example.com' },
+        { metadata: { source: 'unit-test' } }
+      );
+      const withoutMetadata = await createDidWebIdentity(crypto, { domain: 'example.com' });
+
+      expect(withMetadata.metadata).toEqual({ source: 'unit-test' });
+      expect(Object.prototype.hasOwnProperty.call(withoutMetadata, 'metadata')).toBe(false);
+    });
+
+    it('produces an Identity that buildDidWebDocument accepts', async () => {
+      const identity = await createDidWebIdentity(crypto, {
+        domain: 'example.com',
+        path: ['users', 'alice'],
+      });
+
+      const document = buildDidWebDocument(identity);
+
+      expect(document.id).toBe(identity.did);
+      expect(document.verificationMethod?.[0]?.id).toBe(identity.kid);
+      expect(document.verificationMethod?.[0]?.controller).toBe(identity.did);
+    });
+  });
+
+  describe('domain validation — surface checks', () => {
+    it('throws when domain is empty', async () => {
+      await expect(
+        createDidWebIdentity(crypto, { domain: '' })
+      ).rejects.toThrow(/must not be empty/);
+    });
+
+    it('throws when domain includes a scheme prefix', async () => {
+      await expect(
+        createDidWebIdentity(crypto, { domain: 'https://example.com' })
+      ).rejects.toThrow(/must not include a scheme/);
+    });
+
+    it('throws when domain contains "/"', async () => {
+      await expect(
+        createDidWebIdentity(crypto, { domain: 'example.com/users' })
+      ).rejects.toThrow(/must not contain "\/"/);
+    });
+
+    it.each([':example.com', 'example.com:', 'example.com:8080', 'a:b:c'])(
+      'throws when domain contains a literal ":" (%s)',
+      async (domain) => {
+        await expect(
+          createDidWebIdentity(crypto, { domain })
+        ).rejects.toThrow(/must not contain ":"; percent-encode ports as "%3A"/);
+      }
+    );
+  });
+
+  describe('domain validation — percent-encoding traversal', () => {
+    it.each(['%', '%G1', 'example.com%', 'example.com%2'])(
+      'throws on invalid or incomplete percent-encoding (%s)',
+      async (domain) => {
+        await expect(
+          createDidWebIdentity(crypto, { domain })
+        ).rejects.toThrow(/invalid percent-encoded byte sequence/);
+      }
+    );
+
+    it.each([
+      ['%2F..%2Fevil.com', '"/", "\\\\", or NUL'],
+      ['%2f..%2fevil.com', '"/", "\\\\", or NUL'],
+      ['example.com%00', '"/", "\\\\", or NUL'],
+      ['example.com%5Cevil.com', '"/", "\\\\", or NUL'],
+    ])(
+      'rejects encoded traversal sequences (%s)',
+      async (domain, expected) => {
+        await expect(
+          createDidWebIdentity(crypto, { domain })
+        ).rejects.toThrow(new RegExp(expected));
+      }
+    );
+  });
+
+  describe('domain validation — RFC 3986 reg-name grammar', () => {
+    it.each([
+      'example com',         // space
+      '-example.com',         // leading hyphen on first label
+      'example-.com',         // trailing hyphen on first label
+      'example..com',         // empty label
+      '.example.com',         // leading dot → empty first label
+      'example.com.',         // trailing dot → empty last label
+      '-',                     // hyphen-only label
+      '.',                     // empty labels around dot
+    ])('rejects invalid hostname shape (%s)', async (domain) => {
+      await expect(
+        createDidWebIdentity(crypto, { domain })
+      ).rejects.toThrow(/invalid hostname|must not decode|containing/);
+    });
+
+    it('rejects hostnames over 253 characters', async () => {
+      const longLabel = 'a'.repeat(60);
+      const domain = `${longLabel}.${longLabel}.${longLabel}.${longLabel}.${longLabel}`; // 304 chars
+      await expect(
+        createDidWebIdentity(crypto, { domain })
+      ).rejects.toThrow(/invalid hostname/);
+    });
+
+    it('rejects labels over 63 characters', async () => {
+      const longLabel = 'a'.repeat(64);
+      await expect(
+        createDidWebIdentity(crypto, { domain: `${longLabel}.com` })
+      ).rejects.toThrow(/invalid hostname/);
+    });
+  });
+
+  describe('domain validation — port grammar', () => {
+    it('accepts a valid percent-encoded port', async () => {
+      const identity = await createDidWebIdentity(crypto, {
+        domain: 'example.com%3A8080',
+      });
+      expect(identity.did).toBe('did:web:example.com%3A8080');
+    });
+
+    it.each(['example.com%3A99999', 'example.com%3Aabc', 'example.com%3A'])(
+      'rejects invalid ports (%s)',
+      async (domain) => {
+        await expect(
+          createDidWebIdentity(crypto, { domain })
+        ).rejects.toThrow(/invalid port/);
+      }
+    );
+  });
+
+  describe('path-segment validation', () => {
+    it('throws when a path segment is empty', async () => {
+      await expect(
+        createDidWebIdentity(crypto, { domain: 'example.com', path: ['users', ''] })
+      ).rejects.toThrow(/path segments must be non-empty/);
+    });
+
+    it.each(['alice:bob', 'a:b:c'])(
+      'rejects raw ":" in segment (%s)',
+      async (segment) => {
+        await expect(
+          createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          })
+        ).rejects.toThrow(/must not contain ":"/);
+      }
+    );
+
+    it('rejects raw "/" in segment', async () => {
+      await expect(
+        createDidWebIdentity(crypto, {
+          domain: 'example.com',
+          path: ['alice/bob'],
+        })
+      ).rejects.toThrow(/must not contain "\/"/);
+    });
+
+    it.each(['..', '.'])(
+      'rejects relative-path segment (%s)',
+      async (segment) => {
+        await expect(
+          createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          })
+        ).rejects.toThrow(/relative path component|disallowed by did:web/);
+      }
+    );
+
+    it.each([
+      '%2E%2E',           // .. encoded
+      '%2e%2e',           // .. encoded (lowercase hex)
+      '%2Fevil',          // / encoded
+      'foo%00bar',        // NUL encoded
+      'foo%5Cevil',       // backslash encoded
+    ])('rejects encoded traversal in segment (%s)', async (segment) => {
+      await expect(
+        createDidWebIdentity(crypto, {
+          domain: 'example.com',
+          path: [segment],
+        })
+      ).rejects.toThrow(/relative path component|must not decode|containing/);
+    });
+
+    it.each(['%', '%G1', 'foo%', 'foo%2'])(
+      'rejects invalid percent-encoding in segment (%s)',
+      async (segment) => {
+        await expect(
+          createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          })
+        ).rejects.toThrow(/invalid percent-encoded byte sequence/);
+      }
+    );
+
+    it('accepts valid percent-encoded segments', async () => {
+      const identity = await createDidWebIdentity(crypto, {
+        domain: 'example.com',
+        path: ['users', 'alice%20smith'],
+      });
+      expect(identity.did).toBe('did:web:example.com:users:alice%20smith');
+    });
+
+    it.each([
+      '%2E',      // single dot, uppercase hex
+      '%2e',      // single dot, lowercase hex
+    ])(
+      'rejects single-dot segment via encoded form (%s) — symmetry with %2E%2E',
+      async (segment) => {
+        // The exact-string check `decoded === '.'` catches it, but
+        // pinning the symmetry with the existing `%2E%2E` rejection
+        // ensures a future refactor that loosens one without the
+        // other gets caught by CI.
+        await expect(
+          createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          })
+        ).rejects.toThrow(/relative path component/);
+      }
+    );
+
+    it.each([
+      'alice!bob',         // sub-delim "!"
+      "O'Brien",           // sub-delim "'"
+      'c++',               // sub-delim "+"
+      'cost,benefit',      // sub-delim ","
+      'key=value',         // sub-delim "="
+      'fn(arg)',           // sub-delims "()"
+      '$pecial',           // sub-delim "$"
+      'user@host',         // pchar "@"
+      'nested;mark',       // sub-delim ";"
+      'ampersand&here',    // sub-delim "&"
+      'multiplier*here',   // sub-delim "*"
+    ])(
+      'accepts RFC 3986 pchar segment character class (%s)',
+      async (segment) => {
+        // Widened from the prior `unreserved + pct-encoded` set to the
+        // full pchar grammar minus `:` (the path separator). Pins the
+        // spec-conformant surface: any segment another implementation
+        // can legally emit must round-trip through this helper.
+        const identity = await createDidWebIdentity(crypto, {
+          domain: 'example.com',
+          path: [segment],
+        });
+        expect(identity.did).toBe(`did:web:example.com:${segment}`);
+      }
+    );
+
+    it.each([
+      'has space',         // SP — not in pchar
+      'has\ttab',          // HT — control char
+      'lt<gt',             // "<" — not in pchar (gen-delim)
+      'pipe|here',         // "|" — not in pchar
+      'caret^here',        // "^" — not in pchar
+      'has`backtick',      // "`" — not in pchar
+      'sq[bracket',        // "[" — gen-delim, not in pchar
+      'curly{brace',       // "{" — not in pchar
+      'question?mark',     // "?" — in fragment grammar but not in pchar
+      'hash#mark',         // "#" — gen-delim, not in pchar
+    ])(
+      'rejects characters outside RFC 3986 pchar via the final structural regex (%s)',
+      async (segment) => {
+        // These inputs survive the surface checks (no raw ":" or "/"),
+        // survive percent-decoding (no "%" to decode), and survive the
+        // decoded-traversal checks — they must still be rejected by
+        // the final pchar regex. Without this coverage that branch was
+        // reached by nothing in the suite.
+        await expect(
+          createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          })
+        ).rejects.toThrow(/disallowed by RFC 3986 pchar grammar/);
+      }
+    );
+  });
+
+  describe('domain validation — multi-delimiter ordering', () => {
+    it('reports "multiple \\":\\"" before "invalid port" for a%3Ab%3Ac', async () => {
+      // The post-decode multi-colon check used to live after the port
+      // check, where it was unreachable (`portPart` containing `:`
+      // would fail `isValidPort` first). Reordering makes the check
+      // reachable AND produces a more specific error for the input.
+      await expect(
+        createDidWebIdentity(crypto, { domain: 'a%3Ab%3Ac' })
+      ).rejects.toThrow(/multiple ":" delimiters/);
+    });
+  });
+
+  describe('kidFragment validation', () => {
+    it('throws when kidFragment is the empty string', async () => {
+      await expect(
+        createDidWebIdentity(
+          crypto,
+          { domain: 'example.com' },
+          { kidFragment: '' }
+        )
+      ).rejects.toThrow(/kidFragment must not be empty/);
+    });
+
+    it.each([
+      'foo#bar',          // "#" — only one fragment delimiter per URI
+      'has space',        // whitespace not in pchar
+      'tab\there',        // tab control char
+      'line\nfeed',       // LF control char
+      'null byte',   // NUL control char
+      'foo%G1',           // invalid percent escape
+      'foo%',             // bare percent
+    ])('rejects fragments outside RFC 3986 grammar (%s)', async (kidFragment) => {
+      await expect(
+        createDidWebIdentity(
+          crypto,
+          { domain: 'example.com' },
+          { kidFragment }
+        )
+      ).rejects.toThrow(/disallowed by RFC 3986 fragment grammar/);
+    });
+
+    it.each([
+      'keys-1',
+      'verification-method-1',
+      'controller-2024',
+      'auth:primary',      // ":" is in pchar
+      'keys/main',         // "/" is allowed by fragment grammar
+      'keys.v1',
+      'key_~tilde',
+    ])('accepts fragments inside RFC 3986 grammar (%s)', async (kidFragment) => {
+      const identity = await createDidWebIdentity(
+        crypto,
+        { domain: 'example.com' },
+        { kidFragment }
+      );
+      expect(identity.kid).toBe(`did:web:example.com#${kidFragment}`);
+    });
+  });
+});
+
+describe('cryptographic correctness', () => {
+  it('createDidKeyIdentity produces a keypair that signs and verifies', async () => {
+    const identity = await createDidKeyIdentity(crypto);
+    const message = new TextEncoder().encode('cryptographic sanity check');
+
+    const signature = await crypto.sign(message, identity.privateKey);
+    const valid = await crypto.verify(message, signature, identity.publicKey);
+
+    expect(valid).toBe(true);
+  });
+
+  it('createDidWebIdentity produces a keypair that signs and verifies', async () => {
+    const identity = await createDidWebIdentity(crypto, {
+      domain: 'example.com',
+      path: ['users', 'alice'],
+    });
+    const message = new TextEncoder().encode('cryptographic sanity check');
+
+    const signature = await crypto.sign(message, identity.privateKey);
+    const valid = await crypto.verify(message, signature, identity.publicKey);
+
+    expect(valid).toBe(true);
+  });
+
+  it('signatures do not verify against a different identity', async () => {
+    const a = await createDidKeyIdentity(crypto);
+    const b = await createDidKeyIdentity(crypto);
+    const message = new TextEncoder().encode('cross-identity isolation');
+
+    const signedByA = await crypto.sign(message, a.privateKey);
+    const verifiesAgainstB = await crypto.verify(message, signedByA, b.publicKey);
+
+    expect(verifiesAgainstB).toBe(false);
+  });
+});
+
+describe('metadata isolation', () => {
+  /**
+   * One test per helper, each asserting the strong property: the
+   * produced `metadata` is a deep clone — distinct reference at the top
+   * level AND at every nested level — so subsequent caller mutations
+   * cannot leak in. A shallow clone would pass top-level reference
+   * inequality but fail the nested mutation assertion.
+   */
+
+  it('createDidKeyIdentity deep-clones metadata (top-level + nested)', async () => {
+    const nested = { ttlSeconds: 60 };
+    const metadata: Record<string, unknown> = { policy: nested };
+
+    const identity = await createDidKeyIdentity(crypto, { metadata });
+
+    expect(identity.metadata).not.toBe(metadata);
+    expect(identity.metadata?.['policy']).not.toBe(nested);
+
+    nested.ttlSeconds = 999;
+    expect(
+      (identity.metadata?.['policy'] as { ttlSeconds: number }).ttlSeconds
+    ).toBe(60);
+  });
+
+  it('createDidWebIdentity deep-clones metadata (top-level + nested)', async () => {
+    const nested = { ttlSeconds: 60 };
+    const metadata: Record<string, unknown> = { policy: nested };
+
+    const identity = await createDidWebIdentity(
+      crypto,
+      { domain: 'example.com' },
+      { metadata }
+    );
+
+    expect(identity.metadata).not.toBe(metadata);
+    expect(identity.metadata?.['policy']).not.toBe(nested);
+
+    nested.ttlSeconds = 999;
+    expect(
+      (identity.metadata?.['policy'] as { ttlSeconds: number }).ttlSeconds
+    ).toBe(60);
+  });
+});
+
+describe('CryptoProvider error propagation', () => {
+  class FailingCryptoProvider extends CryptoProvider {
+    async sign(): Promise<Uint8Array> {
+      throw new Error('unused in this test');
+    }
+    async verify(): Promise<boolean> {
+      throw new Error('unused in this test');
+    }
+    async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> {
+      throw new Error('crypto subsystem unavailable');
+    }
+    async hash(): Promise<string> {
+      throw new Error('unused in this test');
+    }
+    async randomBytes(): Promise<Uint8Array> {
+      throw new Error('unused in this test');
+    }
+  }
+
+  it('createDidKeyIdentity rejects when the provider fails to generate a key pair', async () => {
+    await expect(createDidKeyIdentity(new FailingCryptoProvider())).rejects.toThrow(
+      /crypto subsystem unavailable/
+    );
+  });
+
+  it('createDidWebIdentity rejects when the provider fails to generate a key pair', async () => {
+    await expect(
+      createDidWebIdentity(new FailingCryptoProvider(), { domain: 'example.com' })
+    ).rejects.toThrow(/crypto subsystem unavailable/);
+  });
+
+  it('createDidWebIdentity surfaces validation errors before invoking the provider', async () => {
+    // Argument validation runs synchronously inside the async function,
+    // so a CryptoProvider that throws on every call should not be
+    // reached when the inputs are themselves invalid.
+    const provider = new FailingCryptoProvider();
+
+    await expect(
+      createDidWebIdentity(provider, { domain: 'https://example.com' })
+    ).rejects.toThrow(/must not include a scheme prefix/);
+  });
+});
+
+describe('type contract', () => {
+  it('Identity is NOT assignable to ProvisionedIdentity (privateKey is narrowed to required)', () => {
+    // A base Identity without `privateKey` must fail to assign to
+    // ProvisionedIdentity. The `@ts-expect-error` directive flips the
+    // failure mode: if a future refactor weakens ProvisionedIdentity
+    // (e.g. removes the `& { privateKey: string }` narrowing), the
+    // directive becomes unused and the build fails.
+    //
+    // The reverse direction — `ProvisionedIdentity` → `Identity` — is
+    // tautological for intersection types (always satisfied by
+    // construction), so it would not catch a regression of this kind.
+    const identityOnly: Identity = {
+      did: 'did:key:z6Mk',
+      kid: 'did:key:z6Mk#z6Mk',
+      publicKey: 'pk',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    // @ts-expect-error — Identity has optional privateKey;
+    // ProvisionedIdentity requires it.
+    const _narrowed: ProvisionedIdentity = identityOnly;
+
+    expect(_narrowed.did).toBe('did:key:z6Mk');
+  });
+
+  it('a fully-formed ProvisionedIdentity satisfies its declared shape', () => {
+    // Sanity-check that the runtime shape carrying every documented
+    // field still type-checks. This is intentionally a tautology — its
+    // job is to fail compilation if any field is renamed or removed
+    // from the public type.
+    const provisioned: ProvisionedIdentity = {
+      did: 'did:key:z6Mk',
+      kid: 'did:key:z6Mk#z6Mk',
+      publicKey: 'pk',
+      privateKey: 'sk',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    expect(provisioned.privateKey).toBe('sk');
+  });
+});
+
+describe('did:web resolver round-trip', () => {
+  /**
+   * The produced DID must survive a parse-rebuild via the existing
+   * `parseDidWeb` and `didWebToUrl` helpers. This catches encoding
+   * mistakes that `buildDidWebDocument` (a different consumer) would
+   * not surface — e.g. a `kid` whose fragment slips a `/` into the
+   * resolution URL.
+   */
+
+  it('produces a DID that round-trips through parseDidWeb and didWebToUrl', async () => {
+    const identity = await createDidWebIdentity(crypto, {
+      domain: 'example.com%3A8080',
+      path: ['users', 'alice'],
+    });
+
+    const parsed = parseDidWeb(identity.did);
+    expect(parsed?.domain).toBe('example.com:8080');
+    expect(parsed?.path).toEqual(['users', 'alice']);
+
+    const url = didWebToUrl(identity.did);
+    expect(url).toBe('https://example.com:8080/users/alice/did.json');
+  });
+
+  it('kidFragment with a "/" character does not corrupt the resolution URL', async () => {
+    // RFC 3986 allows "/" in fragment grammar; verify the slash stays
+    // in the fragment (after "#") and never bleeds into the path-side
+    // of the DID where it would change `didWebToUrl` output.
+    const identity = await createDidWebIdentity(
+      crypto,
+      { domain: 'example.com', path: ['users', 'alice'] },
+      { kidFragment: 'keys/main' }
+    );
+
+    expect(identity.did).toBe('did:web:example.com:users:alice');
+    expect(identity.kid).toBe('did:web:example.com:users:alice#keys/main');
+    expect(didWebToUrl(identity.did)).toBe(
+      'https://example.com/users/alice/did.json'
+    );
+  });
+});
+
+describe('input-shape defensive checks', () => {
+  it('throws a helper-prefixed error when args.path is not an array', async () => {
+    // Plain-JS callers can pass non-array values that TypeScript's
+    // `readonly string[]` signature would otherwise reject. Surface a
+    // construction-throws message rather than a cryptic platform
+    // `TypeError` from `.map`.
+    await expect(
+      createDidWebIdentity(crypto, {
+        domain: 'example.com',
+        path: 'users' as unknown as readonly string[],
+      })
+    ).rejects.toThrow(/args\.path must be an array of strings/);
+  });
+
+  it('wraps structuredClone failures with a helper-prefixed message', async () => {
+    // Functions and other host-bound values cannot be structurally
+    // cloned. The platform raises a `DataCloneError`/`DOMException`;
+    // the helper wraps that in a consistent construction-throws Error
+    // so callers see the same message shape as the validators.
+    const metadata = { policy: () => 'not-cloneable' };
+
+    await expect(
+      createDidKeyIdentity(crypto, { metadata })
+    ).rejects.toThrow(
+      /metadata contains values that cannot be structurally cloned/
+    );
+
+    await expect(
+      createDidWebIdentity(crypto, { domain: 'example.com' }, { metadata })
+    ).rejects.toThrow(
+      /metadata contains values that cannot be structurally cloned/
+    );
+  });
+});
+
+describe('providers barrel re-exports', () => {
+  it('exposes the factory through @kya-os/mcp/providers', async () => {
+    const barrel = await import('../../providers/index.js');
+
+    expect(barrel.createDidKeyIdentity).toBe(createDidKeyIdentity);
+    expect(barrel.createDidWebIdentity).toBe(createDidWebIdentity);
+    expect(barrel.createIdentity).toBe(createIdentity);
+  });
+});
+
+/* ============================================================
+ * createIdentity dispatching surface
+ * ============================================================
+ *
+ * The dispatcher exists so future DID methods (did:jwk, did:peer,
+ * did:ion) can be added by extending the discriminated union rather
+ * than by adding new top-level exports. These tests pin three
+ * properties: (1) each branch produces the same output as the
+ * method-specific helper, (2) options propagate per method, (3) the
+ * discriminated-union argument shape catches caller mistakes at
+ * compile time.
+ */
+
+describe('createIdentity dispatcher', () => {
+  it('did:key branch produces the same Identity shape as createDidKeyIdentity', async () => {
+    const fixedMs = Date.UTC(2026, 0, 1);
+    const a = await createIdentity(crypto, {
+      method: 'did:key',
+      clock: new FixedClock(fixedMs),
+      metadata: { source: 'dispatcher' },
+    });
+    const b = await createDidKeyIdentity(crypto, {
+      clock: new FixedClock(fixedMs),
+      metadata: { source: 'helper' },
+    });
+
+    // Shape parity (modulo the key material, which is freshly minted
+    // on each call).
+    expect(a.did).toMatch(/^did:key:z6Mk/);
+    expect(b.did).toMatch(/^did:key:z6Mk/);
+    expect(a.kid.startsWith(`${a.did}#`)).toBe(true);
+    expect(a.createdAt).toBe(b.createdAt);
+    expect(a.metadata).toEqual({ source: 'dispatcher' });
+  });
+
+  it('did:web branch produces the same Identity shape as createDidWebIdentity', async () => {
+    const fixedMs = Date.UTC(2026, 0, 1);
+    const a = await createIdentity(crypto, {
+      method: 'did:web',
+      domain: 'example.com',
+      path: ['users', 'alice'],
+      clock: new FixedClock(fixedMs),
+      kidFragment: 'keys-1',
+    });
+    const b = await createDidWebIdentity(
+      crypto,
+      { domain: 'example.com', path: ['users', 'alice'] },
+      { clock: new FixedClock(fixedMs), kidFragment: 'keys-1' }
+    );
+
+    expect(a.did).toBe('did:web:example.com:users:alice');
+    expect(a.did).toBe(b.did);
+    expect(a.kid).toBe(b.kid);
+    expect(a.createdAt).toBe(b.createdAt);
+  });
+
+  it('did:key branch rejects kidFragment at compile time (W3C did:key §3 fixes the fragment)', () => {
+    // The W3C CCG did:key specification fixes the fragment to the
+    // multibase public-key id; allowing an override would violate
+    // that contract. The discriminated request type makes the
+    // misuse a compile error — replacing the prior runtime "silent
+    // ignore" behaviour with build-time rejection.
+    //
+    // The `@ts-expect-error` directive flips the failure mode: if a
+    // future refactor weakens the union (e.g. flattens kidFragment
+    // onto the shared options), the directive becomes unused and
+    // the build fails.
+
+    // @ts-expect-error — `kidFragment` does not exist on the did:key branch.
+    void { method: 'did:key', kidFragment: 'overridden' } satisfies CreateIdentityRequest;
+
+    expect(true).toBe(true);
+  });
+
+  it('rejects did:web through the dispatcher with the same error as the direct helper', async () => {
+    await expect(
+      createIdentity(crypto, {
+        method: 'did:web',
+        domain: 'https://example.com',
+      })
+    ).rejects.toThrow(/must not include a scheme/);
+  });
+
+  it('request shape enforces method-specific required fields at compile time', () => {
+    // @ts-expect-error — did:web requires `domain`; this object is missing it.
+    const _bad: CreateIdentityRequest = { method: 'did:web' };
+    expect(_bad.method).toBe('did:web');
+
+    // did:key with no extra fields type-checks as a minimal request.
+    const ok: CreateIdentityRequest = { method: 'did:key' };
+    expect(ok.method).toBe('did:key');
+  });
+});
+
+/* ============================================================
+ * Error-message sanitisation
+ * ============================================================
+ *
+ * Identity-protocol error pipelines flow into logs that downstream
+ * operators read. Caller-controlled input that contains control
+ * characters, NULs, or ANSI escapes could spoof log entries or break
+ * structured-log parsers. The helper sanitises every echoed input.
+ */
+
+describe('error-message sanitisation', () => {
+  it('truncates over-long input to ~60 chars with an ellipsis', async () => {
+    const longDomain = 'a'.repeat(200);
+    try {
+      await createDidWebIdentity(crypto, { domain: longDomain });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      // The echoed portion must not exceed the truncation cap.
+      const echo = msg.match(/"([^"]*)"/);
+      expect(echo).not.toBeNull();
+      expect(echo![1]!.length).toBeLessThanOrEqual(60);
+      expect(echo![1]!.endsWith('...')).toBe(true);
+    }
+  });
+
+  it('hex-encodes C0 control characters in the echoed input', async () => {
+    // Embedded NUL is the canonical log-injection vector. The
+    // sanitiser must replace it with `\x00` so a downstream log
+    // parser sees the literal bytes "\x00", not an embedded NUL.
+    const domainWithNul = `evil${String.fromCharCode(0)}example.com`;
+    try {
+      await createDidWebIdentity(crypto, { domain: domainWithNul });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('\\x00');
+      expect(msg.includes(String.fromCharCode(0))).toBe(false);
+    }
+  });
+
+  it('hex-encodes C1 control characters (e.g. CSI 0x9B)', async () => {
+    // A C1 control byte like 0x9B (Control Sequence Introducer) is
+    // not a printable character and can drive an ANSI-capable
+    // terminal into an unsafe state if logged unfiltered.
+    const domainWithCsi = `evil${String.fromCharCode(0x9b)}example.com`;
+    try {
+      await createDidWebIdentity(crypto, { domain: domainWithCsi });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('\\x9B');
+      expect(msg.includes(String.fromCharCode(0x9b))).toBe(false);
+    }
+  });
+
+  it('passes through printable ASCII unchanged', async () => {
+    // Regression guard: the sanitiser must not over-strict by
+    // mangling normal printable characters. Use an invalid
+    // percent-encoding (`%XX` — `XX` is not hex) so the validator
+    // reaches the echoing throw site at `validateDidWebDomain`
+    // step 2 (`decodeURIComponent` failure), past the surface checks
+    // that would short-circuit on raw `/` or `:`.
+    const printableDomain = 'EXAMPLE.com%XX';
+    try {
+      await createDidWebIdentity(crypto, { domain: printableDomain });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('EXAMPLE.com%XX');
+    }
+  });
+
+  it('hex-escapes bidi-override characters (Trojan-Source class)', async () => {
+    // The Trojan-Source family of attacks (CVE-2021-42574) splices
+    // bidi-override characters into source / log streams to reverse
+    // the rendered display. The sanitiser must hex-escape these
+    // bytes alongside C0/C1 controls — otherwise the docstring's
+    // log-spoofing defence claim is false.
+    //
+    // We use a domain failing percent-decoding (`%XX`) so the
+    // validator reaches the echoing throw site and exercises the
+    // sanitiser on caller-controlled bytes that contain a bidi
+    // override (U+202E, RIGHT-TO-LEFT OVERRIDE).
+    const domainWithBidiOverride = `evil‮txt%XX`;
+    try {
+      await createDidWebIdentity(crypto, { domain: domainWithBidiOverride });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('\\u202E');
+      expect(msg.includes('‮')).toBe(false);
+    }
+  });
+
+  it.each([
+    ['​', 'U+200B'], // ZWSP (zero-width space)
+    ['‎', 'U+200E'], // LRM (left-to-right mark)
+    ['‪', 'U+202A'], // LRE (left-to-right embedding)
+    ['‭', 'U+202D'], // LRO (left-to-right override)
+    ['⁦', 'U+2066'], // LRI (left-to-right isolate)
+    ['⁩', 'U+2069'], // PDI (pop directional isolate)
+  ])(
+    'hex-escapes zero-width / direction-mark / isolate %s (%s)',
+    async (rawChar, codePointLabel) => {
+      void codePointLabel;
+      const expectedEscape = `\\u${rawChar
+        .charCodeAt(0)
+        .toString(16)
+        .padStart(4, '0')
+        .toUpperCase()}`;
+
+      try {
+        await createDidWebIdentity(crypto, { domain: `evil${rawChar}txt%XX` });
+        expect.fail('should have rejected');
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).toContain(expectedEscape);
+        expect(msg.includes(rawChar)).toBe(false);
+      }
+    }
+  );
+
+  it('truncates by code points, not UTF-16 code units (no surrogate-pair split)', async () => {
+    // String.prototype.slice cuts in the middle of surrogate pairs;
+    // a sanitiser that uses it can emit lone high surrogates —
+    // invalid UTF-16 that downstream JSON loggers may double-encode
+    // or corrupt. Build an input whose 57th UTF-16 code unit is the
+    // high surrogate of a 4-byte (astral) character; the truncator
+    // must NOT slice between the high and low surrogates.
+    //
+    // 56 ASCII chars + astral emoji (U+1F600, 2 code units) + `%XX`
+    // (forces validator rejection) = 61 code units, with the emoji
+    // straddling the 57th code unit boundary.
+    const astral = '\u{1F600}'; // GRINNING FACE
+    const domain = `${'a'.repeat(56)}${astral}%XX`;
+
+    try {
+      await createDidWebIdentity(crypto, { domain });
+      expect.fail('should have rejected');
+    } catch (err) {
+      const msg = (err as Error).message;
+      const echo = msg.match(/"([^"]*)"/)?.[1] ?? '';
+      // Either the astral character is present in full, or it is
+      // entirely absent — never a lone surrogate. We assert the
+      // string is well-formed UTF-16 by re-encoding it through
+      // TextEncoder; a lone surrogate triggers a replacement char.
+      const reencoded = new TextDecoder('utf-8', { fatal: false }).decode(
+        new TextEncoder().encode(echo)
+      );
+      expect(reencoded).toBe(echo);
+    }
+  });
+});
+
+/* ============================================================
+ * Spec-anchored fixture vector
+ * ============================================================
+ *
+ * A frozen (publicKey, privateKey) → did:key triple. If this test
+ * ever fails, the encoding pipeline has drifted (base64 vs base64url,
+ * multibase prefix, multicodec varint, etc.) and downstream
+ * implementations that mirror this reference impl will interoperate
+ * incorrectly. Generated once with NodeCryptoProvider on a Node 22
+ * runtime; the value is the contract.
+ */
+
+describe('spec-anchored fixture vector (did:key)', () => {
+  /**
+   * A deterministic CryptoProvider that returns a known Ed25519
+   * keypair. Used to anchor the encoding pipeline against drift.
+   */
+  class DeterministicCryptoProvider extends CryptoProvider {
+    constructor(
+      private readonly fixedPublicKey: string,
+      private readonly fixedPrivateKey: string
+    ) {
+      super();
+    }
+    async sign(): Promise<Uint8Array> {
+      throw new Error('unused in this test');
+    }
+    async verify(): Promise<boolean> {
+      throw new Error('unused in this test');
+    }
+    async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> {
+      return { publicKey: this.fixedPublicKey, privateKey: this.fixedPrivateKey };
+    }
+    async hash(): Promise<string> {
+      throw new Error('unused in this test');
+    }
+    async randomBytes(): Promise<Uint8Array> {
+      throw new Error('unused in this test');
+    }
+  }
+
+  // Frozen test vector. Update only when the protocol's encoding
+  // changes intentionally — never as a side-effect of refactoring.
+  const FIXTURE_PUBLIC_KEY = 'ckFn+mgrgQA4IP49QprCHXx9gjpWs5H0O2N8vOrD/Sw=';
+  const FIXTURE_PRIVATE_KEY = 'vRzbvcUsJyIO8zz49pkwI3iwQVip1dssHLVuepE1w5s=';
+  const FIXTURE_EXPECTED_DID =
+    'did:key:z6Mkn9GNL7fid2os9RRZje6rGTqhuNb1gfsv3GzZbqYdwwaB';
+
+  it('createDidKeyIdentity produces the byte-frozen DID for the fixture keypair', async () => {
+    const deterministic = new DeterministicCryptoProvider(
+      FIXTURE_PUBLIC_KEY,
+      FIXTURE_PRIVATE_KEY
+    );
+
+    const identity = await createDidKeyIdentity(deterministic);
+
+    expect(identity.did).toBe(FIXTURE_EXPECTED_DID);
+    expect(identity.kid).toBe(
+      `${FIXTURE_EXPECTED_DID}#${FIXTURE_EXPECTED_DID.slice('did:key:'.length)}`
+    );
+    expect(identity.publicKey).toBe(FIXTURE_PUBLIC_KEY);
+    expect(identity.privateKey).toBe(FIXTURE_PRIVATE_KEY);
+  });
+
+  it('the fixture DID survives byte-for-byte through the createIdentity dispatcher', async () => {
+    const deterministic = new DeterministicCryptoProvider(
+      FIXTURE_PUBLIC_KEY,
+      FIXTURE_PRIVATE_KEY
+    );
+
+    const identity = await createIdentity(deterministic, { method: 'did:key' });
+
+    expect(identity.did).toBe(FIXTURE_EXPECTED_DID);
+  });
+});
+
+/* ============================================================
+ * Property tests (fast-check)
+ * ============================================================
+ *
+ * Table-driven cases catch regressions on inputs the author already
+ * thought about. Property tests catch regressions on inputs the
+ * author did not. Each property below asserts an invariant the
+ * validator contract guarantees over an entire input class.
+ */
+
+describe('property tests', () => {
+  it('createDidKeyIdentity always produces a valid Ed25519 did:key', async () => {
+    // No input parameter — the property is over the implicit random
+    // seed of `crypto.generateKeyPair()`. Run a small number of
+    // iterations to keep the suite fast.
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 0, max: 1000 }), async () => {
+        const identity = await createDidKeyIdentity(crypto);
+        return (
+          identity.did.startsWith('did:key:z6Mk') &&
+          identity.kid.startsWith(`${identity.did}#`)
+        );
+      }),
+      { numRuns: 20 }
+    );
+  });
+
+  it('createDidWebIdentity rejects any domain containing raw ":" or "/"', async () => {
+    // Construction-throws contract: literal delimiters in the
+    // authority MUST be rejected at call time, no matter what surrounds
+    // them. The property generates arbitrary strings containing at
+    // least one such delimiter and asserts rejection.
+    await fc.assert(
+      fc.asyncProperty(
+        fc.tuple(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.constantFrom(':', '/'),
+          fc.string({ minLength: 0, maxLength: 20 })
+        ),
+        async ([prefix, delim, suffix]) => {
+          const domain = `${prefix}${delim}${suffix}`;
+          try {
+            await createDidWebIdentity(crypto, { domain });
+            return false;
+          } catch {
+            return true;
+          }
+        }
+      ),
+      { numRuns: 30 }
+    );
+  });
+
+  it('any accepted path segment appears verbatim in the produced DID', async () => {
+    // Round-trip invariant: if the validator accepts a segment, the
+    // produced DID must contain that segment unchanged (no silent
+    // re-encoding). This is the property that guarantees the
+    // construction-throws contract is honest about its outputs.
+    //
+    // Generator filters out segments that the validator legitimately
+    // rejects (`.`, `..`) — those are tested as negative cases
+    // elsewhere; here we only assert the round-trip on accepted
+    // inputs.
+    const pcharChar = fc.constantFrom(
+      'a', 'B', '1', '-', '.', '_', '~',
+      '!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=', '@'
+    );
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .array(pcharChar, { minLength: 1, maxLength: 20 })
+          .filter((chars) => {
+            const s = chars.join('');
+            return s !== '.' && s !== '..';
+          }),
+        async (chars) => {
+          const segment = chars.join('');
+          const identity = await createDidWebIdentity(crypto, {
+            domain: 'example.com',
+            path: [segment],
+          });
+          return identity.did === `did:web:example.com:${segment}`;
+        }
+      ),
+      { numRuns: 30 }
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,18 @@ export {
 
 export { NodeCryptoProvider } from './providers/node-crypto.js';
 
+export {
+  createDidKeyIdentity,
+  createDidWebIdentity,
+  createIdentity,
+  type ProvisionedIdentity,
+  type CreateIdentityOptions,
+  type CreateIdentityMethod,
+  type CreateIdentityRequest,
+  type CreateDidWebIdentityArgs,
+  type CreateDidWebIdentityOptions,
+} from './providers/identity-factory.js';
+
 // Middleware
 export {
   createMCPIMiddleware,

--- a/src/providers/identity-factory.ts
+++ b/src/providers/identity-factory.ts
@@ -1,0 +1,748 @@
+/**
+ * Identity provisioning helpers
+ *
+ * Compose a {@link CryptoProvider} with the appropriate DID method to
+ * mint a fresh {@link Identity} in a single call. The package
+ * previously exposed the lower-level primitives
+ * (`CryptoProvider.generateKeyPair`, `generateDidKeyFromBase64`) but
+ * no high-level "issue an identity" shortcut — every consumer ended
+ * up writing roughly the same wrapper.
+ *
+ * Both helpers return a {@link ProvisionedIdentity}: an `Identity` with
+ * `privateKey` narrowed to required, since the helper itself produced
+ * the key material and the contract guarantees it is present.
+ *
+ * ## Public surfaces
+ *
+ *   - {@link createDidKeyIdentity} — method-specific shortcut for did:key
+ *   - {@link createDidWebIdentity} — method-specific shortcut for did:web
+ *   - {@link createIdentity}       — dispatching surface (discriminated
+ *     union over `method`) for callers that want to parameterise the
+ *     DID method or for forward-compatibility with did:jwk / did:peer /
+ *     did:ion as those land. New methods extend this dispatcher
+ *     without growing the top-level export surface.
+ *
+ * Related Spec: MCP-I §3 (Protocol Overview), §4 (Agent Identity),
+ * §4.3 (did:key Derivation — the normative `<did>#keys-1`
+ * verification-method-id statement lives here), §4.4 (did:web
+ * Resolution); CONFORMANCE.md §3 (Key ID format). See
+ * `delegation/did-web-resolver.ts#buildDidWebDocument` for the
+ * companion that publishes the resulting did:web DID Document.
+ *
+ * ## Design notes for downstream ports (Rust / Go / Python / …)
+ *
+ * The implementation makes four protocol-level choices the spec
+ * either leaves open or is internally inconsistent about. Each is
+ * called out here so a competing implementation can mirror them
+ * faithfully — or argue against them at TAAWG — without re-deriving
+ * the reasoning from source.
+ *
+ * 1. **did:web verification-method-id default = `<did>#keys-1`.**
+ *    SPEC.md is internally inconsistent: line 177 normatively states
+ *    `<did>#keys-1` (matched by CONFORMANCE.md:43 and the did:key
+ *    examples at lines 344, 885, 896), but the did:web examples at
+ *    lines 125, 194, 203, 204, 498, 528 use `<did>#key-1` (singular).
+ *    This helper picks `keys-1` because (a) it matches the normative
+ *    line-177 statement, (b) it matches CONFORMANCE.md, and (c) it
+ *    keeps did:key and did:web symmetric. A working-group decision
+ *    is required before 1.0 to resolve the inconsistency — once
+ *    resolved, flip {@link DEFAULT_DID_WEB_KID_FRAGMENT} and update
+ *    CONFORMANCE.md / SPEC.md to match.
+ *
+ * 2. **Path segments are NOT auto-percent-encoded.** The helper
+ *    rejects raw `/` and `:` rather than escaping them silently.
+ *    Rationale: silent escaping changes the DID the caller intended,
+ *    which is harmful in identity-protocol semantics where the DID
+ *    is the identifier. Callers who want to include reserved bytes
+ *    must pass them already-encoded. This trades convenience for
+ *    determinism and matches the existing behaviour of
+ *    `parseDidWeb` / `didWebToUrl` in this repo.
+ *
+ * 3. **`metadata` is deep-cloned via `structuredClone`.** Threat
+ *    model: a caller passes a metadata object, retains a reference,
+ *    later mutates a nested value (e.g. a policy bag or a counter),
+ *    and the produced Identity silently shifts under their feet —
+ *    or worse, two long-lived Identities share aliased state. Deep
+ *    cloning eliminates the aliasing. Cost is one O(n) traversal at
+ *    creation; n is small in practice.
+ *
+ * 4. **`kidFragment` is configurable on did:web but not did:key.**
+ *    Per W3C CCG did:key §3 (Document Creation Algorithm) the
+ *    fragment is fixed to the multibase id of the public key — so
+ *    there is no configurable choice for did:key. did:web makes no
+ *    such determination; the fragment is whatever the DID Document
+ *    declares, so the helper exposes a single configurable knob.
+ *    The asymmetry is required by the specs, not a stylistic one.
+ */
+
+import type { ClockProvider, CryptoProvider, Identity } from './base.js';
+import {
+  didKeyFragment,
+  generateDidKeyFromBase64,
+} from '../utils/did-helpers.js';
+
+/**
+ * Default verification-method fragment for fresh did:web identities.
+ *
+ * See "Design notes" §1 in the file header for the rationale on
+ * `keys-1` vs `key-1`. The spec is internally inconsistent and a
+ * TAAWG decision is pending; this default flips trivially once that
+ * decision lands.
+ */
+const DEFAULT_DID_WEB_KID_FRAGMENT = 'keys-1';
+
+/**
+ * Maximum length of caller-supplied input echoed back in a thrown
+ * error message before truncation. Keeps log output bounded and
+ * limits the bytes an attacker can spray through error pipelines.
+ */
+const ERROR_ECHO_MAX_LENGTH = 60;
+
+/**
+ * RFC 3986 `fragment` grammar — `*( pchar / "/" / "?" )` where
+ * `pchar = unreserved / pct-encoded / sub-delims / ":" / "@"`.
+ *
+ * Excludes `"#"` (one fragment delimiter per URI), whitespace, and
+ * control characters. Used to validate caller-supplied `kidFragment`
+ * values so the produced verification-method id is well-formed.
+ *
+ * @see RFC 3986 §3.5
+ */
+const RFC3986_FRAGMENT_PATTERN =
+  /^(?:[A-Za-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})+$/;
+
+/**
+ * An {@link Identity} that carries its private-key material.
+ *
+ * Returned by the provisioning helpers: they mint the key, so the
+ * field is always present and callers do not need to narrow before
+ * signing.
+ */
+export type ProvisionedIdentity = Identity & { privateKey: string };
+
+/**
+ * Options shared by both provisioning helpers.
+ */
+export interface CreateIdentityOptions {
+  /**
+   * Clock used to stamp `createdAt`. Defaults to the host wall clock.
+   * Inject in tests for deterministic timestamps.
+   */
+  clock?: ClockProvider;
+  /** Free-form metadata to attach to the produced Identity. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for {@link createDidWebIdentity}.
+ */
+export interface CreateDidWebIdentityOptions extends CreateIdentityOptions {
+  /**
+   * Verification-method fragment used to build the produced Identity's
+   * `kid` (`<did>#<fragment>`). Defaults to `keys-1`.
+   *
+   * Set this when the DID Document published at the resolution URL
+   * declares a non-default fragment, so the produced Identity's `kid`
+   * round-trips through the resolver cleanly.
+   */
+  kidFragment?: string;
+}
+
+/**
+ * Arguments for {@link createDidWebIdentity}.
+ */
+export interface CreateDidWebIdentityArgs {
+  /**
+   * did:web authority component (host or host:port). The port, when
+   * present, must be percent-encoded as `%3A` per did:web encoding
+   * rules (e.g. `example.com%3A8080`).
+   *
+   * Must not include a scheme prefix or any `/` — pass path segments
+   * via {@link CreateDidWebIdentityArgs.path}.
+   */
+  domain: string;
+
+  /**
+   * Optional path segments appended after the authority. The produced
+   * DID resolves to `https://<domain>/<segment>/.../did.json` (see
+   * `didWebToUrl`).
+   *
+   * @example
+   * `{ domain: 'example.com', path: ['users', 'alice'] }`
+   * → `did:web:example.com:users:alice`
+   * → `https://example.com/users/alice/did.json`
+   */
+  path?: readonly string[];
+}
+
+/**
+ * Mint a fresh `did:key` Identity using the supplied
+ * {@link CryptoProvider}.
+ *
+ * Generates an Ed25519 key pair, derives the did:key encoding, and
+ * bundles the pieces into an Identity. The returned object carries
+ * the private key in plain memory; the **caller is responsible for
+ * routing it to a wallet / HSM / KMS and wiping the in-memory copy**
+ * once it has been persisted. The helper itself performs no key
+ * zeroisation — string immutability prevents reliable wiping in
+ * JavaScript.
+ *
+ * @throws Error if the supplied {@link CryptoProvider} fails to
+ *   produce a key pair, or if {@link CreateIdentityOptions.metadata}
+ *   contains values that cannot be structurally cloned (functions,
+ *   DOM nodes, host-bound objects).
+ *
+ * @example
+ * ```typescript
+ * const identity = await createDidKeyIdentity(new NodeCryptoProvider());
+ * // identity.did === 'did:key:z6Mk...'
+ * // identity.kid === `${identity.did}#${didKeyFragment(identity.did)}`
+ * ```
+ */
+export async function createDidKeyIdentity(
+  crypto: CryptoProvider,
+  options?: CreateIdentityOptions
+): Promise<ProvisionedIdentity> {
+  const metadata = cloneMetadata(options?.metadata);
+  const { publicKey, privateKey } = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(publicKey);
+  const kid = `${did}#${didKeyFragment(did)}`;
+  return {
+    did,
+    kid,
+    publicKey,
+    privateKey,
+    createdAt: nowIso(options?.clock),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+/**
+ * Mint a fresh `did:web` Identity for a subject hosted under a domain.
+ *
+ * Produces `did:web:<domain>[:<path1>[:<path2>...]]` bound to a
+ * freshly generated Ed25519 key. The caller is responsible for
+ * publishing the resulting DID Document at the resolution URL — pair
+ * with `buildDidWebDocument` and `didWebToUrl`.
+ *
+ * Same private-key responsibility as {@link createDidKeyIdentity}:
+ * the returned object carries the private key in plain memory and
+ * the caller must route it onward.
+ *
+ * Validates `domain`, `path` segments, and `kidFragment` at call time
+ * per the repository's construction-throws contract: invalid input
+ * fails before any key material is generated.
+ *
+ * @throws Error if `args.path` is supplied but is not an array.
+ * @throws Error if `args.domain` is empty, includes a scheme prefix,
+ *   contains a literal `/` or `:`, contains invalid or incomplete
+ *   percent-encoding, decodes to a value containing `/`, `\`, or NUL,
+ *   decodes to a malformed hostname (per RFC 952 / RFC 1123 — empty
+ *   labels, leading/trailing hyphens, oversize labels or total
+ *   length), or decodes to an invalid port (per RFC 3986 §3.2.3).
+ * @throws Error if any `args.path` segment is empty, contains a
+ *   literal `:` or `/`, contains invalid percent-encoding, or
+ *   decodes to a relative path component (`.` / `..`), `/`, `\`, or
+ *   NUL.
+ * @throws Error if `options.kidFragment` is empty or contains
+ *   characters outside the RFC 3986 fragment grammar.
+ * @throws Error if {@link CreateIdentityOptions.metadata} contains
+ *   values that cannot be structurally cloned (functions, DOM nodes,
+ *   host-bound objects).
+ * @throws Error if the supplied {@link CryptoProvider} fails to
+ *   produce a key pair.
+ *
+ * @example
+ * ```typescript
+ * const identity = await createDidWebIdentity(crypto, {
+ *   domain: 'example.com',
+ *   path: ['users', 'alice'],
+ * });
+ * // identity.did === 'did:web:example.com:users:alice'
+ * // identity.kid === 'did:web:example.com:users:alice#keys-1'
+ * ```
+ */
+export async function createDidWebIdentity(
+  crypto: CryptoProvider,
+  args: CreateDidWebIdentityArgs,
+  options?: CreateDidWebIdentityOptions
+): Promise<ProvisionedIdentity> {
+  const domain = validateDidWebDomain(args.domain);
+  const segments = validatePath(args.path);
+  const did =
+    segments.length === 0
+      ? `did:web:${domain}`
+      : `did:web:${domain}:${segments.join(':')}`;
+  const fragment =
+    options?.kidFragment !== undefined
+      ? validateDidWebKidFragment(options.kidFragment)
+      : DEFAULT_DID_WEB_KID_FRAGMENT;
+  const kid = `${did}#${fragment}`;
+
+  const metadata = cloneMetadata(options?.metadata);
+  const { publicKey, privateKey } = await crypto.generateKeyPair();
+
+  return {
+    did,
+    kid,
+    publicKey,
+    privateKey,
+    createdAt: nowIso(options?.clock),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+/**
+ * Supported DID methods. Extend this union (and the corresponding
+ * branch in {@link createIdentity}) when adding a new method-specific
+ * helper.
+ */
+export type CreateIdentityMethod = 'did:key' | 'did:web';
+
+/**
+ * Discriminated-union request shape for {@link createIdentity}.
+ *
+ * The `method` field selects the per-method members — both the args
+ * (e.g. `domain` / `path` for did:web) and the options
+ * (`kidFragment` only on the did:web branch).
+ *
+ * The shape pulls options into the request itself rather than into a
+ * separate parameter. This is deliberate: it lets TypeScript reject
+ * did:key requests that try to pass a `kidFragment` at compile time
+ * (the field does not exist on the did:key branch), rather than the
+ * helper silently ignoring it at runtime. The W3C CCG did:key
+ * specification fixes the verification-method fragment to the
+ * multibase public-key id; allowing a caller to attempt an override
+ * would violate that contract — surfacing it as a type error keeps
+ * the public surface honest.
+ */
+export type CreateIdentityRequest =
+  | ({ method: 'did:key' } & CreateIdentityOptions)
+  | ({ method: 'did:web' } & CreateDidWebIdentityArgs &
+      CreateDidWebIdentityOptions);
+
+/**
+ * Mint a fresh Identity, choosing the DID method at call time rather
+ * than at import time.
+ *
+ * This is the forward-compatible surface: when did:jwk / did:peer /
+ * did:ion land, they extend the {@link CreateIdentityMethod} union and
+ * gain a branch on {@link CreateIdentityRequest} here, without growing
+ * the top-level export footprint. Method-specific shortcuts
+ * ({@link createDidKeyIdentity}, {@link createDidWebIdentity}) remain
+ * available for callers that prefer a fixed surface — both routes
+ * produce the same {@link ProvisionedIdentity}.
+ *
+ * The single-`request` argument shape (vs the more conventional
+ * `(args, options)` split) is intentional: bundling per-method
+ * options into the discriminated request lets the type system reject
+ * cross-method misuse at compile time. See the JSDoc on
+ * {@link CreateIdentityRequest} for the rationale.
+ *
+ * @throws Error — see {@link createDidKeyIdentity} and
+ *   {@link createDidWebIdentity} for the per-method rejection
+ *   contracts. All construction-throws semantics apply.
+ *
+ * @example
+ * ```typescript
+ * const a = await createIdentity(crypto, { method: 'did:key' });
+ * const b = await createIdentity(crypto, {
+ *   method: 'did:web',
+ *   domain: 'example.com',
+ *   path: ['users', 'alice'],
+ *   kidFragment: 'keys-1',
+ * });
+ * ```
+ */
+export async function createIdentity(
+  crypto: CryptoProvider,
+  request: CreateIdentityRequest
+): Promise<ProvisionedIdentity> {
+  switch (request.method) {
+    case 'did:key': {
+      // Strip the discriminator before forwarding to the per-method
+      // helper. The remaining fields satisfy CreateIdentityOptions
+      // by construction of the union branch.
+      const { clock, metadata } = request;
+      return createDidKeyIdentity(crypto, { clock, metadata });
+    }
+    case 'did:web': {
+      const { domain, path, clock, metadata, kidFragment } = request;
+      return createDidWebIdentity(
+        crypto,
+        { domain, path },
+        { clock, metadata, kidFragment }
+      );
+    }
+  }
+}
+
+/* ------------------------------ internals ------------------------------ */
+
+/**
+ * Validate a did:web authority component (`domain`).
+ *
+ * Defence-in-depth: a permissive character-class regex is not enough.
+ * `%2F` decodes to `/` (path traversal), `%00` to NUL (URL-parser
+ * confusion), `..` short-circuits hostname semantics, and bare `%`
+ * or incomplete escapes (`%G1`) are accepted by lax regexes but
+ * break resolvers downstream. We therefore:
+ *
+ *   1. Reject unencoded delimiters that resolvers depend on (`:`, `/`).
+ *   2. Percent-decode the input — catching invalid escapes here at
+ *      construction time rather than letting the resolver discover
+ *      the problem.
+ *   3. Reject decoded forms that would change path semantics (`/`,
+ *      `\`, NUL, leading/trailing `.`).
+ *   4. Re-validate the decoded authority against the RFC 3986
+ *      `reg-name [: port]` grammar (DNS-style hostname with optional
+ *      port; IPv4 falls out of the same grammar; IPv6 is not
+ *      currently supported in this helper).
+ *
+ * @see RFC 3986 §3.2.2 (host), RFC 952 / RFC 1123 (hostname labels)
+ */
+function validateDidWebDomain(input: string): string {
+  if (input.length === 0) {
+    throw new Error('createDidWebIdentity: domain must not be empty');
+  }
+  if (/^https?:\/\//i.test(input)) {
+    throw new Error(
+      'createDidWebIdentity: domain must not include a scheme prefix'
+    );
+  }
+  if (input.includes('/')) {
+    throw new Error(
+      'createDidWebIdentity: domain must not contain "/"; pass path segments via the "path" option'
+    );
+  }
+  if (input.includes(':')) {
+    throw new Error(
+      'createDidWebIdentity: domain must not contain ":"; percent-encode ports as "%3A"'
+    );
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(input);
+  } catch {
+    throw new Error(
+      `createDidWebIdentity: domain "${sanitizeForError(input)}" contains an invalid percent-encoded byte sequence`
+    );
+  }
+
+  if (
+    decoded.includes('/') ||
+    decoded.includes('\\') ||
+    decoded.includes('\0')
+  ) {
+    throw new Error(
+      `createDidWebIdentity: domain "${sanitizeForError(input)}" decodes to a value containing "/", "\\", or NUL`
+    );
+  }
+
+  const colonIdx = decoded.indexOf(':');
+  // Multi-colon must be checked before the port check; otherwise an
+  // input like `a%3Ab%3Ac` short-circuits on the port regex (digits
+  // only) and surfaces a less-specific "invalid port" error.
+  if (colonIdx !== -1 && decoded.indexOf(':', colonIdx + 1) !== -1) {
+    throw new Error(
+      `createDidWebIdentity: domain "${sanitizeForError(input)}" decodes to a value with multiple ":" delimiters`
+    );
+  }
+  const hostPart = colonIdx === -1 ? decoded : decoded.slice(0, colonIdx);
+  const portPart = colonIdx === -1 ? null : decoded.slice(colonIdx + 1);
+
+  if (!isValidRegName(hostPart)) {
+    throw new Error(
+      `createDidWebIdentity: domain "${sanitizeForError(input)}" decodes to an invalid hostname`
+    );
+  }
+  if (portPart !== null && !isValidPort(portPart)) {
+    throw new Error(
+      `createDidWebIdentity: domain "${sanitizeForError(input)}" decodes to an invalid port`
+    );
+  }
+
+  return input;
+}
+
+/**
+ * Validate a did:web path segment.
+ *
+ * Same defence-in-depth approach as {@link validateDidWebDomain}:
+ * reject unencoded `:` and `/`, decode and reject traversal byte
+ * sequences (`%2F`, `%00`, `..`), then enforce a structural character
+ * class that matches the RFC 3986 `segment` grammar (the subset
+ * actually used by DID method paths).
+ */
+function validateDidWebSegment(segment: string): string {
+  if (segment.length === 0) {
+    throw new Error(
+      'createDidWebIdentity: path segments must be non-empty strings'
+    );
+  }
+  if (segment.includes(':')) {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" must not contain ":"; percent-encode if intentional`
+    );
+  }
+  if (segment.includes('/')) {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" must not contain "/"`
+    );
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" contains an invalid percent-encoded byte sequence`
+    );
+  }
+
+  if (decoded === '.' || decoded === '..') {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" must not decode to a relative path component`
+    );
+  }
+  if (
+    decoded.includes('/') ||
+    decoded.includes('\\') ||
+    decoded.includes('\0')
+  ) {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" must not decode to a value containing "/", "\\", or NUL`
+    );
+  }
+
+  // The W3C CCG did:web Method Specification (§3 DID Method Operations)
+  // defines a did:web DID's path component as a method-specific
+  // identifier, but does NOT normatively constrain its character set.
+  // It therefore inherits whatever the broader URI grammar permits.
+  //
+  // This implementation adopts RFC 3986 §3.3 `pchar` as the segment
+  // character class — minus the literal `:`, which is the did:web
+  // path separator (callers must percent-encode it as `%3A` inside a
+  // segment, which `pct-encoded` already permits).
+  //
+  // `pchar = unreserved / pct-encoded / sub-delims / ":" / "@"`
+  //
+  // The choice is implementation policy, not spec-mandated: any
+  // downstream port may adopt a different (typically stricter) set
+  // and still be conformant. Widening to the full pchar class
+  // (vs the earlier `unreserved + pct-encoded` only) keeps this
+  // factory capable of recreating any spec-conformant did:web DID a
+  // different implementation might emit — e.g. `alice!bob`,
+  // `O'Brien`, `c++`, `user@host`. A narrower port would reject those.
+  if (
+    !/^(?:[A-Za-z0-9\-._~!$&'()*+,;=@]|%[0-9A-Fa-f]{2})+$/.test(segment)
+  ) {
+    throw new Error(
+      `createDidWebIdentity: path segment "${sanitizeForError(segment)}" contains characters disallowed by RFC 3986 pchar grammar`
+    );
+  }
+
+  return segment;
+}
+
+/**
+ * Validate a caller-supplied `kidFragment` against the RFC 3986
+ * `fragment` grammar.
+ *
+ * Rejects the empty string, an embedded `#` (only one fragment
+ * delimiter per URI), whitespace, control characters, and any byte
+ * outside the documented grammar. Permits the full `pchar / "/" / "?"`
+ * character class so callers can use the same fragments their DID
+ * Documents declare (e.g. `keys-1`, `controller-2024`, `verification-method-1`).
+ *
+ * Unlike {@link validateDidWebDomain} and {@link validateDidWebSegment},
+ * this validator deliberately does **not** percent-decode and
+ * re-check the input. Decode-and-recheck guards against path-traversal
+ * semantics (e.g. `%2F` becoming `/`), which only matter when the
+ * value participates in URL path construction. A fragment is an
+ * opaque verification-method identifier — its percent-encoded bytes
+ * carry no path semantics, so RFC 3986 explicitly permits any
+ * `pct-encoded` octet inside it. Adding decode-and-recheck here would
+ * make the helper stricter than the spec.
+ */
+function validateDidWebKidFragment(fragment: string): string {
+  if (fragment.length === 0) {
+    throw new Error('createDidWebIdentity: kidFragment must not be empty');
+  }
+  if (!RFC3986_FRAGMENT_PATTERN.test(fragment)) {
+    throw new Error(
+      `createDidWebIdentity: kidFragment "${sanitizeForError(fragment)}" contains characters disallowed by RFC 3986 fragment grammar`
+    );
+  }
+  return fragment;
+}
+
+/**
+ * Sanitise caller-supplied input for inclusion in an error message.
+ *
+ * Identity-protocol error pipelines frequently flow into logs that
+ * downstream operators read line-by-line. A caller able to splice
+ * control bytes, NULs, ANSI escapes, or bidi-override characters
+ * through a thrown error message can spoof log entries (CR/LF
+ * splitting, bidi-rewritten attacker text — see CVE-2021-42574
+ * "Trojan Source"), break structured-log parsers, or hijack a
+ * terminal session.
+ *
+ * Two-stage defence:
+ *
+ *   1. Truncate to {@link ERROR_ECHO_MAX_LENGTH} **code points**
+ *      (not UTF-16 code units) — slicing by code units can split a
+ *      surrogate pair, producing invalid UTF-16 that downstream
+ *      JSON loggers may double-encode or corrupt.
+ *
+ *   2. Hex-escape every character matched by
+ *      {@link CONTROL_CHAR_PATTERN} — C0, C1, zero-width / direction
+ *      marks, explicit bidi overrides, and bidi isolates.
+ */
+// Characters the sanitiser MUST hex-escape to defeat log spoofing
+// and terminal hijacking:
+//
+//   - U+0000–U+001F : C0 controls (NUL log injection, CR/LF line
+//     splitting, TAB column shifting, BEL terminal interaction)
+//   - U+007F–U+009F : C1 controls (DEL, CSI 0x9B, etc.)
+//   - U+200B–U+200F : ZWSP, ZWNJ, ZWJ, LRM, RLM (invisible / mis-
+//     rendered text)
+//   - U+202A–U+202E : LRE, RLE, PDF, LRO, RLO (Trojan-Source class
+//     bidi overrides — CVE-2021-42574)
+//   - U+2066–U+2069 : LRI, RLI, FSI, PDI (bidi isolates with the
+//     same display-spoofing capability)
+//
+// Constructed from a string source so the regex literal in this file
+// carries no unprintable bytes — both for readability and to satisfy
+// `no-control-regex` without opt-out directives.
+const CONTROL_CHAR_PATTERN = new RegExp(
+  // eslint-disable-next-line no-control-regex
+  '[\\u0000-\\u001F\\u007F-\\u009F\\u200B-\\u200F\\u202A-\\u202E\\u2066-\\u2069]',
+  'g'
+);
+
+function sanitizeForError(input: string): string {
+  // Truncate by code points, not UTF-16 code units. `String.prototype.slice`
+  // cuts in the middle of surrogate pairs; `Array.from` iterates code
+  // points so the result is always well-formed UTF-16.
+  const codePoints = Array.from(input);
+  const truncated =
+    codePoints.length > ERROR_ECHO_MAX_LENGTH
+      ? `${codePoints.slice(0, ERROR_ECHO_MAX_LENGTH - 3).join('')}...`
+      : input;
+  return truncated.replace(CONTROL_CHAR_PATTERN, (c) => {
+    // Encode each code unit at the matched position. For BMP
+    // controls this is just `\xHH`; for the higher bidi ranges we
+    // emit `\uHHHH` to make the substitution unambiguous to a
+    // downstream log parser.
+    const code = c.charCodeAt(0);
+    return code <= 0xff
+      ? `\\x${code.toString(16).padStart(2, '0').toUpperCase()}`
+      : `\\u${code.toString(16).padStart(4, '0').toUpperCase()}`;
+  });
+}
+
+/**
+ * RFC 952 / RFC 1123 hostname grammar: 1–253 chars total, dot-
+ * separated labels of 1–63 chars each, letters/digits/hyphens, no
+ * leading or trailing hyphen per label.
+ */
+function isValidRegName(hostname: string): boolean {
+  if (hostname.length === 0 || hostname.length > 253) {
+    return false;
+  }
+  const labels = hostname.split('.');
+  for (const label of labels) {
+    if (label.length === 0 || label.length > 63) {
+      return false;
+    }
+    if (!/^[A-Za-z0-9-]+$/.test(label)) {
+      return false;
+    }
+    if (label.startsWith('-') || label.endsWith('-')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Validate a decoded did:web port component.
+ *
+ * RFC 3986 §3.2.3 defines the URI port grammar as `port = *DIGIT` —
+ * no upper bound. We additionally bound to the IANA TCP/UDP port
+ * range (0–65535) per RFC 6335 §6, since a did:web DID Document
+ * served over HTTPS cannot reach a port outside that range anyway.
+ * The lower bound (0) is reserved by IANA but syntactically valid
+ * and emitted by some test vectors; we accept it rather than
+ * over-stricting and forcing a special case downstream.
+ *
+ * @see RFC 3986 §3.2.3 (syntactic grammar)
+ * @see RFC 6335 §6 (port-range semantics)
+ */
+function isValidPort(port: string): boolean {
+  if (port.length === 0 || port.length > 5) {
+    return false;
+  }
+  if (!/^[0-9]+$/.test(port)) {
+    return false;
+  }
+  const n = Number(port);
+  return n >= 0 && n <= 65535;
+}
+
+/**
+ * Detach the produced Identity's `metadata` from the caller's input
+ * object so subsequent mutations on either side do not leak across.
+ *
+ * Uses `structuredClone` to clone nested values too: shallow cloning
+ * (`{ ...m }`) still shares references for nested objects, which would
+ * defeat the point for callers attaching structured metadata.
+ *
+ * Wraps `structuredClone` failures (functions, DOM nodes, host-bound
+ * objects) in a helper-prefixed error so callers see a consistent
+ * construction-throws message rather than a raw `DataCloneError` /
+ * `DOMException` from the platform.
+ */
+function cloneMetadata(
+  metadata: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (metadata === undefined) {
+    return undefined;
+  }
+  try {
+    return structuredClone(metadata);
+  } catch (cause) {
+    throw new Error(
+      'identity-factory: metadata contains values that cannot be structurally cloned (functions, DOM nodes, host-bound objects)',
+      { cause }
+    );
+  }
+}
+
+/**
+ * Validate and normalise the optional `path` argument.
+ *
+ * TypeScript narrows `args.path` to `readonly string[] | undefined` for
+ * strict callers, but plain-JavaScript consumers (and accidental
+ * `as unknown as` casts) can still pass non-array values. Surface that
+ * as a helper-prefixed construction error rather than letting `.map`
+ * throw a cryptic `TypeError`.
+ */
+function validatePath(path: readonly string[] | undefined): string[] {
+  if (path === undefined) {
+    return [];
+  }
+  if (!Array.isArray(path)) {
+    throw new Error(
+      'createDidWebIdentity: args.path must be an array of strings when supplied'
+    );
+  }
+  return path.map(validateDidWebSegment);
+}
+
+function nowIso(clock?: ClockProvider): string {
+  const ms = clock ? clock.now() : Date.now();
+  return new Date(ms).toISOString();
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ export {
   StorageProvider,
   NonceCacheProvider,
   IdentityProvider,
+  type Identity,
   type AgentIdentity,
 } from './base.js';
 
@@ -15,3 +16,15 @@ export {
 } from './memory.js';
 
 export { NodeCryptoProvider } from './node-crypto.js';
+
+export {
+  createDidKeyIdentity,
+  createDidWebIdentity,
+  createIdentity,
+  type ProvisionedIdentity,
+  type CreateIdentityOptions,
+  type CreateIdentityMethod,
+  type CreateIdentityRequest,
+  type CreateDidWebIdentityArgs,
+  type CreateDidWebIdentityOptions,
+} from './identity-factory.js';


### PR DESCRIPTION
## Description

Single-call identity provisioning. Compose a `CryptoProvider` with the
appropriate DID method to mint a fresh `Identity` (introduced in #48)
without rolling the same five-step wrapper at every call site.

- **`createDidKeyIdentity(crypto, options?)`** — generates an Ed25519
  key pair, derives the did:key, and bundles the pieces into an
  Identity with the spec-compliant fragment id.

- **`createDidWebIdentity(crypto, { domain, path? }, options?)`** —
  composes `did:web:<domain>[:<path1>[:<path2>...]]` bound to a freshly
  generated Ed25519 key. Validates `domain` and `path` segments at call
  time (rejects scheme prefixes, embedded `/`, leading/trailing `:`,
  raw `:` — ports must be percent-encoded — and empty/invalid path
  segments), per the repository's construction-throws contract. Output
  feeds straight into `buildDidWebDocument` for hosting.

- **`ProvisionedIdentity`** — the narrowed `Identity & { privateKey:
  string }` returned by both helpers, so callers do not have to
  re-check a private-key field the helper they just invoked is
  guaranteed to populate.

Both helpers accept an optional `ClockProvider` for deterministic
`createdAt` stamping (tests, event-sourced flows), and an optional
`metadata` bag that is attached to the produced Identity only when
supplied — no `metadata: undefined` artefacts in serialized output.

## Spec Impact

None. Pure-additive implementation helpers; no changes to wire format,
conformance levels, or any normative section of `SPEC.md` /
`CONFORMANCE.md`.

## Checklist

- [x] Tests pass (`npm test`) — 918/918
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted (none)
- [x] CHANGELOG.md updated