### PR TITLE
security: flip requireAudienceOnRedelegation default to true + fix .well-known path triple-rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Security
+
+- **BREAKING (default flip): `requireAudienceOnRedelegation` now defaults to `true`.**
+  Every non-root credential in a delegation chain must carry an `audience`
+  constraint. Closes the confused-deputy class flagged by Alan Karp's
+  transitive-access analysis and matches `SPEC.md` §11.6. Integrations that
+  cannot yet bind audience on every re-delegation can set the flag to `false`
+  explicitly to preserve legacy behavior; doing so logs a one-time
+  per-process warning so the configuration is auditable in production logs.
+- **Unsafe-mode warning:** setting `allowLegacyUnsafeDelegation` to `true`
+  now emits a one-time per-process `console.warn` on first use. Default
+  is unchanged (`false` / strict). The warning surfaces accidental
+  configuration in production logs without spamming per-session.
+- `SECURITY.md` gained a "Secure Defaults & Unsafe Delegation Modes" section
+  documenting both flags, when to opt out, and the migration path back to
+  safe defaults.
+
 ### Added
 
 - **Generic `Identity` interface** exported from the root entry point.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Versioning: https://semver.org/spec/v2.0.0.html
   to DIF TAAWG. Version stays at 1.2.0 — the wire format, public
   exports, and behavior are unchanged. The old `@mcp-i/core` package
   is deprecated and points at this one.
-- **Spec renamed from KYA-OS to KYA-OS** across `SPEC.md`,
+- **Spec renamed from MCP-I to KYA-OS** across `SPEC.md`,
   `CONFORMANCE.md`, `GOVERNANCE.md`, and example READMEs. Wire-format
   identifiers (`_kyaos` tool name, well-known path, JSON Schema
   files, JSON-LD context URLs) are deferred to a later cutover so
@@ -75,7 +75,7 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - In-memory implementations for all providers (testing)
 - Configurable logging with debug, info, warn, error levels
 - Pure TypeScript protocol type definitions (zero runtime dependencies)
-- Well-known endpoint (`/.well-known/kyaos-os-os`) for server discovery
+- Well-known endpoint (`/.well-known/mcp`) for server discovery
 - Outbound delegation proof JWT builder for downstream API calls
 - Three-tier conformance levels:
   - Level 1: Core Crypto (key generation, signing, hashing, DID resolution)

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -30,7 +30,7 @@ Level 1 establishes the cryptographic foundation. An implementation at this leve
 | L1.7 | Extract Ed25519 public key from `did:key` | `src/delegation/__tests__/did-key-resolver.test.ts` | `extractPublicKeyFromDidKey > should extract public key bytes from valid did:key` |
 | L1.8 | Convert public key bytes to JWK format | `src/delegation/__tests__/did-key-resolver.test.ts` | `publicKeyToJwk > should convert public key bytes to JWK format` |
 | L1.9 | Implement base58btc encoding/decoding | `src/delegation/__tests__/did-key-resolver.test.ts` | `Base58 Utilities` (all tests) |
-| L1.10 | Expose `/.well-known/kyaos-os-os` endpoint (recommended) | — | Implementation-specific |
+| L1.10 | Expose `/.well-known/mcp` endpoint (recommended) | — | Implementation-specific |
 
 ### Detailed Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,3 +38,34 @@ This policy covers the `@kya-os/mcp` npm package and this repository. It include
 
 - Vulnerabilities in dependencies (report to the respective maintainers)
 - Issues requiring physical access to the host
+
+## Secure Defaults & Unsafe Delegation Modes
+
+`@kya-os/mcp` ships with secure-by-default behavior. As of 1.3.x, two delegation knobs are wired to safe values; both can be opted out of for backward compatibility, and both emit a one-time per-process warning when set unsafely so operators can spot the configuration in logs.
+
+### `requireAudienceOnRedelegation` — default `true`
+
+Every non-root credential in a delegation chain MUST carry an `audience` constraint. This prevents confused-deputy attacks where a re-delegated credential issued for service A is forwarded to service B and accepted there. See `SPEC.md` §11.6 and Alan Karp's transitive-access analysis for the underlying vulnerability class.
+
+- **When to set to `false`:** legacy integrations that issue re-delegations without an audience field and cannot yet update their issuance pipeline. Do this only as a temporary migration step. The middleware logs a warning on first use per process.
+- **Migration path:** update your delegation issuer to bind `audience = <verifying-server-did>` on every non-root credential, then flip the flag back to `true` (or remove it).
+
+### `allowLegacyUnsafeDelegation` — default `false`
+
+When `false` (the default), the middleware enforces full delegation-chain resolution and `credentialStatus` / StatusList revocation checks on every invocation.
+
+Setting this to `true` weakens verification:
+- Parent-linked delegations are accepted without chain resolution.
+- `credentialStatus` is accepted without StatusList lookups.
+
+- **When to set to `true`:** integrations that have not yet provided `resolveDelegationChain` and `resolveStatusList` resolvers and need a controlled migration window. The middleware logs a warning on first use per process.
+- **Migration path:** wire up `delegationConfig.resolveDelegationChain` and `delegationConfig.resolveStatusList`, then remove this flag.
+
+### What to do if you see the warning in production logs
+
+Treat the warning as a configuration audit finding. Either:
+1. The flag is set intentionally as part of a migration — track a deadline and close it.
+2. The flag is set unintentionally (often inherited from copy-pasted test config) — remove it.
+
+Either way the warning is a one-shot signal, not a per-request alarm.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -627,7 +627,7 @@ interface NeedsAuthorizationError {
 
 ## 10. Well-Known Endpoint
 
-KYA-OS servers SHOULD expose `/.well-known/kyaos-os-os`:
+KYA-OS servers SHOULD expose `/.well-known/mcp`:
 
 ```json
 {
@@ -701,7 +701,7 @@ An adversary or non-compliant client may omit KYA-OS headers entirely, bypassing
 
 - Servers that require identity MUST reject tool calls without a valid session (fail-closed)
 - Servers SHOULD NOT fall back to unauthenticated mode for tools that require delegation
-- The `/.well-known/kyaos-os-os` endpoint allows clients to discover server requirements before connecting
+- The `/.well-known/mcp` endpoint allows clients to discover server requirements before connecting
 
 ### 11.8 Delegation Credential Theft
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -79,7 +79,7 @@ Schemas can reference each other using `$ref`. For example, the delegation crede
 │ Client │                          │ Server │
 └───┬────┘                          └───┬────┘
     │                                   │
-    │  GET /.well-known/kyaos-os-os            │
+    │  GET /.well-known/mcp                │
     │──────────────────────────────────>│
     │  (well-known-kyaos.json)           │
     │<──────────────────────────────────│

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/discovery/well-known-kyaos.v1.0.0.json",
   "title": "KYA-OS Discovery Document",
-  "description": "Well-known discovery document served at /.well-known/kyaos-os-os for KYA-OS service discovery.",
+  "description": "Well-known discovery document served at /.well-known/mcp for KYA-OS service discovery.",
   "type": "object",
   "required": ["version", "serverDid", "endpoints"],
   "properties": {

--- a/src/delegation/__tests__/transitive-access.test.ts
+++ b/src/delegation/__tests__/transitive-access.test.ts
@@ -136,6 +136,16 @@ async function createServer(opts?: {
   const did = generateDidKeyFromBase64(keyPair.publicKey);
   const kid = `${did}#${did.replace('did:key:', '')}`;
 
+  // These transitive-access tests exercise chain-integrity, scope attenuation,
+  // and confused-deputy invariants — they pre-date the secure-default flip
+  // of `requireAudienceOnRedelegation` (now `true` by default in production).
+  // We opt out here so each test can isolate the invariant it's checking;
+  // explicit audience-enforcement tests in §11 set the flag back to `true`.
+  const delegation: KyaOsDelegationConfig = {
+    requireAudienceOnRedelegation: false,
+    ...(opts?.delegation ?? {}),
+  };
+
   const middleware = createKyaOsMiddleware(
     {
       identity: {
@@ -145,7 +155,7 @@ async function createServer(opts?: {
         publicKey: keyPair.publicKey,
       },
       session: { sessionTtlMinutes: 60 },
-      delegation: opts?.delegation,
+      delegation,
       autoSession: opts?.autoSession,
     },
     crypto,
@@ -1144,9 +1154,11 @@ describe('Transitive Access — Karp Use Cases', () => {
       expect(result.content[0].text).toBe('ok');
     });
 
-    it('allows re-delegations without audience when enforcement is disabled (default)', async () => {
-      // Backward compatibility: the flag defaults to false, so existing
-      // integrations that omit audience on re-delegations continue to work.
+    it('allows re-delegations without audience when enforcement is explicitly disabled', async () => {
+      // Backward-compatibility opt-out: setting the flag to `false`
+      // restores legacy behavior for integrations that cannot yet bind
+      // audience on every re-delegation. A one-time warn is emitted
+      // per process; we assert behavior here, not the warning.
 
       const aliceToBob = await issueVC({
         from: alice,
@@ -1159,12 +1171,12 @@ describe('Transitive Access — Karp Use Cases', () => {
         to: carol,
         scopes: ['query:x'],
         parentId: aliceToBob.credentialSubject.delegation.id,
-        // no audience — allowed when flag is off
+        // no audience — allowed when flag is explicitly false
       });
 
       const { middleware } = await createServer({
         delegation: {
-          // requireAudienceOnRedelegation not set (defaults to false)
+          requireAudienceOnRedelegation: false, // explicit opt-out
           resolveDelegationChain: async () => [aliceToBob],
         },
       });

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -26,11 +26,21 @@ async function createTestMiddleware(options?: {
   const did = generateDidKeyFromBase64(keyPair.publicKey);
   const kid = `${did}#${did.replace('did:key:', '')}`;
 
+  // Pre-secure-default fixture: legacy tests in this file exercise specific
+  // chain/scope invariants without binding audience on each hop. Opt out of
+  // the (now-default-true) audience-on-redelegation check so each test can
+  // isolate the invariant under examination. Tests that need to assert
+  // audience enforcement set the flag explicitly to `true`.
+  const delegation: KyaOsDelegationConfig = {
+    requireAudienceOnRedelegation: false,
+    ...(options?.delegation ?? {}),
+  };
+
   const middleware = createKyaOsMiddleware(
     {
       identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
       session: { sessionTtlMinutes: 60 },
-      delegation: options?.delegation,
+      delegation,
       autoSession: options?.autoSession,
     },
     crypto,

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -96,7 +96,10 @@ export interface KyaOsDelegationConfig {
    * Recommended for production. See: Alan Karp's transitive access analysis
    * and KYA-OS §11.6 (Confused Deputy Attacks).
    *
-   * Default is false for backward compatibility.
+   * Default is `true` as of KYA-OS 1.3.x. Existing integrations that
+   * issue re-delegations without an `audience` constraint can set this
+   * to `false` to preserve legacy behavior; doing so logs a one-time
+   * warning per process.
    */
   requireAudienceOnRedelegation?: boolean;
   /**
@@ -321,6 +324,13 @@ function validateScopeAttenuation(
  * deployments behind a load balancer. For distributed deployments, implement a custom
  * `SessionStore` backed by Redis, DynamoDB, or similar and pass it via `config.session`.
  */
+
+// Module-level warn-once flags for unsafe configuration. Per-process,
+// not per-session, so long-running servers don't spam logs on every new
+// session.
+let warnedAudienceOptOut = false;
+let warnedLegacyUnsafeDelegation = false;
+
 export function createKyaOsMiddleware(
   config: KyaOsConfig,
   cryptoProvider: CryptoProvider,
@@ -607,6 +617,25 @@ export function createKyaOsMiddleware(
   ): KyaOsToolHandler {
     const legacyUnsafeDelegationEnabled =
       delegationConfig?.allowLegacyUnsafeDelegation === true;
+    if (legacyUnsafeDelegationEnabled && !warnedLegacyUnsafeDelegation) {
+      warnedLegacyUnsafeDelegation = true;
+      console.warn(
+        "⚠️  KYA-OS: allowLegacyUnsafeDelegation=true disables delegation-chain " +
+          "resolution and StatusList revocation checks. This is unsafe for production. " +
+          "See SECURITY.md (Unsafe Delegation Modes).",
+      );
+    }
+    if (
+      delegationConfig?.requireAudienceOnRedelegation === false &&
+      !warnedAudienceOptOut
+    ) {
+      warnedAudienceOptOut = true;
+      console.warn(
+        "⚠️  KYA-OS: requireAudienceOnRedelegation=false disables confused-deputy " +
+          "protection on re-delegations. The default is true as of 1.3.x. " +
+          "See SECURITY.md (Unsafe Delegation Modes).",
+      );
+    }
     const didKeyResolver = createDidKeyResolver();
     const fetchProvider =
       delegationConfig?.fetchProvider ??
@@ -811,8 +840,14 @@ export function createKyaOsMiddleware(
         // credential in the chain MUST have an audience constraint.
         // This prevents confused-deputy attacks where re-delegated
         // credentials are forwarded to unintended servers.
+        //
+        // Defaults to `true`. Set explicitly to `false` to preserve
+        // legacy behavior (logged once per process — see opt-out warning
+        // below).
+        const requireAudienceOnRedelegation =
+          delegationConfig?.requireAudienceOnRedelegation !== false;
         if (
-          delegationConfig?.requireAudienceOnRedelegation &&
+          requireAudienceOnRedelegation &&
           delegation.parentId &&
           !delegation.constraints.audience
         ) {


### PR DESCRIPTION
Two coordinated changes, sized for the DIF steering-committee review on Tuesday.

## Summary

### 1. Doc-safety fix: `/.well-known/kyaos-os-os` -> `/.well-known/mcp`

The path `kyaos-os-os` is clearly triple-rename residue from the MCP-I -> KYA-OS pass and not the intended canonical value. Replaced with `/.well-known/mcp` across SPEC.md, CONFORMANCE.md, CHANGELOG.md, and schema docs.

Also fixed the typo `Spec renamed from KYA-OS to KYA-OS` in CHANGELOG.md (should read `from MCP-I to KYA-OS`).

**Wire-format identifiers, schema $id hosts, JSON-LD context URLs, and the npm package name remain untouched** — those are explicitly deferred per the existing CHANGELOG note pending a coordinated cutover.

### 2. Security: flip `requireAudienceOnRedelegation` default to `true`

This is the confused-deputy class Alan Karp flagged on the public docs review (and that SPEC.md §11.6 already warns about as a class). Every non-root credential in a delegation chain must now carry an `audience` constraint by default; without it, a re-delegation issued for service A could be forwarded to service B and accepted there.

- Default is now `true`.
- Existing integrations that issue re-delegations without audience can opt out by setting `requireAudienceOnRedelegation: false` explicitly. Opt-out logs a one-time `console.warn` per process so the configuration is visible in production logs.
- Companion change: setting `allowLegacyUnsafeDelegation: true` also emits a one-time `console.warn` on first use. Default behavior unchanged (`false` / strict).
- Warn-once flags are deduped at module scope so long-running servers don't spam logs across sessions.
- `SECURITY.md` gained a 'Secure Defaults & Unsafe Delegation Modes' section explaining both flags, when to opt out, and the migration path back.

## Testing

- All 895 tests pass.
- Test fixtures (`transitive-access.test.ts`, `with-kya-os.test.ts`) that pre-date this flip now opt out of audience enforcement in their setup so each test can isolate the invariant it actually checks. The explicit audience-enforcement tests in §11 of `transitive-access.test.ts` set the flag to `true` and continue to pass unchanged.
- `pnpm lint` clean (0 errors, 0 warnings).
- `pnpm build` clean.