### PR TITLE
feat: AuditLogProvider — pluggable sink for proof/audit retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Versioning: https://semver.org/spec/v2.0.0.html
   audience, scope, request/response hashes, and the verification result — never
   key material or nonces. The storage backend is operator-provided (durable,
   append-only); the package stays storage-agnostic, like the other providers.
+- **Delegation scope on audit records.** Delegation-protected tools record the
+  scope they were authorized under: `wrapWithDelegation` threads its `scopeId`
+  through a new optional `KyaOsCallContext` (3rd handler argument) into the proof
+  meta, so the audit record's `scope` reflects it (was `'-'`). The argument is
+  optional and backward-compatible; tool handlers that ignore it are unaffected.
 
 ## [1.4.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- **`AuditLogProvider` — pluggable sink for audit-record retention.** A new
+  provider (abstract base + `MemoryAuditLogProvider` / `NoopAuditLogProvider`
+  defaults, exported from the root and `./providers`) for persisting the frozen
+  `audit.v1` record of each verified tool call. Wire it via `KyaOsConfig.auditLog`
+  (default: no-op); `createKyaOsMiddleware` emits a record after each proofed
+  call, and a sink failure never breaks the tool response. `buildAuditRecord(ctx)`
+  exposes the context→record mapping. Records carry only DID/key id, session,
+  audience, scope, request/response hashes, and the verification result — never
+  key material or nonces. The storage backend is operator-provided (durable,
+  append-only); the package stays storage-agnostic, like the other providers.
+
 ## [1.4.0] - 2026-05-26
 
 ### Spec

--- a/src/delegation/__tests__/transitive-access.test.ts
+++ b/src/delegation/__tests__/transitive-access.test.ts
@@ -48,6 +48,10 @@ import { MemoryStatusListStorage } from '../storage/memory-statuslist-storage.js
 import {
   buildOutboundDelegationHeaders,
 } from '../outbound-headers.js';
+import {
+  MemoryAuditLogProvider,
+  type AuditLogProvider,
+} from '../../providers/audit-log.js';
 
 // ---------------------------------------------------------------------------
 // Shared identity helpers
@@ -130,6 +134,7 @@ async function issueVC(opts: {
 async function createServer(opts?: {
   delegation?: KyaOsDelegationConfig;
   autoSession?: boolean;
+  auditLog?: AuditLogProvider;
 }): Promise<{ middleware: KyaOsMiddleware; did: string }> {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
@@ -149,6 +154,7 @@ async function createServer(opts?: {
       session: { sessionTtlMinutes: 60 },
       delegation,
       autoSession: opts?.autoSession,
+      auditLog: opts?.auditLog,
     },
     crypto,
   );
@@ -1271,6 +1277,51 @@ describe('Transitive Access — Karp Use Cases', () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.error).toBe('delegation_invalid');
       expect(parsed.reason).toContain('must end with the leaf credential');
+    });
+  });
+
+  // =========================================================================
+  // 13. Audit scope from delegation
+  // =========================================================================
+
+  describe('13. Audit scope from delegation', () => {
+    it('records the delegation scope on the audit record for a verified delegated call', async () => {
+      const auditLog = new MemoryAuditLogProvider();
+      const { middleware, did: serverDid } = await createServer({
+        delegation: { resolveDelegationChain: async () => [aliceToBob] },
+        autoSession: true,
+        auditLog,
+      });
+
+      const aliceToBob = await issueVC({
+        from: alice,
+        to: bob,
+        scopes: ['query:x', 'update:y'],
+      });
+      const bobToCarol = await issueVC({
+        from: bob,
+        to: carol,
+        scopes: ['query:x'],
+        parentId: aliceToBob.credentialSubject.delegation.id,
+        audience: serverDid,
+      });
+
+      // Delegation-protected tool: wrapWithDelegation threads scopeId into the
+      // inner wrapWithProof, so the audit record carries the real scope, not '-'.
+      const handler = middleware.wrapWithDelegation(
+        'query_x',
+        { scopeId: 'query:x', consentUrl: 'https://aperture.example/consent' },
+        middleware.wrapWithProof('query_x', async () => ({
+          content: [{ type: 'text', text: 'query result' }],
+        })),
+      );
+
+      const result = await handler({ _kyaos_delegation: bobToCarol });
+
+      expect(result.isError).toBeUndefined();
+      expect(auditLog.records).toHaveLength(1);
+      expect(auditLog.records[0]!.scope).toBe('query:x');
+      expect(auditLog.records[0]!.verified).toBe('yes');
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,13 @@ export {
 
 export { NodeCryptoProvider } from './providers/node-crypto.js';
 
+export {
+  AuditLogProvider,
+  MemoryAuditLogProvider,
+  NoopAuditLogProvider,
+  buildAuditRecord,
+} from './providers/audit-log.js';
+
 // Middleware
 export {
   createKyaOsMiddleware,

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -16,10 +16,12 @@ import {
   base64ToBytes,
   base64urlEncodeFromBytes,
 } from '../../utils/base64.js';
+import { AuditLogProvider, MemoryAuditLogProvider } from '../../providers/audit-log.js';
 
 async function createTestMiddleware(options?: {
   autoSession?: boolean;
   delegation?: KyaOsDelegationConfig;
+  auditLog?: AuditLogProvider;
 }) {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
@@ -32,6 +34,7 @@ async function createTestMiddleware(options?: {
       session: { sessionTtlMinutes: 60 },
       delegation: options?.delegation,
       autoSession: options?.autoSession,
+      auditLog: options?.auditLog,
     },
     crypto,
   );
@@ -270,6 +273,60 @@ describe('createKyaOsMiddleware', () => {
       const result = await handler({}, sessionId);
       expect(result.isError).toBe(true);
       expect(result._meta).toBeUndefined();
+    });
+
+    it('logs an audit record to the configured AuditLogProvider after a proofed call', async () => {
+      const auditLog = new MemoryAuditLogProvider();
+      const { middleware: kyaos, did } = await createTestMiddleware({ auditLog });
+
+      const hs = await kyaos.handleHandshake({
+        nonce: 'audit-nonce',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'hi' }],
+      }));
+      await handler({}, sessionId);
+
+      expect(auditLog.records).toHaveLength(1);
+      const rec = auditLog.records[0]!;
+      expect(rec.version).toBe('audit.v1');
+      expect(rec.session).toBe(sessionId);
+      expect(rec.audience).toBe(did);
+      expect(rec.did).toBe(did);
+      expect(rec.verified).toBe('yes');
+      expect(rec.reqHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    });
+
+    it('does not break the tool response when the audit sink throws', async () => {
+      class ThrowingAuditLog extends AuditLogProvider {
+        async logAuditRecord(): Promise<void> {
+          throw new Error('sink down');
+        }
+        async logEvent(): Promise<void> {}
+      }
+      const { middleware: kyaos, did } = await createTestMiddleware({
+        auditLog: new ThrowingAuditLog(),
+      });
+
+      const hs = await kyaos.handleHandshake({
+        nonce: 'audit-nonce-2',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'hi' }],
+      }));
+      const result = await handler({}, sessionId);
+
+      // The proofed response must be intact despite the sink failure.
+      expect(result.content[0].text).toBe('hi');
+      expect(result._meta!.proof).toBeDefined();
     });
 
     it('should return result without proof when no session exists and autoSession is off', async () => {

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -329,6 +329,26 @@ describe('createKyaOsMiddleware', () => {
       expect(result._meta!.proof).toBeDefined();
     });
 
+    it('records the delegation scope when threaded via call context', async () => {
+      const auditLog = new MemoryAuditLogProvider();
+      const { middleware: kyaos, did } = await createTestMiddleware({ auditLog });
+
+      const hs = await kyaos.handleHandshake({
+        nonce: 'audit-scope-nonce',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'hi' }],
+      }));
+      // wrapWithDelegation threads its scopeId as the 3rd (context) argument.
+      await handler({}, sessionId, { scopeId: 'calendar:read' });
+
+      expect(auditLog.records[0]!.scope).toBe('calendar:read');
+    });
+
     it('should return result without proof when no session exists and autoSession is off', async () => {
       const { middleware: kyaos } = await createTestMiddleware({ autoSession: false });
 

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -121,12 +121,22 @@ export interface KyaOsToolDefinition {
   };
 }
 
+/**
+ * Per-call context threaded through the middleware wrappers (not part of the
+ * tool's public arguments). `wrapWithDelegation` populates `scopeId` so the
+ * proof and audit record reflect the scope the call was authorized under.
+ */
+export interface KyaOsCallContext {
+  scopeId?: string;
+}
+
 export interface KyaOsToolHandler<
   T extends Record<string, unknown> = Record<string, unknown>,
 > {
   (
     args: T,
     sessionId?: string,
+    context?: KyaOsCallContext,
   ): Promise<{
     content: Array<{ type: string; text: string; [key: string]: unknown }>;
     isError?: boolean;
@@ -541,8 +551,12 @@ export function createKyaOsMiddleware(
     toolName: string,
     handler: KyaOsToolHandler<T>,
   ): KyaOsToolHandler {
-    return async (args: Record<string, unknown>, sessionId?: string) => {
-      const result = await handler(args as T, sessionId);
+    return async (
+      args: Record<string, unknown>,
+      sessionId?: string,
+      context?: KyaOsCallContext,
+    ) => {
+      const result = await handler(args as T, sessionId, context);
 
       if (result.isError) {
         return result;
@@ -567,6 +581,7 @@ export function createKyaOsMiddleware(
           request,
           response,
           session,
+          { scopeId: context?.scopeId },
         );
 
         // Attach proof as _meta (rendered by MCP Inspector, invisible to LLMs)
@@ -951,7 +966,7 @@ export function createKyaOsMiddleware(
       logger.debug(
         `[kya-os] Delegation verified for "${toolName}", scope "${config.scopeId}"`,
       );
-      return handler(cleanArgs, sessionId);
+      return handler(cleanArgs, sessionId, { scopeId: config.scopeId });
     };
   }
 

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -19,6 +19,7 @@ import {
   type CryptoProvider,
   FetchProvider,
 } from "../providers/base.js";
+import { AuditLogProvider, NoopAuditLogProvider } from "../providers/audit-log.js";
 import {
   SessionManager,
   type SessionConfig,
@@ -101,6 +102,12 @@ export interface KyaOsConfig {
    * In production, KYA-OS-aware runtimes should execute handshake before tool calls.
    */
   autoSession?: boolean;
+  /**
+   * Sink for retaining audit records of verified tool calls. Defaults to a
+   * no-op; supply an {@link AuditLogProvider} (e.g. a durable, append-only
+   * implementation) to capture an audit trail.
+   */
+  auditLog?: AuditLogProvider;
 }
 
 export interface KyaOsToolDefinition {
@@ -315,6 +322,7 @@ export function createKyaOsMiddleware(
 
   const proofGenerator = new ProofGenerator(identity, cryptoProvider);
   const delegationConfig = config.delegation;
+  const auditLog = config.auditLog ?? new NoopAuditLogProvider();
 
   // Session map: sessionId → last nonce (for proof generation)
   const sessionNonces = new Map<string, string>();
@@ -563,6 +571,27 @@ export function createKyaOsMiddleware(
 
         // Attach proof as _meta (rendered by MCP Inspector, invisible to LLMs)
         result._meta = { proof };
+
+        // Hand the verified call to the audit sink. A sink failure MUST NOT
+        // break the tool response, so it is logged and swallowed.
+        try {
+          await auditLog.logAuditRecord({
+            identity: { did: identity.did, kid: identity.kid },
+            session: { sessionId: session.sessionId, audience: session.audience },
+            requestHash: proof.meta.requestHash,
+            responseHash: proof.meta.responseHash,
+            verified: "yes",
+            scopeId: proof.meta.scopeId,
+          });
+        } catch (auditError) {
+          logger.error("[kya-os] Audit log failed", {
+            tool: toolName,
+            error:
+              auditError instanceof Error
+                ? auditError.message
+                : String(auditError),
+          });
+        }
       } catch (error) {
         logger.error("[kya-os] Proof generation failed", {
           tool: toolName,

--- a/src/providers/__tests__/audit-log.test.ts
+++ b/src/providers/__tests__/audit-log.test.ts
@@ -34,6 +34,35 @@ describe("buildAuditRecord", () => {
     const { scopeId: _omit, ...noScope } = ctx;
     expect(buildAuditRecord(noScope).scope).toBe("-");
   });
+
+  it("maps a failed verification (verified: 'no')", () => {
+    expect(buildAuditRecord({ ...ctx, verified: "no" }).verified).toBe("no");
+  });
+
+  it("never leaks context fields beyond the frozen record (no private key, no nonce)", () => {
+    // AuditContext.identity/session allow passthrough fields; the record MUST NOT
+    // carry anything beyond the 10 frozen audit.v1 fields — never key material or nonces.
+    const record = buildAuditRecord({
+      ...ctx,
+      identity: { ...ctx.identity, privateKey: "SECRET_KEY" },
+      session: { ...ctx.session, nonce: "SECRET_NONCE" },
+    });
+    expect(Object.keys(record).sort()).toEqual(
+      [
+        "audience",
+        "did",
+        "kid",
+        "reqHash",
+        "resHash",
+        "scope",
+        "session",
+        "ts",
+        "verified",
+        "version",
+      ].sort(),
+    );
+    expect(JSON.stringify(record)).not.toContain("SECRET");
+  });
 });
 
 describe("MemoryAuditLogProvider", () => {

--- a/src/providers/__tests__/audit-log.test.ts
+++ b/src/providers/__tests__/audit-log.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAuditRecord,
+  MemoryAuditLogProvider,
+  NoopAuditLogProvider,
+} from "../audit-log.js";
+import type { AuditContext, AuditEventContext } from "../../types/protocol.js";
+
+const ctx: AuditContext = {
+  identity: { did: "did:key:zAlice", kid: "did:key:zAlice#keys-1" },
+  session: { sessionId: "kyaos_123", audience: "did:web:server.example" },
+  requestHash: "sha256:" + "a".repeat(64),
+  responseHash: "sha256:" + "b".repeat(64),
+  verified: "yes",
+  scopeId: "calendar:read",
+};
+
+describe("buildAuditRecord", () => {
+  it("maps an AuditContext to a frozen audit.v1 record", () => {
+    const rec = buildAuditRecord(ctx);
+    expect(rec.version).toBe("audit.v1");
+    expect(rec.session).toBe("kyaos_123");
+    expect(rec.audience).toBe("did:web:server.example");
+    expect(rec.did).toBe("did:key:zAlice");
+    expect(rec.kid).toBe("did:key:zAlice#keys-1");
+    expect(rec.reqHash).toBe(ctx.requestHash);
+    expect(rec.resHash).toBe(ctx.responseHash);
+    expect(rec.verified).toBe("yes");
+    expect(rec.scope).toBe("calendar:read");
+    expect(typeof rec.ts).toBe("number");
+  });
+
+  it("uses '-' for scope when scopeId is absent", () => {
+    const { scopeId: _omit, ...noScope } = ctx;
+    expect(buildAuditRecord(noScope).scope).toBe("-");
+  });
+});
+
+describe("MemoryAuditLogProvider", () => {
+  it("stores a built record on logAuditRecord", async () => {
+    const p = new MemoryAuditLogProvider();
+    await p.logAuditRecord(ctx);
+    expect(p.records).toHaveLength(1);
+    expect(p.records[0]?.session).toBe("kyaos_123");
+    expect(p.records[0]?.version).toBe("audit.v1");
+  });
+
+  it("deduplicates audit records per session (one record per session)", async () => {
+    const p = new MemoryAuditLogProvider();
+    await p.logAuditRecord(ctx);
+    await p.logAuditRecord({ ...ctx, requestHash: "sha256:" + "c".repeat(64) }); // same session
+    expect(p.records).toHaveLength(1);
+
+    await p.logAuditRecord({
+      ...ctx,
+      session: { sessionId: "kyaos_999", audience: ctx.session.audience },
+    });
+    expect(p.records).toHaveLength(2);
+  });
+
+  it("logEvent records every event without session dedup", async () => {
+    const p = new MemoryAuditLogProvider();
+    const ev: AuditEventContext = {
+      eventType: "consent:approved",
+      identity: ctx.identity,
+      session: ctx.session,
+    };
+    await p.logEvent(ev);
+    await p.logEvent(ev);
+    expect(p.events).toHaveLength(2);
+  });
+});
+
+describe("NoopAuditLogProvider", () => {
+  it("is a no-op that resolves without error", async () => {
+    const p = new NoopAuditLogProvider();
+    await expect(p.logAuditRecord(ctx)).resolves.toBeUndefined();
+    await expect(
+      p.logEvent({ eventType: "x", identity: ctx.identity, session: ctx.session }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/providers/audit-log.ts
+++ b/src/providers/audit-log.ts
@@ -9,7 +9,7 @@
  * defaults — durable backends (Postgres, object storage, append-only log)
  * are operator-provided, keeping the package storage-agnostic exactly like
  * `CryptoProvider` / `NonceCacheProvider`. Audit records are intended for a
- * durable, append-only store; see `SECURITY.md` for retention guidance.
+ * durable, append-only store; see `SPEC.md` §12.4 (Proof Retention) for guidance.
  */
 
 import type {

--- a/src/providers/audit-log.ts
+++ b/src/providers/audit-log.ts
@@ -1,0 +1,98 @@
+/**
+ * Audit Log Provider
+ *
+ * Platform-agnostic seam for retaining KYA-OS audit records and events.
+ *
+ * The protocol attaches a detached proof to each tool response; an
+ * `AuditLogProvider` is the pluggable sink an operator supplies to *persist*
+ * those records as an audit trail. The package ships in-memory and no-op
+ * defaults — durable backends (Postgres, object storage, append-only log)
+ * are operator-provided, keeping the package storage-agnostic exactly like
+ * `CryptoProvider` / `NonceCacheProvider`. Audit records are intended for a
+ * durable, append-only store; see `SECURITY.md` for retention guidance.
+ */
+
+import type {
+  AuditContext,
+  AuditEventContext,
+  AuditRecord,
+} from "../types/protocol.js";
+
+/**
+ * Build a frozen `audit.v1` record from audit context metadata.
+ *
+ * Privacy: only the DID/key id, session id, audience, scope, request/response
+ * hashes, and verification result are captured — never private keys, nonces,
+ * or raw request/response payloads.
+ */
+export function buildAuditRecord(context: AuditContext): AuditRecord {
+  return {
+    version: "audit.v1",
+    ts: Date.now(),
+    session: context.session.sessionId,
+    audience: context.session.audience,
+    did: context.identity.did,
+    kid: context.identity.kid,
+    reqHash: context.requestHash,
+    resHash: context.responseHash,
+    verified: context.verified,
+    scope: context.scopeId ?? "-",
+  };
+}
+
+/**
+ * Pluggable sink for KYA-OS audit records and events.
+ *
+ * Implementations persist to whatever store a deployment uses. The package
+ * ships {@link MemoryAuditLogProvider} (dev/test) and {@link NoopAuditLogProvider}
+ * (the default); production deployments supply a durable, append-only impl.
+ */
+export abstract class AuditLogProvider {
+  /**
+   * Persist one audit record per session (deduplicated by `sessionId`).
+   * Called after a verified tool call; the context is mapped to a frozen
+   * `audit.v1` record via {@link buildAuditRecord}.
+   */
+  abstract logAuditRecord(context: AuditContext): Promise<void>;
+
+  /**
+   * Persist an event without session deduplication (e.g. consent events),
+   * allowing multiple events per session.
+   */
+  abstract logEvent(context: AuditEventContext): Promise<void>;
+}
+
+/**
+ * In-memory {@link AuditLogProvider} for development and testing. Audit records
+ * are deduplicated per session; events are not. Inspect via `records`/`events`.
+ */
+export class MemoryAuditLogProvider extends AuditLogProvider {
+  readonly records: AuditRecord[] = [];
+  readonly events: AuditEventContext[] = [];
+  private readonly loggedSessions = new Set<string>();
+
+  async logAuditRecord(context: AuditContext): Promise<void> {
+    const sessionId = context.session.sessionId;
+    if (this.loggedSessions.has(sessionId)) return;
+    this.loggedSessions.add(sessionId);
+    this.records.push(buildAuditRecord(context));
+  }
+
+  async logEvent(context: AuditEventContext): Promise<void> {
+    this.events.push(context);
+  }
+}
+
+/**
+ * No-op {@link AuditLogProvider}. The default when no audit sink is configured,
+ * so the middleware can always invoke the provider without null checks.
+ */
+export class NoopAuditLogProvider extends AuditLogProvider {
+  async logAuditRecord(_context: AuditContext): Promise<void> {
+    // intentionally empty
+  }
+
+  async logEvent(_context: AuditEventContext): Promise<void> {
+    // intentionally empty
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -15,3 +15,10 @@ export {
 } from './memory.js';
 
 export { NodeCryptoProvider } from './node-crypto.js';
+
+export {
+  AuditLogProvider,
+  MemoryAuditLogProvider,
+  NoopAuditLogProvider,
+  buildAuditRecord,
+} from './audit-log.js';


### PR DESCRIPTION
## Summary

Adds  the **audit-retention seam**.  
A pluggable sink that hands each verified tool call's record to a store the operator supplies. Ports the `IAuditLogger` concept from `xmcp-i`, re-expressed against the donated package's own `protocol.ts` audit types (no `@kya-os/contracts` dependency) and the existing provider pattern.

## What's in it

**Seam** (`src/providers/audit-log.ts`):
- `AuditLogProvider` (abstract) — `logAuditRecord(ctx)` / `logEvent(ctx)`, mirroring the existing provider pattern (`CryptoProvider`, `NonceCacheProvider`, …).
- `buildAuditRecord(ctx): AuditRecord` — the frozen `audit.v1` mapping (`scope: '-'` when absent).
- `MemoryAuditLogProvider` (per-session dedup on records, no dedup on events) + `NoopAuditLogProvider` default.
- Exported from the root and `./providers` barrels.

**Wiring** (`createKyaOsMiddleware`):
- New `KyaOsConfig.auditLog?` (defaults to `NoopAuditLogProvider`).
- Emits an `audit.v1` record after each verified, proofed tool call. **A sink failure is logged and swallowed — it never breaks the tool response.**

## Design

- **Storage-agnostic** — ships in-memory/no-op defaults; durable backends (Postgres, object storage, append-only log) are operator-provided. The package bakes in no storage choice, exactly like the other providers. Audit records belong in a durable, append-only store, not a cache (see `SPEC.md` §12.4).
- **Privacy invariant pinned** — records carry only the 10 frozen `audit.v1` fields (DID/key id, session, audience, scope, request/response hashes, verification result); a test asserts key material and nonces never reach the record even when present on the context.


