### PR TITLE
docs: rename MCP-I to KYA-OS in spec, conformance, governance, examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ### Changed
 
-- **Package renamed from `@mcp-i/core` to `@kya-os/mcp`.** Reframed under
-  the KYA-OS taxonomy: MCP-I is the identity surface of KYA-OS (Know
-  Your Agent Operating System), the umbrella protocol for agent
-  identity, authorization, and observability. Version stays at 1.2.0 —
-  the wire format, exports (`MCPI*`), and behavior are unchanged. The
-  old `@mcp-i/core` package is deprecated and points at this one.
+- **Package renamed from `@mcp-i/core` to `@kya-os/mcp`.** Renamed
+  under the KYA-OS protocol (Know Your Agent Operating System), the
+  agent identity, authorization, and observability protocol donated
+  to DIF TAAWG. Version stays at 1.2.0 — the wire format, public
+  exports, and behavior are unchanged. The old `@mcp-i/core` package
+  is deprecated and points at this one.
+- **Spec renamed from MCP-I to KYA-OS** across `SPEC.md`,
+  `CONFORMANCE.md`, `GOVERNANCE.md`, and example READMEs. Wire-format
+  identifiers (`_mcpi` tool name, well-known path, JSON Schema
+  files, JSON-LD context URLs) are deferred to a later cutover so
+  this doc-only rename doesn't break running implementations.
 - **Spec cut to `1.0.0`** (was `0.1.0-draft` in `SPEC.md`, `1.0.0-draft`
   in `CONFORMANCE.md`). The wire format was already pinned at `1.0.0`
   in the handshake protocol-version field; the spec docs now match.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -1,6 +1,6 @@
-# MCP-I Conformance Requirements
+# KYA-OS Conformance Requirements
 
-**Model Context Protocol Identity Extension — Compliance Levels**
+**Compliance levels for KYA-OS implementations**
 
 Version: 1.0.0
 Status: Stable
@@ -9,7 +9,7 @@ Status: Stable
 
 ## Overview
 
-This document defines three compliance levels for MCP-I implementations. Each level builds on the previous, with increasing capability requirements. Implementations MUST pass all tests for a given level to claim conformance at that level.
+This document defines three compliance levels for KYA-OS implementations. Each level builds on the previous, with increasing capability requirements. Implementations MUST pass all tests for a given level to claim conformance at that level.
 
 ---
 
@@ -167,7 +167,7 @@ All Level 2 requirements, plus:
 
 Implementation MUST:
 - Produce valid W3C Verifiable Credential structure
-- Include `@context` with VC v1 and MCP-I delegation context
+- Include `@context` with VC v1 and KYA-OS delegation context
 - Include `type` array with `VerifiableCredential` and `DelegationCredential`
 - Include `issuer` as DID string or object with `id`
 - Include `issuanceDate` in ISO 8601 format
@@ -278,7 +278,7 @@ To submit conformance results for your implementation:
 ### Issue Template
 
 ```markdown
-## MCP-I Conformance Submission
+## KYA-OS Conformance Submission
 
 **Implementation**: [Name] v[Version]
 **Conformance Level**: [1 | 2 | 3]
@@ -310,9 +310,9 @@ To submit conformance results for your implementation:
 
 Implementations that pass conformance testing may display badges:
 
-- **MCP-I Level 1 Conformant** — Core cryptographic operations
-- **MCP-I Level 2 Conformant** — Session management and proofs
-- **MCP-I Level 3 Conformant** — Full delegation support
+- **KYA-OS Level 1 Conformant** — Core cryptographic operations
+- **KYA-OS Level 2 Conformant** — Session management and proofs
+- **KYA-OS Level 3 Conformant** — Full delegation support
 
 Badge assets will be provided upon successful conformance submission.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 ## Project Role
 
-This repository is the **DIF TAAWG protocol reference implementation** for the KYA-OS (Know Your Agent Operating System) protocol's MCP binding. KYA-OS is the agent identity, authorization, and observability protocol; this repo provides the TypeScript implementation of its MCP binding — cryptographic identity, delegation chains, and non-repudiation proofs over Model Context Protocol. The wire format is specified in [`SPEC.md`](./SPEC.md) (the MCP-I specification, version 1.0.0).
+This repository is the **DIF TAAWG protocol reference implementation** for the KYA-OS (Know Your Agent Operating System) protocol's MCP binding. KYA-OS is the agent identity, authorization, and observability protocol; this repo provides the TypeScript implementation of its MCP binding — cryptographic identity, delegation chains, and non-repudiation proofs over Model Context Protocol. The wire format is specified in [`SPEC.md`](./SPEC.md) (the KYA-OS specification, version 1.0.0).
 
 ## Maintainers
 
@@ -31,7 +31,7 @@ Breaking changes to the specification require **explicit vote**:
 
 ## Relationship to DIF TAAWG
 
-This repository implements the MCP-I specification (the MCP binding of KYA-OS), donated to the **Decentralized Identity Foundation (DIF) Trust and Authorization for AI Working Group (TAAWG)** and under review there for ratification as a DIF standard.
+This repository implements the KYA-OS specification, donated to the **Decentralized Identity Foundation (DIF) Trust and Authorization for AI Working Group (TAAWG)** and under review there for ratification as a DIF standard.
 
 - **Spec decisions** are made in the working group
 - **Implementation decisions** are made here

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="https://modelcontextprotocol-identity.io">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://modelcontextprotocol-identity.io/images/logo-mark_white.svg">
-      <img alt="MCP-I" src="https://modelcontextprotocol-identity.io/images/logo-mark_black.svg" width="64">
+      <img alt="" src="https://modelcontextprotocol-identity.io/images/logo-mark_black.svg" width="64">
     </picture>
   </a>
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,17 +1,17 @@
-# MCP-I Protocol Specification
+# KYA-OS Protocol Specification
 
-**Model Context Protocol Identity Extension**
+**Cryptographic identity, delegation, and proof for Model Context Protocol servers**
 
 Version: 1.0.0
 Status: Stable
-Editors: MCP-I Working Group
-Repository: https://github.com/modelcontextprotocol-identity/mcp-i-core
+Editors: KYA-OS Working Group
+Repository: https://github.com/decentralized-identity/kya-os-mcp
 
 ---
 
 ## Abstract
 
-MCP-I (Model Context Protocol Identity) is a protocol extension for the Model Context Protocol (MCP) that adds cryptographic identity, delegation chains, and non-repudiation proofs to AI agent interactions. MCP-I enables MCP servers to verify *who* is calling (agent DID), *on whose behalf* (user delegation via W3C Verifiable Credentials), and *what* was done (signed proof for audit trails). The protocol uses Decentralized Identifiers (DIDs) for agent identity, W3C Verifiable Credentials for delegation, Ed25519 signatures for cryptographic operations, and StatusList2021 for revocation.
+KYA-OS (Know Your Agent Operating System) is a protocol extension for the Model Context Protocol (MCP) that adds cryptographic identity, delegation chains, and non-repudiation proofs to AI agent interactions. KYA-OS enables MCP servers to verify *who* is calling (agent DID), *on whose behalf* (user delegation via W3C Verifiable Credentials), and *what* was done (signed proof for audit trails). The protocol uses Decentralized Identifiers (DIDs) for agent identity, W3C Verifiable Credentials for delegation, Ed25519 signatures for cryptographic operations, and StatusList2021 for revocation.
 
 ---
 
@@ -55,7 +55,7 @@ DIDs and Verifiable Credentials are the right fit for this problem:
 
 | Term | Definition |
 |------|------------|
-| **Agent DID** | A Decentralized Identifier (DID) that uniquely identifies an AI agent. MCP-I supports `did:key` (self-certifying, ephemeral) and `did:web` (organization-hosted, persistent). |
+| **Agent DID** | A Decentralized Identifier (DID) that uniquely identifies an AI agent. KYA-OS supports `did:key` (self-certifying, ephemeral) and `did:web` (organization-hosted, persistent). |
 | **Delegation Chain** | An ordered sequence of Delegation Credentials from a root delegator to the current agent, where each credential's subject is the next credential's issuer. |
 | **Delegation Credential** | A W3C Verifiable Credential that grants specific permissions from an issuer (delegator) to a subject (delegate). Contains CRISP constraints defining allowed operations. |
 | **Detached Proof** | A JWS (JSON Web Signature) that cryptographically binds a tool request and response together, enabling non-repudiation and audit. Attached to responses in the `_meta` field. |
@@ -68,7 +68,7 @@ DIDs and Verifiable Credentials are the right fit for this problem:
 
 ## 3. Protocol Overview
 
-The following diagram illustrates the MCP-I protocol flow:
+The following diagram illustrates the KYA-OS protocol flow:
 
 ```
 ┌─────────────────┐                              ┌─────────────────┐
@@ -138,7 +138,7 @@ The following diagram illustrates the MCP-I protocol flow:
 
 ### 4.1 Supported DID Methods
 
-MCP-I implementations MUST support:
+KYA-OS implementations MUST support:
 
 | Method | Use Case | Resolution |
 |--------|----------|------------|
@@ -149,7 +149,7 @@ Implementations MAY support additional DID methods.
 
 ### 4.2 Key Material
 
-MCP-I uses Ed25519 (EdDSA over Curve25519) for all cryptographic operations:
+KYA-OS uses Ed25519 (EdDSA over Curve25519) for all cryptographic operations:
 
 - **Key Size**: 32-byte private seed, 32-byte public key
 - **Signature Size**: 64 bytes
@@ -412,7 +412,7 @@ When a delegation is revoked:
 
 ### 6.6 StatusList2021 Revocation
 
-MCP-I uses the W3C StatusList2021 specification for revocation:
+KYA-OS uses the W3C StatusList2021 specification for revocation:
 
 ```json
 {
@@ -550,7 +550,7 @@ When an MCP server calls downstream services (APIs, other MCP servers), it MUST 
 |--------|-------|
 | `KYA-Agent-DID` | Original agent's DID |
 | `KYA-Delegation-Chain` | Comma-separated list of delegation IDs from root to current |
-| `KYA-Session-Id` | MCP-I session ID |
+| `KYA-Session-Id` | KYA-OS session ID |
 | `KYA-Delegation-Proof` | Signed JWT proving delegation authority |
 | `KYA-Granted-Scopes` | Comma-separated list of granted scopes |
 
@@ -566,7 +566,7 @@ interface DelegationProofJWT {
   exp: number;   // Expires at (iat + 60 seconds)
   jti: string;   // Unique JWT ID (UUID)
 
-  // MCP-I claims
+  // KYA-OS claims
   delegation_id: string;    // Current delegation ID
   delegation_chain: string; // Chain path (vcId>delegationId)
   scope: string;            // Comma-separated scopes
@@ -627,7 +627,7 @@ interface NeedsAuthorizationError {
 
 ## 10. Well-Known Endpoint
 
-MCP-I servers SHOULD expose `/.well-known/mcpi`:
+KYA-OS servers SHOULD expose `/.well-known/mcpi`:
 
 ```json
 {
@@ -697,7 +697,7 @@ A confused deputy attack occurs when Agent B receives a valid delegation from Ag
 
 ### 11.7 Downgrade Attacks
 
-An adversary or non-compliant client may omit MCP-I headers entirely, bypassing identity and delegation checks. Because MCP-I is an extension to MCP, a server cannot distinguish between a client that does not support MCP-I and one that is deliberately stripping identity headers.
+An adversary or non-compliant client may omit KYA-OS headers entirely, bypassing identity and delegation checks. Because KYA-OS is an extension to MCP, a server cannot distinguish between a client that does not support KYA-OS and one that is deliberately stripping identity headers.
 
 - Servers that require identity MUST reject tool calls without a valid session (fail-closed)
 - Servers SHOULD NOT fall back to unauthenticated mode for tools that require delegation
@@ -758,7 +758,7 @@ Minor version differences SHOULD be handled gracefully — servers SHOULD implem
 
 ## 14. Transport Binding
 
-MCP-I is transport-agnostic. The handshake and proofs use standard MCP mechanisms:
+KYA-OS is transport-agnostic. The handshake and proofs use standard MCP mechanisms:
 
 **Handshake**: Implemented as an MCP tool named `_mcpi_handshake`. This is compatible with all MCP transports (stdio, SSE, HTTP Streamable) without modification.
 
@@ -848,7 +848,7 @@ These test vectors enable interoperability testing across implementations.
 5057521f310b536837b619f0ac040ef8064f8c597da8ec22a56801b435744033
 ```
 
-**MCP-I Format:**
+**KYA-OS Format:**
 ```
 sha256:5057521f310b536837b619f0ac040ef8064f8c597da8ec22a56801b435744033
 ```

--- a/examples/node-server/README.md
+++ b/examples/node-server/README.md
@@ -44,7 +44,7 @@ The response includes:
   - `meta.ts` — signature timestamp
 
 > Sessions are created automatically — no manual handshake step needed.
-> In production, MCP-I-aware clients handle the handshake transparently.
+> In production, KYA-OS-aware clients handle the handshake transparently.
 
 ### Call `restricted_greet` (protected tool)
 

--- a/examples/outbound-delegation/README.md
+++ b/examples/outbound-delegation/README.md
@@ -1,6 +1,6 @@
 # Outbound Delegation Propagation Example
 
-This example demonstrates MCP-I §7 (Outbound Delegation Propagation) — how an MCP server forwards delegation context when calling downstream services.
+This example demonstrates KYA-OS §7 (Outbound Delegation Propagation) — how an MCP server forwards delegation context when calling downstream services.
 
 ## The Scenario
 
@@ -31,7 +31,7 @@ With outbound delegation propagation:
 |--------|-------------|---------|
 | `KYA-Agent-DID` | The original agent's DID | `did:key:z6Mk...` |
 | `KYA-Delegation-Chain` | The delegation chain ID (vcId of the root delegation) | `urn:uuid:abc-123` |
-| `KYA-Session-Id` | The current MCP-I session ID | `mcpi_xyz789` |
+| `KYA-Session-Id` | The current KYA-OS session ID | `mcpi_xyz789` |
 | `KYA-Delegation-Proof` | Signed JWT proving the delegation is being forwarded | `eyJhbGciOiJFZERTQS...` |
 
 ## The Delegation Proof JWT
@@ -110,5 +110,5 @@ const response = await fetch(targetUrl, {
 
 ## Related Spec
 
-- MCP-I §7 — Outbound Delegation Propagation
+- KYA-OS §7 — Outbound Delegation Propagation
 - [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.io)


### PR DESCRIPTION
## Scope

| File | Change |
| --- | --- |
| `SPEC.md` | Title, editors line, abstract, glossary, every prose ref. Title now reads "KYA-OS Protocol Specification". Acronym expansion in the abstract changed from "Model Context Protocol Identity" to "Know Your Agent Operating System". Repository URL updated to `decentralized-identity/kya-os-mcp`. |
| `CONFORMANCE.md` | Title, subtitle, level-badge names (`MCP-I Level 1/2/3 Conformant` → `KYA-OS Level 1/2/3 Conformant`), prose throughout. |
| `GOVERNANCE.md` | Drops the parenthetical `(the MCP-I specification)` and the redundant `(the MCP binding of KYA-OS)` clause. |
| `examples/outbound-delegation/README.md` | Spec-section pointers (`MCP-I §7` → `KYA-OS §7`), session-id description. |
| `examples/node-server/README.md` | `MCP-I-aware clients` → `KYA-OS-aware clients`. |
| `README.md` | Logo alt-text emptied (`alt=""`). The logo sits in a centered intro block above the project name, so the image is decorative — empty alt is the correct a11y value; screen readers skip it and the textual context carries the identity. |
| `CHANGELOG.md` `[Unreleased]` | Rewrites the rename entry to drop the MCP-I-as-surface framing; adds a new entry documenting this spec rename. |

## Deliberately untouched (per donor guidance)

- **`schemas/*.json` + `schemas/README.md`**: wire-format identifiers
  and schema docs stay on MCP-I naming until a coordinated wire-format
  cutover. Eventual rename is queued behind the
  `schema.modelcontextprotocol-identity.io` domain 301 redirect.
- **`/.well-known/mcpi` path** in `SPEC.md`: wire-format path, same
  deferral.
- **`CHANGELOG.md` `[1.0.0-draft]` historical entries**: descriptive
  of what the package was named at the time of that release.
- **TypeScript `MCPI*` exports + `createMCPIMiddleware` factory
  name**: code-level identifiers; renaming them is a breaking-API
  change (semver-major bump) and not in scope for a doc rename.

## Verification

- 884/884 unit tests pass (doc-only)
- `git grep MCP-I` after this PR returns only intentional remainders:
  schema files, the new CHANGELOG entry that describes the rename,
  and the historical `[1.0.0-draft]` entry.
- Signed (DCO) commits.