### PR TITLE
chore: retire modelcontextprotocol-identity trademark domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://kya-os.ai">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://modelcontextprotocol-identity.io/images/logo-mark_white.svg">
-      <img alt="" src="https://modelcontextprotocol-identity.io/images/logo-mark_black.svg" width="64">
+      <source media="(prefers-color-scheme: dark)" srcset="https://kya-os.ai/mcp/images/logo-mark_white.svg">
+      <img alt="" src="https://kya-os.ai/mcp/images/logo-mark_black.svg" width="64">
     </picture>
   </a>
 </p>
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@kya-os/mcp"><img src="https://img.shields.io/npm/v/@kya-os/mcp" alt="npm"></a>
-  <a href="https://modelcontextprotocol-identity.io"><img src="https://img.shields.io/badge/spec-KYA--OS-blue" alt="spec"></a>
+  <a href="https://kya-os.ai/mcp"><img src="https://img.shields.io/badge/spec-KYA--OS-blue" alt="spec"></a>
   <a href="https://identity.foundation/working-groups/agent-and-authorization.html"><img src="https://img.shields.io/badge/DIF-TAAWG-purple" alt="DIF TAAWG"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/decentralized-identity/kya-os-mcp" alt="license"></a>
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -316,7 +316,7 @@ Delegations are issued as W3C Verifiable Credentials:
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation.v1.0.0.json"
+    "https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json"
   ],
   "id": "urn:uuid:d7f8a9b0-1234-5678-9abc-def012345678",
   "type": ["VerifiableCredential", "DelegationCredential"],

--- a/examples/outbound-delegation/README.md
+++ b/examples/outbound-delegation/README.md
@@ -111,4 +111,4 @@ const response = await fetch(targetUrl, {
 ## Related Spec
 
 - KYA-OS §7 — Outbound Delegation Propagation
-- [modelcontextprotocol-identity.io](https://modelcontextprotocol-identity.io)
+- [kya-os.ai/mcp](https://kya-os.ai/mcp)

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -67,7 +67,7 @@ except ValidationError as e:
 All schemas use JSON Schema draft 2020-12 and are published at:
 
 ```
-https://schema.modelcontextprotocol-identity.io/xmcp-i/{category}/{schema-name}.v1.0.0.json
+https://schema.kya-os.ai/xmcp-i/{category}/{schema-name}.v1.0.0.json
 ```
 
 Schemas can reference each other using `$ref`. For example, the delegation credential schema references shared definitions for constraints and proof structures.

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation-credential.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/xmcp-i/credentials/delegation-credential.v1.0.0.json",
   "title": "KYA-OS Delegation Credential",
   "description": "W3C Verifiable Credential containing a KYA-OS delegation with CRISP constraints.",
   "type": "object",
@@ -286,7 +286,7 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation.v1.0.0.json"
+        "https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json"
       ],
       "id": "urn:uuid:12345678-1234-1234-1234-123456789abc",
       "type": ["VerifiableCredential", "DelegationCredential"],

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/proof/detached-proof.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/xmcp-i/proof/detached-proof.v1.0.0.json",
   "title": "KYA-OS Detached Proof",
   "description": "Cryptographic proof binding an MCP tool request/response pair to an agent's identity and session context.",
   "type": "object",

--- a/schemas/handshake-request.json
+++ b/schemas/handshake-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/handshake/handshake-request.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/xmcp-i/handshake/handshake-request.v1.0.0.json",
   "title": "KYA-OS Handshake Request",
   "description": "Client-initiated handshake request to establish a KYA-OS session with nonce-based replay protection.",
   "type": "object",

--- a/schemas/handshake-response.json
+++ b/schemas/handshake-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/handshake/handshake-response.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/xmcp-i/handshake/handshake-response.v1.0.0.json",
   "title": "KYA-OS Handshake Response",
   "description": "Server response to a successful handshake request, establishing session context.",
   "type": "object",

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.modelcontextprotocol-identity.io/xmcp-i/discovery/well-known-kyaos.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/xmcp-i/discovery/well-known-kyaos.v1.0.0.json",
   "title": "KYA-OS Discovery Document",
   "description": "Well-known discovery document served at /.well-known/mcp for KYA-OS service discovery.",
   "type": "object",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@
  * KYA-OS Canonical Error Codes
  *
  * Single source of truth for all wire-format error codes.
- * Aligned with the error catalog at modelcontextprotocol-identity.io.
+ * Aligned with the error catalog at kya-os.ai/mcp.
  *
  * Naming convention: snake_case, no protocol prefix.
  * Follows OAuth 2.0 / Stripe conventions for readability and portability.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Delegation, proof, and session for Model Context Protocol Identity.
  * This package is a DIF TAAWG protocol reference implementation.
  *
- * Related Spec: https://modelcontextprotocol-identity.io
+ * Related Spec: https://kya-os.ai/mcp
  *
  * ## Error handling strategy
  *

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -118,7 +118,7 @@ export interface DelegationCredential {
 }
 
 export const DELEGATION_CREDENTIAL_CONTEXT =
-  'https://schema.modelcontextprotocol-identity.io/xmcp-i/credentials/delegation.v1.0.0.json' as const;
+  'https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json' as const;
 
 // ============================================================================
 // StatusList2021 (W3C)


### PR DESCRIPTION
## What

DIF trademark request: remove the `modelcontextprotocol-identity` host from the donated repo.

- **Schema `$id` host** — `schema.modelcontextprotocol-identity.io` → `schema.kya-os.ai` across the 5 schemas, `SPEC.md`, `schemas/README.md`, `src/types/protocol.ts`, and the `delegation-credential.json` context `$ref`. **Host-only swap; paths unchanged.** Nothing dereferences these `$id`s over the wire (no ref-resolver, no `fetch`, all internal `#/$defs`), so this is a safe identifier relabel.
- **Docs/spec links, README logo + badge, src comments** — `modelcontextprotocol-identity.io` → `kya-os.ai/mcp`.

## Verification

- `rg modelcontextprotocol-identity` → **0 hits**.
- All 5 schema files validate as JSON.
