### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-05-26
+
+### Security
+
+- **Verifier rejects claim-contaminated delegation credentials.** A
+  `DelegationCredential` whose `credentialSubject` carries properties beyond
+  `id` and `delegation` is now rejected by default — claim-bearing fields in a
+  permission credential separate designation from authorization (the
+  confused-deputy class, `SPEC.md` §6.2 / §11.6). The reference verifier exposes
+  `allowNonDelegationSubjectFields` (default `false`) as an audited opt-out that
+  logs a one-time per-process warning. Spec-conformant issuers are unaffected;
+  the reference issuer already emits `{ id, delegation }` subjects. New
+  conformance requirement L3.5a. (#67)
+
+### Changed
+
+- **Schema `$id` and JSON-LD `@context` hosts migrated** off the
+  `modelcontextprotocol-identity.io` trademark domain to the foundation-owned
+  `schema.kya-os.ai`. All five shipped JSON Schemas (`schemas/*.json`), the
+  spec's context references, and the `DELEGATION_CREDENTIAL_CONTEXT` constant
+  now resolve under `schema.kya-os.ai`; schemas are served identically at both
+  hosts during the migration window (no `$id` is 301-redirected). (#65)
+
+## [1.3.1] - 2026-05-26
+
+> These entries accreted across the 1.2.0 → 1.3.1 donation cutover and were
+> published without strict per-version sectioning. They are grouped here for
+> completeness; see `npm view @kya-os/mcp time` and git history for exact ship
+> points. A clean per-version backfill is tracked separately.
+
 ### Added
 
 - Export the byte-variant base64url helpers (`base64urlEncodeFromBytes`, `base64urlDecodeToBytes`) from the package entry point. They existed in `src/utils/base64.ts` but were not on the public API; downstream consumers need them for DID/JWK key encoding.
@@ -49,15 +79,6 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - Added test coverage pinning the warn-once behavior on both unsafe-mode
   flags: warns exactly once per process on opt-in, silent on safe defaults,
   no duplicate warnings across repeated `wrapWithDelegation` calls.
-- **Verifier rejects claim-contaminated delegation credentials.** A
-  `DelegationCredential` whose `credentialSubject` carries properties beyond
-  `id` and `delegation` is now rejected by default: claim-bearing fields in a
-  permission credential separate designation from authorization (the
-  confused-deputy class — `SPEC.md` §6.2 / §11.6). The reference verifier
-  exposes `allowNonDelegationSubjectFields` (default `false`) as an audited
-  opt-out that logs a one-time per-process warning. Spec-conformant issuers are
-  unaffected — the reference issuer already emits `{ id, delegation }` subjects,
-  and the full suite passes unchanged. New conformance requirement L3.5a.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.2.0",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Bookkeeping reconciliation for **`@kya-os/mcp@1.3.2`**, now **published and live on npm** (`latest`). This PR brings `main` in sync so its version metadata stops lagging the registry.

## Why this was needed

`main`'s `package.json` was stuck at **1.3.0** while npm `latest` was already **1.3.1** — the 1.3.1 version bump was never committed back to `main`. Publishing 1.3.2 cleanly required setting the version explicitly (a `patch` bump would have collided with the existing 1.3.1).

## What's in 1.3.2 (delta since npm 1.3.1 / commit `b1b093a`)

- **#67** — verifier rejects claim-contaminated `DelegationCredential`s (only `id` + `delegation` allowed in `credentialSubject`; audited `allowNonDelegationSubjectFields` opt-out). Conformance L3.5a.
- **#65** — schema `$id` / JSON-LD `@context` hosts migrated to `schema.kya-os.ai`.

## This PR's diff (3 files)

- `package.json` + `package-lock.json`: 1.3.0 → **1.3.2**
- `CHANGELOG.md`: new `[1.3.2]` section; the accreted `[Unreleased]` blob relabeled `[1.3.1]` with a note that it aggregates the 1.2.0→1.3.1 cutover (it was published without per-version sectioning).

## Verification

- Published from a clean `main` checkout: build + lint + suite **928/928** green, re-gated by `prepublishOnly` (clean→build→test) during publish.
- Tarball verified: 5 schemas shipped, **zero** `src`/tests, 182 files / 128 kB.
- Tagged **`v1.3.2`** → `251df74` and pushed (first release tag past `v1.2.0`).

## Follow-up (not in this PR)

The CHANGELOG still carries pre-existing drift — the `[1.3.1]` blob actually spans 1.2.0→1.3.1. A proper per-version backfill is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
