### PR TITLE
chore: replace em-dash in package.json description with colon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kya-os/mcp",
   "version": "1.2.0",
-  "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers \u2014 delegation, proof, and session primitives",
+  "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Follow-up to #52. The description field on main carries a literal
em-dash (U+2014), which JSON serialises as `—` and shows up as
escape noise in the raw `package.json` source even though npm renders
it correctly. Swap to a plain colon — same separator semantics, ASCII-
only, no escape in the file.

```diff
-  "description": "...Model Context Protocol servers — delegation, proof, and session primitives",
+  "description": "...Model Context Protocol servers: delegation, proof, and session primitives",
```

## Spec Impact

None. Single-character punctuation swap in `package.json`. No code,
lockfile, behaviour, or rendered-output change for npm consumers.

## Checklist

- [x] Tests pass (`pnpm test`) — no test surface touched
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted (none)
- [ ] CHANGELOG.md updated — N/A for npm metadata polish