### PR TITLE
spec: designation invariant, revocation rights, lamport race + warning-once tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - Added normative _meta hash exclusion paragraph and `session.metaPolicy` opt-in (default: `strict`).
 - Documented anonymous handshake nonce-dedupe boundary; reference impl now uses a 60s TTL for anonymous nonces.
 - Added `clockSkewSeconds` field to `.well-known/mcp` for server-advertised skew negotiation.
+- Added the **designation invariant** to §6.4.1 as a normative MUST: invocations must designate the specific resource being exercised, even when the delegation authorizes multiple resources. The reference implementation already enforces this via the per-tool `scopeId` check; this change makes the behavior normative and cross-references it from §11.6 (Confused Deputy Attacks).
+- Added §6.5.1 (Revocation Rights) defining who may revoke a delegation in v1.0: direct issuer, any ancestor issuer in the chain, and the responsible party at the root. Subject-side revocation is explicitly disallowed in v1.0; UCAN-style "revocation as a delegatable permission" is tracked for v1.1.
+- Added §6.5.2 (Concurrency and the Revocation Race) acknowledging the Lamport-concurrent race between revocation issuance and propagation, with implementation guidance on bounding the window.
 
 ### Security
 
@@ -29,6 +32,9 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - `SECURITY.md` gained a "Secure Defaults & Unsafe Delegation Modes" section
   documenting both flags, when to opt out, and the migration path back to
   safe defaults.
+- Added test coverage pinning the warn-once behavior on both unsafe-mode
+  flags: warns exactly once per process on opt-in, silent on safe defaults,
+  no duplicate warnings across repeated `wrapWithDelegation` calls.
 
 ### Added
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -402,6 +402,32 @@ Delegations form a directed acyclic graph (DAG):
 - Child delegation's `issuerDid` MUST equal parent's `subjectDid`
 - Scope constraints MUST be equal to or narrower than parent's constraints
 
+### 6.4.1 Designation Invariant
+
+A `DelegationCredential` may authorize multiple resources, either via a list
+of explicit scope strings (`constraints.scopes[]`) or via pattern matchers
+(`constraints.crisp.scopes[].matcher`: `'exact' | 'prefix' | 'regex'`). When
+the credential is used to invoke a specific tool or resource, the invocation
+MUST designate the specific scope being exercised, and verifiers MUST confirm
+that the designated scope is a member of (or matches a pattern in) the
+delegation's authorized scopes.
+
+In other words: multi-resource delegations are valid as authority grants
+but cannot be used in invocations without designation. An invocation that
+omits the specific resource designation MUST be rejected, even if the
+delegation would have authorized it under any matching scope.
+
+This is the designation/authorization separation: without it, an attacker
+who acquires a multi-resource delegation can use it against resources the
+original delegator did not anticipate. Together with the audience-on-
+re-delegation requirement (§11.6), this closes the confused-deputy class
+on the invocation path.
+
+Reference implementation: each tool wrapped via `wrapWithDelegation` is
+registered with a fixed `scopeId`; invocations carry the wrapped tool's
+name and the verifier requires the delegation's scopes to contain that
+exact scopeId before the handler runs.
+
 ### 6.5 Cascading Revocation
 
 When a delegation is revoked:
@@ -410,6 +436,56 @@ When a delegation is revoked:
 2. Recursively mark all descendant delegations as `revoked`
 3. Update StatusList2021 credential for each revoked delegation
 4. Emit revocation events for audit logging
+
+#### 6.5.1 Revocation Rights
+
+For v1.0, the parties authorized to revoke a delegation are:
+
+1. **The direct issuer of the delegation.** The party that signed the
+   `DelegationCredential` MAY revoke it at any time.
+2. **Any ancestor issuer in the delegation chain.** A party that issued
+   an upstream delegation MAY revoke any descendant delegation; cascading
+   revocation propagates downward through the graph (§6.5).
+3. **The Responsible Party at the root of the chain.** The root issuer
+   MAY revoke the entire chain.
+4. **The subject of a delegation MAY NOT revoke it.** Revocation requires
+   authority from above; an agent cannot unilaterally invalidate a
+   delegation it received.
+
+Revocation requests SHOULD be signed by the revoking party's key, and
+verifiers SHOULD validate the revoker's identity against the chain before
+honoring the revocation.
+
+Future versions may adopt an explicit "revocation as a delegatable
+permission" model (UCAN-style), allowing the responsible party to grant
+revocation authority to other parties (e.g. a security operations team)
+without those parties being in the original chain. Tracked for v1.1.
+
+#### 6.5.2 Concurrency and the Revocation Race
+
+Revocation and invocation are concurrent operations in the Lamport sense.
+An invocation that arrives at a verifier between the moment a revocation
+is issued and the moment that revocation propagates to the verifier will
+succeed despite the revocation being logically prior. This race is
+unavoidable in any distributed system; implementations can bound the
+window but cannot eliminate it.
+
+Implementations MUST:
+
+- Propagate revocations to all known verifiers as quickly as possible,
+  including immediate StatusList2021 updates and cache invalidation.
+- Cache status-list lookups with a TTL no longer than the revocation
+  propagation target. For high-privilege scopes, ≤ 60 seconds is
+  recommended.
+- Honor explicit revocation signals (e.g., a side-channel notification
+  from a trusted source) immediately, ahead of the next status-list
+  refresh.
+
+Operators of high-stakes resources SHOULD reduce the race window by
+issuing short-lived delegations (so revocation by expiration is the
+primary mechanism) and polling status lists frequently. The unavoidable
+race is the same trade-off familiar from PKI: short certificate lifetimes
+reduce the window during which a compromised credential can be used.
 
 ### 6.6 StatusList2021 Revocation
 
@@ -706,6 +782,18 @@ A confused deputy attack occurs when Agent B receives a valid delegation from Ag
 - Delegation scopes SHOULD be as narrow as possible (prefer `tool:read_file` over `tool:*`)
 - CRISP `matcher: 'exact'` SHOULD be used for sensitive resources
 - Servers MAY implement per-delegation call logging to detect misuse
+
+Two normative invariants close the confused-deputy class on the invocation path:
+
+1. **Designation invariant (§6.4.1).** Invocations MUST designate the specific
+   resource being exercised; verifiers MUST reject invocations that rely on a
+   multi-resource delegation without designation. The reference implementation
+   enforces this by requiring each tool's registered `scopeId` to be present
+   in the delegation's authorized scopes before the handler runs.
+2. **Audience-on-redelegation default (§this section).** Non-root credentials
+   in a delegation chain MUST carry an `audience` constraint binding them to a
+   specific verifying server. This default is `true` as of v1.3.x; opt-out is
+   available with a one-time per-process warning for legacy integrations.
 
 ### 11.7 Downgrade Attacks
 

--- a/src/middleware/__tests__/unsafe-mode-warnings.test.ts
+++ b/src/middleware/__tests__/unsafe-mode-warnings.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the warn-once behavior on the two unsafe delegation knobs.
+ *
+ * These warnings are observability — they don't change protocol behavior,
+ * they just make unsafe configuration visible in production logs. The
+ * dedupe logic uses module-level flags, so we reload the middleware module
+ * between tests to get a fresh warned-state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import type { KyaOsDelegationConfig } from '../with-kya-os.js';
+
+async function freshMiddleware(delegation?: KyaOsDelegationConfig) {
+  vi.resetModules();
+  const mod = await import('../with-kya-os.js');
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#${did.replace('did:key:', '')}`;
+  return mod.createKyaOsMiddleware(
+    {
+      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+      session: { sessionTtlMinutes: 60 },
+      delegation,
+    },
+    crypto,
+  );
+}
+
+async function wrapNoop(middleware: Awaited<ReturnType<typeof freshMiddleware>>) {
+  return middleware.wrapWithDelegation(
+    'noop_tool',
+    { scopeId: 'noop', consentUrl: 'https://example.com/consent' },
+    async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+  );
+}
+
+describe('Unsafe delegation mode warnings', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('allowLegacyUnsafeDelegation', () => {
+    it('warns once on first wrapWithDelegation when set to true', async () => {
+      const middleware = await freshMiddleware({ allowLegacyUnsafeDelegation: true });
+      await wrapNoop(middleware);
+
+      const legacyWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('allowLegacyUnsafeDelegation'),
+      );
+      expect(legacyWarnings).toHaveLength(1);
+      expect(legacyWarnings[0][0]).toContain('unsafe for production');
+      expect(legacyWarnings[0][0]).toContain('SECURITY.md');
+    });
+
+    it('does not re-warn on subsequent wrapWithDelegation calls in the same process', async () => {
+      const middleware = await freshMiddleware({ allowLegacyUnsafeDelegation: true });
+      await wrapNoop(middleware);
+      await wrapNoop(middleware);
+      await wrapNoop(middleware);
+
+      const legacyWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('allowLegacyUnsafeDelegation'),
+      );
+      expect(legacyWarnings).toHaveLength(1);
+    });
+
+    it('does not warn when set to false', async () => {
+      const middleware = await freshMiddleware({ allowLegacyUnsafeDelegation: false });
+      await wrapNoop(middleware);
+
+      const legacyWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('allowLegacyUnsafeDelegation'),
+      );
+      expect(legacyWarnings).toHaveLength(0);
+    });
+
+    it('does not warn when omitted (default is false)', async () => {
+      const middleware = await freshMiddleware();
+      await wrapNoop(middleware);
+
+      const legacyWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('allowLegacyUnsafeDelegation'),
+      );
+      expect(legacyWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('requireAudienceOnRedelegation opt-out', () => {
+    it('warns once on first wrapWithDelegation when explicitly set to false', async () => {
+      const middleware = await freshMiddleware({ requireAudienceOnRedelegation: false });
+      await wrapNoop(middleware);
+
+      const audienceWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('requireAudienceOnRedelegation'),
+      );
+      expect(audienceWarnings).toHaveLength(1);
+      expect(audienceWarnings[0][0]).toContain('confused-deputy');
+      expect(audienceWarnings[0][0]).toContain('SECURITY.md');
+    });
+
+    it('does not re-warn on subsequent wrapWithDelegation calls in the same process', async () => {
+      const middleware = await freshMiddleware({ requireAudienceOnRedelegation: false });
+      await wrapNoop(middleware);
+      await wrapNoop(middleware);
+      await wrapNoop(middleware);
+
+      const audienceWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('requireAudienceOnRedelegation'),
+      );
+      expect(audienceWarnings).toHaveLength(1);
+    });
+
+    it('does not warn when omitted (defaults to true — strict)', async () => {
+      const middleware = await freshMiddleware();
+      await wrapNoop(middleware);
+
+      const audienceWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('requireAudienceOnRedelegation'),
+      );
+      expect(audienceWarnings).toHaveLength(0);
+    });
+
+    it('does not warn when explicitly set to true', async () => {
+      const middleware = await freshMiddleware({ requireAudienceOnRedelegation: true });
+      await wrapNoop(middleware);
+
+      const audienceWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('requireAudienceOnRedelegation'),
+      );
+      expect(audienceWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('default safe configuration', () => {
+    it('emits no delegation warnings when both knobs are at their safe defaults', async () => {
+      const middleware = await freshMiddleware();
+      await wrapNoop(middleware);
+
+      const delegationWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' &&
+          (call[0].includes('allowLegacyUnsafeDelegation') ||
+            call[0].includes('requireAudienceOnRedelegation')),
+      );
+      expect(delegationWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('both unsafe modes together', () => {
+    it('emits both warnings (one each) when both knobs are set unsafely', async () => {
+      const middleware = await freshMiddleware({
+        allowLegacyUnsafeDelegation: true,
+        requireAudienceOnRedelegation: false,
+      });
+      await wrapNoop(middleware);
+
+      const legacyWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('allowLegacyUnsafeDelegation'),
+      );
+      const audienceWarnings = warnSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('requireAudienceOnRedelegation'),
+      );
+      expect(legacyWarnings).toHaveLength(1);
+      expect(audienceWarnings).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
Three spec additions covering the cap-sec model on the invocation and
revocation paths, plus a test-coverage gap from the previous
secure-defaults change.

## Designation invariant (§6.4.1)

The reference middleware already requires each tool's registered `scopeId`
to be present in the delegation's authorized scopes before the handler
runs. This change makes that behaviour normative in the spec: when a
DelegationCredential authorizes multiple resources (via `scopes[]` or
CRISP pattern matchers), an invocation MUST designate the specific scope
being exercised, and verifiers MUST reject any invocation that omits
designation. Without this, multi-resource delegations become
confused-deputy fuel. Cross-referenced from §11.6.

## Revocation rights (§6.5.1)

Defines who may revoke a delegation in v1.0:
- The direct issuer.
- Any ancestor issuer in the chain (cascading downward).
- The responsible party at the root of the chain.
- Subjects MAY NOT revoke their own delegations.

UCAN-style delegatable revocation authority (e.g. for security operations
teams not in the original chain) is tracked for v1.1.

## Revocation race (§6.5.2)

Names the Lamport-concurrent race between revocation issuance and
propagation explicitly. The race is unavoidable in any distributed
system; the spec now states the implementation contract for bounding the
window — short status-list cache TTLs, immediate honoring of side-channel
revocation signals, and an operator recommendation to prefer short-lived
delegations so expiry is the primary revocation mechanism.

## Warn-once tests for unsafe delegation modes

The previous secure-defaults change added one-time per-process warnings
for the two unsafe delegation knobs (`requireAudienceOnRedelegation=false`
opt-out, `allowLegacyUnsafeDelegation=true` opt-in) but did not pin the
warn-once behaviour with tests. This PR closes that gap:

- Warns exactly once per process when the flag is set unsafely.
- Does not re-emit on subsequent `wrapWithDelegation` calls.
- Stays silent at safe defaults.
- Emits both warnings independently when both flags are set unsafely.

Tests use `vi.resetModules()` so each case gets a fresh module-level
warned-state without polluting other suites.

## Testing

- 925 tests pass (10 new in `unsafe-mode-warnings.test.ts`).
- `pnpm lint` clean.
- `pnpm build` clean.