### PR TITLE
refactor: move schema ids to /v1/protocol (drop xmcp-i)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -316,7 +316,7 @@ Delegations are issued as W3C Verifiable Credentials:
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json"
+    "https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0"
   ],
   "id": "urn:uuid:d7f8a9b0-1234-5678-9abc-def012345678",
   "type": ["VerifiableCredential", "DelegationCredential"],

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -67,7 +67,7 @@ except ValidationError as e:
 All schemas use JSON Schema draft 2020-12 and are published at:
 
 ```
-https://schema.kya-os.ai/xmcp-i/{category}/{schema-name}.v1.0.0.json
+https://schema.kya-os.ai/v1/protocol/{family}/{resource}/v1.0.0
 ```
 
 Schemas can reference each other using `$ref`. For example, the delegation credential schema references shared definitions for constraints and proof structures.

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/xmcp-i/credentials/delegation-credential.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/v1/protocol/delegation/credential/v1.0.0",
   "title": "KYA-OS Delegation Credential",
   "description": "W3C Verifiable Credential containing a KYA-OS delegation with CRISP constraints.",
   "type": "object",
@@ -286,7 +286,7 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json"
+        "https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0"
       ],
       "id": "urn:uuid:12345678-1234-1234-1234-123456789abc",
       "type": ["VerifiableCredential", "DelegationCredential"],

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/xmcp-i/proof/detached-proof.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/v1/protocol/proof/detached/v1.0.0",
   "title": "KYA-OS Detached Proof",
   "description": "Cryptographic proof binding an MCP tool request/response pair to an agent's identity and session context.",
   "type": "object",

--- a/schemas/handshake-request.json
+++ b/schemas/handshake-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/xmcp-i/handshake/handshake-request.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/v1/protocol/handshake/request/v1.0.0",
   "title": "KYA-OS Handshake Request",
   "description": "Client-initiated handshake request to establish a KYA-OS session with nonce-based replay protection.",
   "type": "object",

--- a/schemas/handshake-response.json
+++ b/schemas/handshake-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/xmcp-i/handshake/handshake-response.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/v1/protocol/handshake/response/v1.0.0",
   "title": "KYA-OS Handshake Response",
   "description": "Server response to a successful handshake request, establishing session context.",
   "type": "object",

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/xmcp-i/discovery/well-known-kyaos.v1.0.0.json",
+  "$id": "https://schema.kya-os.ai/v1/protocol/well-known/v1.0.0",
   "title": "KYA-OS Discovery Document",
   "description": "Well-known discovery document served at /.well-known/mcp for KYA-OS service discovery.",
   "type": "object",

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -118,7 +118,7 @@ export interface DelegationCredential {
 }
 
 export const DELEGATION_CREDENTIAL_CONTEXT =
-  'https://schema.kya-os.ai/xmcp-i/credentials/delegation.v1.0.0.json' as const;
+  'https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0' as const;
 
 // ============================================================================
 // StatusList2021 (W3C)


### PR DESCRIPTION
Follow-up to #65, which merged with interim schema.kya-os.ai/xmcp-i ids. Restructures the schema identifiers to the architecture-doc layout:

- 5 schema ids: schema.kya-os.ai/xmcp-i/<family>/<name>.v1.0.0.json -> schema.kya-os.ai/v1/protocol/<family>/<resource>/v1.0.0
- DelegationCredential JSON-LD context -> /v1/protocol/delegation/context/v1.0.0 (schema example, SPEC.md, and the DELEGATION_CREDENTIAL_CONTEXT const)

Drops the xmcp-i namespace, the .json suffix, and the dot-version. All 3709 tests green; handshake schemas verified self-contained. Needs a subsequent npm publish to ship the new ids.