### PR TITLE
docs(spec): revocation scope, registry types, audit example, nonce lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,17 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - Added `delegation.allowLegacyUnsafeDelegation` to `createKyaOsMiddleware` as a temporary migration escape hatch for legacy integrations.
 - Added middleware tests covering legacy-compatibility behavior for parent-linked and status-list credentials.
 
+### Docs
+
+- L1 revocation terminology clarified (verifier-local, not global CRL).
+- Orchestration directory scope explicitly narrowed from global to service-local.
+- Nonce lifetime documented to prevent early-eviction replay class.
+- Multi-level audit record example added.
+- Conformance-tiered audit-logging requirements added.
+- Registry types (Delegation / Credential / Trust) disambiguated.
+- Broken link to Protocol Registry fixed.
+- Key Topics ordering aligned with site navigation.
+
 ## [1.0.0-draft] - 2026-03-12
 
 ### Added

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -31,6 +31,7 @@ Level 1 establishes the cryptographic foundation. An implementation at this leve
 | L1.8 | Convert public key bytes to JWK format | `src/delegation/__tests__/did-key-resolver.test.ts` | `publicKeyToJwk > should convert public key bytes to JWK format` |
 | L1.9 | Implement base58btc encoding/decoding | `src/delegation/__tests__/did-key-resolver.test.ts` | `Base58 Utilities` (all tests) |
 | L1.10 | Expose `/.well-known/mcp` endpoint (recommended) | — | Implementation-specific |
+| L1.11 | Audit logging MAY be implemented | — | Implementation-specific |
 
 ### Detailed Requirements
 
@@ -66,6 +67,10 @@ Implementation MUST:
 - Verify `kid` in header matches expected key
 - Return boolean result
 
+#### L1.11 — Audit Logging
+
+Audit logging MAY be implemented at Level 1. If implemented, it SHOULD capture key generation events and signature operations.
+
 ---
 
 ## Level 2 — Full Session
@@ -93,6 +98,7 @@ All Level 1 requirements, plus:
 | L2.13 | Verify proof against request/response | `src/proof/__tests__/proof-generator.test.ts` | `Proof Verification > should reject proof with mismatched request` |
 | L2.14 | Validate handshake request format | `src/session/__tests__/session-manager.test.ts` | `validateHandshakeFormat` (all tests) |
 | L2.15 | Create handshake request with current timestamp | `src/session/__tests__/session-manager.test.ts` | `createHandshakeRequest > should use current timestamp` |
+| L2.16 | Audit logging SHOULD be implemented | — | Implementation-specific |
 
 ### Detailed Requirements
 
@@ -110,6 +116,10 @@ Implementation MUST:
 - Store (nonce, agentDid) tuples for at least `sessionTtlMinutes + 1 minute`
 - Reject any request with a previously-seen nonce for the same agentDid
 - Support cleanup of expired nonces
+
+#### L2.16 — Audit Logging
+
+Audit logging SHOULD be implemented at Level 2. Implementations SHOULD record session lifecycle events (handshake, expiry, replay rejection) and proof generation events with enough detail to reconstruct the sequence of operations for a given session.
 
 #### L2.11 — Detached Proof Generation
 
@@ -160,6 +170,7 @@ All Level 2 requirements, plus:
 | L3.23 | Build delegation proof JWT for outbound calls | `src/delegation/__tests__/outbound-proof.test.ts` | All tests |
 | L3.24 | Build delegation chain string | `src/delegation/__tests__/outbound-proof.test.ts` | `buildChainString` tests |
 | L3.25 | Return `needs_authorization` hints | Implementation-specific | — |
+| L3.26 | Audit logging MUST be implemented | — | Implementation-specific |
 
 ### Detailed Requirements
 
@@ -200,6 +211,18 @@ When revoking a delegation, implementation MUST:
 - Recursively mark all descendants as revoked
 - Update StatusList2021 for each revoked delegation
 - Emit revocation events (implementation-specific)
+
+#### L3.26 — Audit Logging
+
+Audit logging MUST be implemented at Level 3. Implementations MUST record:
+- Delegation issuance and revocation events (including cascading revocations), with issuer DID, subject DID, credential ID, and timestamp
+- Delegation verification outcomes (pass/fail), including chain validation results
+- Outbound delegation proof attachments, including the chain string and target audience
+- Any `needs_authorization` hints returned to callers
+
+Audit records MUST be tamper-evident (e.g., append-only log, signed entries, or equivalent) and MUST be retained for at least the duration of the longest-lived delegation in the system.
+
+> **Note:** Revocation is verifier-local (checked against the verifier's local list or cache). L1 implementations MAY use simple local checks; higher levels MAY use StatusList2021.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,6 +278,8 @@ The nonce cache implementation MUST:
 - Be atomic to prevent race conditions in concurrent environments
 - For distributed deployments: use Redis, DynamoDB, or Cloudflare KV (not in-memory)
 
+Nonce lifetime MUST exceed the session TTL. Servers MUST NOT drop nonces before the lifetime expires, to prevent replay attacks via early eviction.
+
 ---
 
 ## 6. Delegation
@@ -305,6 +307,8 @@ interface DelegationRecord {
 ```
 
 ### 6.2 DelegationCredential as W3C VC
+
+> **Note:** A Delegation credential is itself a W3C Verifiable Credential. The Delegation Registry is a specialized index of delegations, which are VCs.
 
 Delegations are issued as W3C Verifiable Credentials:
 
@@ -515,9 +519,27 @@ KYA-OS uses the W3C StatusList2021 specification for revocation:
 }
 ```
 
+L1 implementations do not require revocation support; revocation checking is available at L3 only.
+
+### 6.7 Orchestration & Extensibility
+
+Orchestration scope is service-local; directory federation is out of scope for this version. Delegation graphs and revocation state are managed within a single service boundary and are not synchronized across independent KYA-OS deployments or external agent directories (e.g. NANDA).
+
 - Each delegation is assigned a `statusListIndex` (0 to 131071)
 - Bit at index is 0 = valid, 1 = revoked
 - Bitstring is gzip-compressed and base64-encoded
+
+### 6.8 Protocol Registry
+
+The registry indexes anything addressable by DID — agents, MCP servers, services, and delegation policies.
+
+Three registry types are defined within the protocol:
+
+- **Delegation Registry** — stores `DelegationCredential` objects and supports querying by issuer, subject, scope, and revocation status.
+- **Credential Registry** — stores all W3C Verifiable Credentials issued within the ecosystem, providing a general-purpose VC index.
+- **Trust Registry** — indexes entities by DID for discovery, enabling participants to resolve trust relationships and verify standing.
+
+`DelegationCredential` IS a Verifiable Credential; Delegation Registry is a specialized Credential Registry view.
 
 ---
 
@@ -625,6 +647,69 @@ The proof is attached to tool responses in the `_meta` field:
 The response hash is computed over the response object with `_meta` removed. Implementations MUST NOT rely on signature coverage of `_meta` fields. Verifiers SHOULD treat `_meta` as containing only `proof` unless the session config explicitly enables additional `_meta` fields via `session.metaPolicy`.
 
 When `session.metaPolicy` is set to `strict` (the default), verifiers MUST reject responses whose `_meta` contains keys other than `proof`. When set to `allow-extensions`, verifiers permit additional keys in `_meta` but MUST NOT include them in any hash computation or signature verification.
+
+### 7.7 Delegation Chain Audit Example
+
+The following shows how audit records link across a 3-level delegation chain: User → Agent A → Agent B → tool call.
+
+**Step 1 — User delegates to Agent A**
+
+```json
+{
+  "id": "urn:uuid:1111-aaaa",
+  "type": "DelegationCredential",
+  "issuer": "did:web:user.example.com",
+  "credentialSubject": {
+    "id": "did:web:agent-a.example.com",
+    "parentDelegation": null,
+    "scope": "files:read files:write"
+  }
+}
+```
+
+**Step 2 — Agent A delegates to Agent B**
+
+```json
+{
+  "id": "urn:uuid:2222-bbbb",
+  "type": "DelegationCredential",
+  "issuer": "did:web:agent-a.example.com",
+  "credentialSubject": {
+    "id": "did:web:agent-b.example.com",
+    "parentDelegation": "urn:uuid:1111-aaaa",
+    "scope": "files:read"
+  }
+}
+```
+
+The `parentDelegation` field links this record back to the User → Agent A credential, forming a verifiable chain.
+
+**Step 3 — Agent B calls a tool; the server generates an audit record**
+
+```json
+{
+  "content": [{ "type": "text", "text": "file contents..." }],
+  "_meta": {
+    "proof": {
+      "jws": "eyJhbGciOiJFZERTQSJ9...",
+      "meta": {
+        "did": "did:web:tool-server.example.com",
+        "kid": "did:web:tool-server.example.com#key-1",
+        "ts": 1710288120,
+        "nonce": "xyz789",
+        "audience": "did:web:tool-server.example.com",
+        "sessionId": "kyaos_f1e2d3c4-...",
+        "requestHash": "sha256:aabbcc...",
+        "responseHash": "sha256:ddeeff...",
+        "delegationRef": "urn:uuid:2222-bbbb",
+        "clientDid": "did:web:agent-b.example.com"
+      }
+    }
+  }
+}
+```
+
+The `delegationRef` in the proof points to Agent B's delegation credential (`urn:uuid:2222-bbbb`), which in turn carries `parentDelegation: urn:uuid:1111-aaaa` back to the original user grant. An auditor can reconstruct the full chain — User → Agent A → Agent B → tool call — by following `delegationRef` → `parentDelegation` links. All three records are independently verifiable offline using the signers' DID documents.
 
 ---
 


### PR DESCRIPTION
Batch of small documentation clarifications. No protocol behavior changes, no code, no schema changes. SPEC.md +85, CONFORMANCE.md +23, CHANGELOG.md +11.

## What changes

**Revocation scope, verifier-local.** §6.6 now explicitly states that L1 implementations do not require revocation support; revocation checking is available at L3 only. The previous wording could be read as requiring participation in a global revocation list. Now it is clear that revocation state lives within a single service boundary.

**Orchestration scope, service-local.** New §6.7 states that orchestration scope is service-local and that directory federation is out of scope for this version. Delegation graphs and revocation state are managed within a single deployment, not synchronized across independent KYA-OS deployments or external agent directories.

**Nonce lifetime MUST exceed session TTL.** §5 adds a single normative line: servers MUST NOT drop nonces before their lifetime expires. Closes a replay class where a server forgetting a nonce inside its still-valid session lets an attacker replay an old request whose nonce has been forgotten but whose session is still live.

**Multi-level audit-record example.** New §7.7 walks a 3-level chain: User to Agent A to Agent B to tool call. Each delegation credential includes `parentDelegation` linking back to the issuer's authority. The audit record on the final tool call references the bottom of the chain. Replaces the previous single-hop example which did not show how multi-agent reasoning chains get verified end to end.

**Conformance-tiered audit logging.** CONFORMANCE.md adds three rows: L1.11 MAY, L2.16 SHOULD, L3.26 MUST. Establishes a progression from "signature-verification only" to "audit-grade evidence with full chain reconstruction." Maps to a deliberate maturity ramp for implementers.

**Registry types disambiguated.** New §6.8 defines three distinct registry concepts: Delegation Registry (index of `DelegationCredential` objects), Credential Registry (general-purpose VC index), Trust Registry (entity discovery by DID). A new callout in §6.2 states that a Delegation credential IS a W3C Verifiable Credential and the Delegation Registry is a specialized view of the Credential Registry. Previous text used "registry" loosely and conflated three different concepts.

**Key Topics nav alignment.** Section ordering shifted to match the docs site's left navigation.

## Verified

- pnpm test 925/925 green
- pnpm lint clean
- pnpm build clean

## Scope notes

Only normative change is the nonce-lifetime MUST. Everything else is clarification or new explanatory content. Implementations conforming to the previous version remain conforming under this change, modulo the nonce-drop class which they should not have been doing anyway.
