### PR TITLE
feat(delegation): reject claim-contaminated DelegationCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - Added test coverage pinning the warn-once behavior on both unsafe-mode
   flags: warns exactly once per process on opt-in, silent on safe defaults,
   no duplicate warnings across repeated `wrapWithDelegation` calls.
+- **Verifier rejects claim-contaminated delegation credentials.** A
+  `DelegationCredential` whose `credentialSubject` carries properties beyond
+  `id` and `delegation` is now rejected by default: claim-bearing fields in a
+  permission credential separate designation from authorization (the
+  confused-deputy class — `SPEC.md` §6.2 / §11.6). The reference verifier
+  exposes `allowNonDelegationSubjectFields` (default `false`) as an audited
+  opt-out that logs a one-time per-process warning. Spec-conformant issuers are
+  unaffected — the reference issuer already emits `{ id, delegation }` subjects,
+  and the full suite passes unchanged. New conformance requirement L3.5a.
 
 ### Added
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -150,6 +150,7 @@ All Level 2 requirements, plus:
 | L3.3 | Support issuance options (id, dates, status) | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should pass options to wrapDelegationAsVC` |
 | L3.4 | Canonicalize VC before signing | `src/delegation/__tests__/vc-issuer.test.ts` | `issueDelegationCredential > should canonicalize VC before signing` |
 | L3.5 | Verify DelegationCredential basic properties | `src/delegation/__tests__/vc-verifier.test.ts` | `verifyDelegationCredential - Basic Validation Stage` (all tests) |
+| L3.5a | Reject claim-contaminated `credentialSubject` (only `id` + `delegation`) | `src/delegation/__tests__/vc-verifier.test.ts` | `Subject Shape (claim contamination) > rejects a credentialSubject carrying non-delegation (claim) fields` |
 | L3.6 | Reject expired credentials | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject expired credentials` |
 | L3.7 | Reject not-yet-valid credentials | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject not-yet-valid credentials` |
 | L3.8 | Reject revoked credentials (status field) | `src/delegation/__tests__/vc-verifier.test.ts` | `Basic Validation Stage > should reject revoked credentials` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -355,6 +355,19 @@ Delegations are issued as W3C Verifiable Credentials:
 }
 ```
 
+A `DelegationCredential` carries a _permission_, not a _claim_. To keep claim
+semantics out of an authorization decision — a confused-deputy vector (§11.6) —
+the `credentialSubject` MUST contain only two properties: `id` (the delegate's
+DID) and `delegation` (the permission payload). A verifier MUST reject a
+`DelegationCredential` whose `credentialSubject` carries any other property, and
+MUST reject a credential whose `type` array does not include both
+`VerifiableCredential` and `DelegationCredential`.
+
+Implementations MAY offer an explicit, audited opt-out of the `credentialSubject`
+shape check to bridge non-conformant issuers. Such an opt-out MUST default to off
+and MUST emit a one-time warning when enabled, so the relaxation is visible in
+operational logs.
+
 ### 6.3 CRISP Constraint Envelope
 
 ```typescript

--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -276,6 +276,73 @@ describe("DelegationCredentialVerifier", () => {
     });
   });
 
+  describe("verifyDelegationCredential - Subject Shape (claim contamination)", () => {
+    // A DelegationCredential `credentialSubject` MUST carry only `id` and
+    // `delegation`. Claim-bearing fields alongside a permission separate
+    // designation from authorization — the confused-deputy class (KYA-OS §11.6).
+    const contaminatedVC: DelegationCredential = {
+      ...mockValidVC,
+      credentialSubject: {
+        ...mockValidVC.credentialSubject,
+        // `alumniOf` is a canonical W3C VC *claim*; it has no place in a
+        // delegation (permission) credential.
+        alumniOf: "did:web:example.edu",
+      } as DelegationCredential["credentialSubject"],
+    };
+
+    it("rejects a credentialSubject carrying non-delegation (claim) fields", async () => {
+      await setupDefaultContractsMocks();
+
+      const result = await verifier.verifyDelegationCredential(contaminatedVC, {
+        skipSignature: true,
+        skipStatus: true,
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.stage).toBe("basic");
+      expect(result.reason).toMatch(/non-delegation field/i);
+      expect(result.reason).toContain("alumniOf");
+    });
+
+    it("accepts contaminated subject under allowNonDelegationSubjectFields, warning once per process", async () => {
+      await setupDefaultContractsMocks();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const first = await verifier.verifyDelegationCredential(contaminatedVC, {
+        skipSignature: true,
+        skipStatus: true,
+        allowNonDelegationSubjectFields: true,
+      });
+      const second = await verifier.verifyDelegationCredential(contaminatedVC, {
+        skipSignature: true,
+        skipStatus: true,
+        skipCache: true,
+        allowNonDelegationSubjectFields: true,
+      });
+
+      expect(first.valid).toBe(true);
+      expect(second.valid).toBe(true);
+      // One-time per-process warning, not once per verification.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(
+        /allowNonDelegationSubjectFields/,
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("accepts a well-formed subject carrying only id and delegation", async () => {
+      await setupDefaultContractsMocks();
+
+      const result = await verifier.verifyDelegationCredential(mockValidVC, {
+        skipSignature: true,
+        skipStatus: true,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
   describe("verifyDelegationCredential - Signature Verification", () => {
     it("should skip signature verification when skipSignature is true", async () => {
       await setupDefaultContractsMocks();

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -21,6 +21,18 @@ import {
   validateDelegationCredential,
 } from "../types/protocol.js";
 
+/**
+ * Properties a DelegationCredential `credentialSubject` may carry. Anything
+ * else is treated as a claim-intended field and rejected by default — a
+ * permission credential must not smuggle claims (KYA-OS §11.6).
+ */
+const DELEGATION_SUBJECT_KEYS: readonly string[] = ["id", "delegation"];
+
+// Module-level warn-once flag for the unsafe opt-out in validateSubjectShape.
+// Per-process, mirroring the convention in middleware/with-kya-os.ts so
+// operators see a single log line rather than one per verification.
+let warnedNonDelegationSubjectFields = false;
+
 export interface DelegationVCVerificationResult {
   valid: boolean;
   reason?: string;
@@ -45,6 +57,15 @@ export interface VerifyDelegationVCOptions {
   skipStatus?: boolean;
   didResolver?: DIDResolver;
   statusListResolver?: StatusListResolver;
+  /**
+   * Accept a delegation credential whose `credentialSubject` carries properties
+   * beyond `id` and `delegation` (e.g. claim-bearing fields). UNSAFE: mixing
+   * claim semantics into a permission credential separates designation from
+   * authorization — the root of the confused-deputy class (KYA-OS §11.6).
+   * Defaults to `false` (strict). When `true`, the verifier emits a one-time
+   * per-process warning and accepts the credential.
+   */
+  allowNonDelegationSubjectFields?: boolean;
 }
 
 export interface DIDResolver {
@@ -139,7 +160,7 @@ export class DelegationCredentialVerifier {
     }
 
     const basicCheckStart = Date.now();
-    const basicValidation = this.validateBasicProperties(vc);
+    const basicValidation = this.validateBasicProperties(vc, options);
     const basicCheckMs = Date.now() - basicCheckStart;
 
     if (!basicValidation.valid) {
@@ -221,7 +242,10 @@ export class DelegationCredentialVerifier {
     return result;
   }
 
-  private validateBasicProperties(vc: DelegationCredential): {
+  private validateBasicProperties(
+    vc: DelegationCredential,
+    options: VerifyDelegationVCOptions,
+  ): {
     valid: boolean;
     reason?: string;
   } {
@@ -257,7 +281,51 @@ export class DelegationCredentialVerifier {
       return { valid: false, reason: "Missing proof" };
     }
 
+    const subjectShape = this.validateSubjectShape(vc, options);
+    if (!subjectShape.valid) {
+      return subjectShape;
+    }
+
     return { valid: true };
+  }
+
+  /**
+   * Reject a delegation credential whose `credentialSubject` carries properties
+   * other than `id` and `delegation`. Claim-bearing fields in a permission
+   * credential separate designation from authorization — the confused-deputy
+   * class (KYA-OS §11.6). Strict by default; the unsafe opt-out emits a
+   * one-time per-process warning.
+   */
+  private validateSubjectShape(
+    vc: DelegationCredential,
+    options: VerifyDelegationVCOptions,
+  ): { valid: boolean; reason?: string } {
+    const extraneous = Object.keys(vc.credentialSubject).filter(
+      (key) => !DELEGATION_SUBJECT_KEYS.includes(key),
+    );
+
+    if (extraneous.length === 0) {
+      return { valid: true };
+    }
+
+    if (options.allowNonDelegationSubjectFields) {
+      if (!warnedNonDelegationSubjectFields) {
+        warnedNonDelegationSubjectFields = true;
+        console.warn(
+          `[DelegationCredentialVerifier] allowNonDelegationSubjectFields is enabled — ` +
+            `accepting credentialSubject with non-delegation field(s): ${extraneous.join(", ")}. ` +
+            `Claim-bearing fields in a permission credential are a confused-deputy risk (KYA-OS §11.6).`,
+        );
+      }
+      return { valid: true };
+    }
+
+    return {
+      valid: false,
+      reason:
+        `credentialSubject contains non-delegation field(s): ${extraneous.join(", ")}. ` +
+        `A DelegationCredential subject MUST carry only 'id' and 'delegation' (KYA-OS §11.6).`,
+    };
   }
 
   private async verifySignature(


### PR DESCRIPTION
## Summary

A `DelegationCredential` carries a **permission**, not a **claim**. Today the verifier accepts a credential whose `credentialSubject` carries arbitrary extra (claim-bearing) properties alongside the `delegation` payload. Mixing claim semantics into a permission credential separates designation from authorization — the confused-deputy class (`SPEC.md` §6.2 / §11.6, and the reviewer feedback that motivated the §6.4.1 designation invariant).

This PR closes the claim-contamination half of that hardening. (The type-marker half — `type` MUST include `DelegationCredential` — was already enforced in `validateDelegationCredential`.)

## What changed

- **Verifier (`src/delegation/vc-verifier.ts`):** a new `validateSubjectShape` step in the basic stage rejects any `DelegationCredential` whose `credentialSubject` carries properties other than `id` and `delegation`.
- **Strict by default, audited opt-out:** `allowNonDelegationSubjectFields` (default `false`) bridges non-conformant issuers and emits a **one-time per-process warning** — same shape as `requireAudienceOnRedelegation` (#56) and `allowLegacyUnsafeDelegation` (#58).
- **SPEC §6.2:** normative MUST on `credentialSubject` shape + the existing type-marker, with the opt-out caveat (MUST default off, MUST warn).
- **CONFORMANCE L3.5a:** new requirement mapped to a named test.
- **CHANGELOG:** entry under `[Unreleased]`.
- **Tests:** 3 new (`reject contamination`, `opt-out warns once per process`, `clean-VC regression guard`).

## Design notes (for review)

- **Policy lives in the verifier, not the shared structural validator.** `protocol.ts:validateDelegationCredential` is untouched, so issuance and other consumers are unaffected — issuers build, verifiers enforce.
- **Scoped to `credentialSubject` top-level keys only** — deliberately *not* `delegation.*` / `constraints.*` / `metadata`, which are legitimately CRISP-extensible. This keeps false-positives at zero.
- **JSON Schema left permissive on purpose.** The rule is policy with an opt-out, which a static schema can't express; flipping `additionalProperties: false` would break external schema-validators of opted-out credentials. The MUST lives in normative SPEC text + the verifier instead. Open to adding the schema constraint if reviewers prefer.

## Verification

- Full suite: **928/928** (baseline 925 + 3 new), 54 files, **zero regressions**.
- `npm run build` (tsc) exit 0 · `npm run lint` (eslint) exit 0.
- Red→green confirmed: new tests failed before the guard, pass after.

## Status

Opened for **Dylan's review** before merge — not auto-merging. Non-breaking for spec-conformant issuers (the reference issuer already emits `{ id, delegation }` subjects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
