### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Reflects the 1.3.1 release already published to npm (adds the base64url byte-helper exports from #66 to the public API).