### PR TITLE
feat: export base64url byte helpers from package entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- Export the byte-variant base64url helpers (`base64urlEncodeFromBytes`, `base64urlDecodeToBytes`) from the package entry point. They existed in `src/utils/base64.ts` but were not on the public API; downstream consumers need them for DID/JWK key encoding.
+
 ### Docs
 
 - Tightened two capability-language hits inside the spec that survived the Responsible Party rename: §8.2 `DelegationProofJWT.sub` comment now describes the Responsible Party explicitly (was "User DID (on whose behalf)"), and the `userDid` field description in `schemas/delegation-credential.json` now reads "whose delegated authority the agent exercises" instead of "on whose behalf the delegation acts."

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,12 @@ export {
   type KyaOsErrorResponse,
 } from './errors.js';
 
+// Encoding utilities (RFC 4648 base64url, byte variants)
+export {
+  base64urlEncodeFromBytes,
+  base64urlDecodeToBytes,
+} from './utils/base64.js';
+
 // Protocol types
 export type {
   DelegationConstraints,


### PR DESCRIPTION
Exports the byte-variant base64url helpers (base64urlEncodeFromBytes, base64urlDecodeToBytes) from the package entry point.

They already existed in src/utils/base64.ts but were not on the public API. The spec site needs them for DID/JWK key encoding, so this re-exports them from src/index.ts.

Additive only. build + all 1850 tests green. Required before the spec site can switch its dependency from the pre-donation @kya-os/mcp-i-core to @kya-os/mcp.