### PR TITLE
chore: sweep package.json description from MCP-I to KYA-OS framing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kya-os/mcp",
   "version": "1.2.0",
-  "description": "Core library for MCP-I \u2014 delegation, proof, and session primitives for Model Context Protocol Identity",
+  "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers \u2014 delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Companion to the README / SPEC / CONTRIBUTING sweeps in #50 / #51:
the `package.json` `description` field still carried the pre-rebrand
`Core library for MCP-I — delegation, proof, and session primitives for Model Context Protocol Identity`
phrasing. Updates to:

```
Reference implementation of the KYA-OS protocol for Model Context Protocol servers — delegation, proof, and session primitives
```

so the npm registry listing reads consistent with the README's
canonical framing (KYA-OS = umbrella protocol; MCP-I = its MCP
binding).

## Spec Impact

None. Single-line `package.json` `description` change. No code,
lockfile, or behaviour change.

## Checklist

- [x] Tests pass (`pnpm test`) — no test surface touched
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted (none)
- [ ] CHANGELOG.md updated — N/A for npm metadata polish