### PR TITLE
docs: tighten two remaining 'on whose behalf' hits to match responsible party rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Docs
+
+- Tightened two capability-language hits inside the spec that survived the Responsible Party rename: §8.2 `DelegationProofJWT.sub` comment now describes the Responsible Party explicitly (was "User DID (on whose behalf)"), and the `userDid` field description in `schemas/delegation-credential.json` now reads "whose delegated authority the agent exercises" instead of "on whose behalf the delegation acts."
+
 ### Spec
 
 - Added §11.0 (Trust Model) naming the three trust boundaries explicitly: the agent process, the verifier (with the Edge Verifier called out as a TCB component at L1), and the service / resource owner. Includes key custody options (software, proxy-managed, hardware-attested) and a mutual-authentication recommendation for services.

--- a/SPEC.md
+++ b/SPEC.md
@@ -648,7 +648,7 @@ When an MCP server calls downstream services (APIs, other MCP servers), it MUST 
 interface DelegationProofJWT {
   // Standard JWT claims
   iss: string;   // Server DID (JWT issuer)
-  sub: string;   // User DID (on whose behalf)
+  sub: string;   // Responsible Party DID (the root issuer of the delegation chain)
   aud: string;   // Target service hostname
   iat: number;   // Issued at (Unix epoch)
   exp: number;   // Expires at (iat + 60 seconds)

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -94,7 +94,7 @@
             "userDid": {
               "type": "string",
               "pattern": "^did:.+$",
-              "description": "DID of the end user on whose behalf the delegation acts."
+              "description": "DID of the end user whose delegated authority the agent exercises."
             },
             "userIdentifier": {
               "type": "string",


### PR DESCRIPTION
PR #59 introduced the Responsible Party concept and updated the Abstract + §6.4 to use capability-security framing. Two stragglers were missed in that pass and survived to current main:

- `§8.2 DelegationProofJWT.sub` comment still read `User DID (on whose behalf)`. Now reads `Responsible Party DID (the root issuer of the delegation chain)`.
- `schemas/delegation-credential.json` `userDid` field description still read `on whose behalf the delegation acts`. Now reads `whose delegated authority the agent exercises`.

The schema field name (`userDid`) is unchanged to preserve wire compatibility. Only the human-facing description is tightened.

No protocol behavior change. No code or test changes.

## Testing

- 925/925 tests pass.
- `pnpm lint` clean.
- `pnpm build` clean.