### PR TITLE
fix(examples): stop infinite identity-generation loop in consent demos

### DIFF
--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -248,7 +248,7 @@ export function createConsentMcpServer(
  * Load identity from .kya-os/identity.json if it exists,
  * otherwise generate an ephemeral one.
  */
-export async function createKyaOsMiddleware() {
+export async function loadKyaOsMiddleware() {
   const crypto = new NodeCryptoProvider();
   let did: string;
   let kid: string;
@@ -379,7 +379,7 @@ if (isMain) {
     ? 0
     : parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
 
-  createKyaOsMiddleware().then(async (kyaos) => {
+  loadKyaOsMiddleware().then(async (kyaos) => {
     // Start consent server with the MCP server's identity so VCs are
     // issued by the same DID that verifies them (single trust domain).
     const cryptoProvider = new NodeCryptoProvider();

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -267,7 +267,7 @@ export function createConsentFullMcpServer(
  * Load identity from .kya-os/identity.json or generate an ephemeral one,
  * then create KYA-OS middleware with session + proof + delegation support.
  */
-export async function createKyaOsMiddleware() {
+export async function loadKyaOsMiddleware() {
   const crypto = new NodeCryptoProvider();
 
   let identity: KyaOsIdentityConfig;
@@ -383,7 +383,7 @@ if (isMain) {
     ? 0
     : parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
 
-  createKyaOsMiddleware().then(async (kyaos) => {
+  loadKyaOsMiddleware().then(async (kyaos) => {
     const cryptoProvider = new NodeCryptoProvider();
     const factory = createDelegationIssuerFromIdentity(cryptoProvider, {
       did: kyaos.identity.did,

--- a/examples/context7-with-kya-os/package.json
+++ b/examples/context7-with-kya-os/package.json
@@ -10,7 +10,7 @@
     "start:http": "npx tsx src/index.ts --transport http"
   },
   "dependencies": {
-    "@kya-os/mcp": "^1.1.2",
+    "@kya-os/mcp": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^14.0.0",
     "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- `examples/consent-basic/src/server.ts` and `examples/consent-full/src/server.ts` each define a local `createKyaOsMiddleware()` wrapper around identity loading. The wrapper's last line calls `createKyaOsMiddleware(...)` intending to hit the SDK export of the same name — but lexical scope resolves it to the wrapper itself.
- Result: infinite recursion. Every call regenerates an ephemeral keypair, writes `[server] Generated ephemeral identity (run 'npm run generate-identity' to persist)` to stderr, and recurses. `pnpm demo` floods the terminal and never boots.
- Renames the local wrapper to `loadKyaOsMiddleware` in both examples and updates the single call site in each.

## Test plan
- [ ] `pnpm demo` boots cleanly and prints the expected `[server] HTTP server:` lines instead of looping
- [ ] `pnpm tsc --noEmit` passes
- [ ] Example test suites (`examples/consent-basic`, `examples/consent-full`) still pass — they import the SDK function directly and are unaffected by the rename