### PR TITLE
docs(spec): agent-controlled keypair MUST, medium clarifications, unsafe modes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ This policy covers the `@kya-os/mcp` npm package and this repository. It include
 
 ## Secure Defaults & Unsafe Delegation Modes
 
-`@kya-os/mcp` ships with secure-by-default behavior. As of 1.3.x, two delegation knobs are wired to safe values; both can be opted out of for backward compatibility, and both emit a one-time per-process warning when set unsafely so operators can spot the configuration in logs.
+`@kya-os/mcp` ships with secure-by-default behavior. As of 1.3.x, three delegation knobs are wired to safe values; each can be opted out of for backward compatibility, and each emits a one-time per-process warning when set unsafely so operators can spot the configuration in logs.
 
 ### `requireAudienceOnRedelegation` — default `true`
 
@@ -60,6 +60,22 @@ Setting this to `true` weakens verification:
 
 - **When to set to `true`:** integrations that have not yet provided `resolveDelegationChain` and `resolveStatusList` resolvers and need a controlled migration window. The middleware logs a warning on first use per process.
 - **Migration path:** wire up `delegationConfig.resolveDelegationChain` and `delegationConfig.resolveStatusList`, then remove this flag.
+
+### `allowNonDelegationSubjectFields` — default `false`
+
+A `DelegationCredential` carries a permission, not a claim: its `credentialSubject` MUST contain only `id` and `delegation` (`SPEC.md` §6.2). The verifier rejects any credential whose subject carries extra, claim-bearing fields, because mixing claim semantics into a permission credential is the root of the confused-deputy class (`SPEC.md` §11.6).
+
+Setting this to `true` accepts credentials whose `credentialSubject` carries non-delegation fields.
+
+- **When to set to `true`:** bridging a non-conformant issuer that emits claim-bearing subjects during migration. The verifier logs a warning on first use per process, naming the offending fields.
+- **Migration path:** move claim data out of the delegation subject (carry it in a separate credential), then remove this flag.
+
+### Protections with no opt-out
+
+Some safeguards have no escape hatch, by design:
+
+- **Replay / nonce caching.** The proof verifier requires a `NonceCacheProvider`; there is no flag to disable replay protection. Implementations MUST NOT disable nonce caching in production — doing so is non-conformant at Conformance Level 2+ (`CONFORMANCE.md` L2.5, `SPEC.md` §11.2) and is trivially vulnerable to replay.
+- **Verification bypass.** There is no "self-signed" or test-only mode that turns off signature or delegation-chain verification. `did:key` identities are appropriate for local development and testing (`SPEC.md` §4.1), but selecting that DID method does not weaken any verification step.
 
 ### What to do if you see the warning in production logs
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -207,6 +207,29 @@ The DID Document MUST contain at least one verification method with `publicKeyJw
 }
 ```
 
+### 4.5 Agent-Controlled Key Generation
+
+An agent MUST generate its own keypair locally. No other party generates,
+holds, escrows, or otherwise gains access to an agent's secret key at any
+point:
+
+1. The agent generates an Ed25519 keypair (§4.2) using a local CSPRNG.
+2. The agent derives its DID from the public key (`did:key`, §4.3) or publishes
+   a DID document referencing the public key (`did:web`, §4.4).
+3. Where a DID document is registered or published through a service, the agent
+   signs the registration request with its secret key.
+4. The service verifies the signature and publishes the document. It receives
+   the public key only.
+
+A registry (§6.8), verifier, or any registration or provisioning service MUST
+NOT generate, escrow, or otherwise gain access to an agent's secret key. This
+invariant keeps identity infrastructure from becoming a centralized key escrow:
+a compromise of a registry or verifier MUST NOT yield agent secret keys (see
+§11.11).
+
+Implementations that generate or hold agent secret keys on the agent's behalf
+are non-conformant.
+
 ---
 
 ## 5. Session Lifecycle
@@ -554,6 +577,42 @@ Three registry types are defined within the protocol:
 
 `DelegationCredential` IS a Verifiable Credential; Delegation Registry is a specialized Credential Registry view.
 
+Trust-registry rejection is advisory, not blocking. The cryptographic
+delegation check is the load-bearing gate (§11.0); registry standing is a
+secondary signal. Services SHOULD honor well-formed delegations from
+low-standing delegates but MAY apply rate limits, additional verification, or
+scope reduction. Outright rejection of well-formed delegations pushes the same
+authority through worse channels — credential sharing, request proxying — which
+reduces auditability rather than improving security.
+
+### 6.9 Ephemeral Delegate Keys (Non-Normative)
+
+A delegator MAY subject a `DelegationCredential` to a one-off ephemeral public
+key (typically a `did:key`) instead of a long-lived agent DID. This
+privacy-preserving pattern lets a chain authorize an action without correlating
+the delegate across unrelated delegations (§12.1).
+
+```json
+{
+  "credentialSubject": {
+    "id": "did:key:z6Mk-ephemeral-...",
+    "delegation": {
+      "id": "del-ephemeral-001",
+      "subjectDid": "did:key:z6Mk-ephemeral-...",
+      "parentId": "urn:uuid:...",
+      "constraints": { "scopes": ["files:read"] },
+      "status": "active"
+    }
+  }
+}
+```
+
+The ephemeral key signs presentations of this credential and is discarded once
+the delegation expires. The `credentialSubject` carries only `id` and
+`delegation`, so the example remains conformant with the subject-shape rule in
+§6.2. Implementations MAY support this pattern; it is not required for any
+conformance level.
+
 ---
 
 ## 7. Proof Generation
@@ -897,7 +956,7 @@ and the residual risk an operator carries.
 | **Scope escalation** — a delegated agent invokes outside the delegator's intent. | Scope subset enforcement at every chain link; CRISP `matcher: 'exact'` for sensitive resources. See §11.4. | Implementation bugs in scope-subset checks. |
 | **Confused deputy** — a multi-resource delegation is repurposed for resources the delegator did not anticipate. | Designation invariant (§6.4.1) + audience-on-redelegation default `true` (§11.6). | Implementation bugs in the designation check. |
 | **Credential theft** — a `DelegationCredential` is intercepted and used by an attacker. | `audience` constraint; short `notAfter`; session binding at high-security tiers (§11.8); StatusList2021 revocation. | Window between theft and revocation. |
-| **Agent abuse** — a legitimate agent exceeds expected behavior. | Audit log of every signed tool call (§7); reputation tracking on both agent and Responsible Party (§2); revocation. | Detection latency; damage done before revocation propagates. |
+| **Agent abuse** — a legitimate agent exceeds expected behavior. | Audit log of every signed tool call (§7); reputation tracking on both agent and Responsible Party (§11.12); revocation. | Detection latency; damage done before revocation propagates. |
 | **Key compromise** — an agent's secret key is exfiltrated. | Short-lived delegations; explicit revocation; key rotation via DID document update. | Window between compromise and detection. See §11.5. |
 | **Revocation race** — an invocation arrives while a revocation is propagating. | Status-list TTL bounded ≤ 60s for high-privilege scopes; side-channel revocation signals honored immediately; expiry as primary revocation mechanism. See §6.5.2. | Unavoidable Lamport-concurrent race. Operators bound the window; they cannot eliminate it. |
 | **Downgrade** — a client strips KYA-OS headers entirely. | Fail-closed: servers requiring identity MUST reject sessionless calls; `/.well-known/mcp` advertises requirements. See §11.7. | A non-compliant client that the operator has not configured to require identity. |
@@ -991,6 +1050,31 @@ deployment-level controls are:
 - Cascading revocation MUST be atomic
 - Status-list cache TTL SHOULD be ≤ 60 seconds for high-privilege scopes
 
+### 11.11 Key Custody and Escrow Exclusion
+
+KYA-OS excludes centralized agent-key generation as a failure mode. If a single
+service generated agent keypairs — even transiently — that service would hold
+the secret material for every identity it provisioned, recreating the escrow
+weakness of identity-based-encryption-style key-generation centers: one
+compromise yields every dependent secret key. Agent-controlled key generation
+(§4.5) removes that single point of total compromise. A registry or verifier
+that is breached leaks public material and metadata, never agent secret keys,
+because no protocol component ever holds them. Operators MUST NOT introduce a
+server-side key-generation or escrow step as a convenience; doing so is
+non-conformant (§4.5).
+
+### 11.12 Reputation Scope
+
+Reputation is tracked primarily on the Responsible Party — the root issuer
+accountable for a delegation chain (§2). Agent-level reputation, where
+surfaced, is a secondary signal scoped to a specific binding rather than a
+free-floating per-agent score. A newly minted agent inheriting authority from a
+high-reputation Responsible Party MUST be treated as carrying that party's
+standing for capability decisions, modulo binding-specific risk signals. This
+closes reputation laundering in both directions: a bad actor cannot shed a poor
+Responsible-Party history by spawning fresh agents, and a new agent under a
+trusted party is not penalized for lacking its own history.
+
 ---
 
 ## 12. Privacy Considerations
@@ -1046,6 +1130,17 @@ Implementation conformance requirements are defined in `CONFORMANCE.md`. Three c
 - **Level 3 — Full Delegation**: VC issuance/verification, delegation graphs, revocation, outbound propagation
 
 See `CONFORMANCE.md` for detailed requirements and test references.
+
+### 15.1 Relationship to OAuth Dynamic Client Registration
+
+KYA-OS L2+ is not OAuth Dynamic Client Registration restated. OAuth-DCR binds a
+client by a `client_id`/`client_secret` registered with an authorization server,
+after which authority rides on a bearer token. KYA-OS binds an agent by its DID
+and requires the delegation chain to be presented and cryptographically verified
+at every invocation (§6, §7). The delegation chain remains required and
+verifiable at Level 2 and Level 3 regardless of whether or how the agent's
+identity is recorded in a trust registry (§6.8). Registry presence is discovery
+and a trust signal (§11.0), never a substitute for chain verification.
 
 ---
 


### PR DESCRIPTION
Combines three READY doc-only tracker items into a single PR (per request).
Spec section numbers were adapted to the **current** `main` structure, which
differs from the numbers assumed in the tracker tasks.

## P2 — H5: agent-controlled keypair (HIGH)
- **§4.5 Agent-Controlled Key Generation** (new, normative). Agents MUST
  generate their own keypair locally; a registry (§6.8), verifier, or any
  registration/provisioning service MUST NOT generate, escrow, or access an
  agent secret key. Implementations that hold agent secret keys are
  non-conformant.
- **§11.11 Key Custody and Escrow Exclusion** (new). Frames centralized
  key generation as an IBE-style key-escrow failure mode and excludes it.
- *Adaptation:* this spec has no "DID Service" concept (DIDs are `did:key`
  local derivation or self-hosted `did:web`), so the invariant is mapped onto
  registry/verifier/provisioning components. Kept Ed25519 per §4.2 rather than
  introducing P-256.

## P3 — M3 / M5 / M7 / M8 (MEDIUM)
- **M3 → §15.1** Relationship to OAuth Dynamic Client Registration.
- **M5 → §6.8** trust-registry rejection is advisory, not blocking
  (complements the existing §11.0 advisory framing; cross-referenced).
- **M7 → §6.9** non-normative ephemeral delegate-key example. Rewritten to
  satisfy the §6.2 subject-shape rule (`credentialSubject` = `id` + `delegation`
  only) that landed on `main` after the tracker item was drafted.
- **M8 → §11.12** Reputation Scope (no §8 reputation section exists; placed in
  Security Considerations where reputation is already referenced). Threat-table
  reputation pointer repointed from §2 → §11.12.


## Verification
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — **928/928 pass** (the tracker's "1850" figure is stale; the
  current suite is 928 tests). Doc-only change; no test/code/schema files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)