### PR TITLE
feat: port policy gate, scope-matcher, signed challenges + verifier content binding (1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,68 @@ All notable changes to @kya-os/mcp will be documented here.
 Format: https://keepachangelog.com/en/1.0.0/
 Versioning: https://semver.org/spec/v2.0.0.html
 
-## [Unreleased]
+## [1.4.0] - 2026-05-31
+
+Ports the KYA-OS authorization primitives developed upstream (xmcp-i) into
+`@kya-os/mcp`: a per-action policy / step-up gate, scope-matcher enforcement,
+signed `needs_authorization` challenges with verifier content binding, and
+shipped runtime providers. Additive over 1.3.x except where noted under
+**Changed** and **Removed**.
 
 ### Added
 
+- **Signed `needs_authorization` challenge.** The delegation challenge returned
+  when a protected tool is invoked without a credential now carries a signed
+  detached-JWS proof in `_meta` (`outcome: 'needs_authorization'`). The proof
+  binds a `responseHash` over the challenge content — including the
+  `authorizationUrl`. A verifier that recomputes the response hash over the
+  content it received — via the new `ProofVerifier` content binding (below) —
+  detects a tampered / MITM-swapped consent URL; the signature alone proves
+  authenticity, not content-match. The challenge content/shape is unchanged; attachment
+  is best-effort (no-ops when no session can be resolved). The proof `outcome`
+  enum widened to include `'needs_authorization'` across `ProofMeta`,
+  `ProofOptions`, `validateDetachedProof`, and the `detached-proof` JSON Schema.
+  Success proofs are byte-identical (unaffected).
+- **`wrapWithDelegation` `formatChallenge` hook.** An optional config callback
+  that renders the `needs_authorization` challenge content (e.g. a clickable
+  markdown consent link for LLM / chat-style MCP clients) **before** the proof is
+  signed — so the challenge `responseHash` binds exactly what the client
+  receives, keeping the `authorizationUrl` tamper-evident regardless of
+  presentation. Defaults to the structured JSON challenge. The consent-basic /
+  consent-full examples now render their consent link via this hook instead of
+  rewriting the response after signing (which had left the proof bound to stale
+  content).
+- **`ProofVerifier` content binding.** `verifyProof(proof, jwk, { request, response })`
+  recomputes `requestHash`/`responseHash` over the request/response the verifier
+  actually received — via a shared `computeCanonicalHashes` (single source of
+  truth with the signer, so they can't drift) — and fails `CONTENT_BINDING_MISMATCH`
+  on divergence. This is what realizes substitution detection (the signed
+  challenge's anti-MITM, and content-binding for any proof); the signature alone
+  proves only authenticity. New `CONTENT_BINDING_MISMATCH` proof-verification
+  error code.
+- **Concrete `SystemClockProvider` + `RuntimeFetchProvider`.** The package now
+  ships a wall-clock `ClockProvider` and a network-capable `FetchProvider`
+  (did:key resolved locally, did:web over HTTPS, StatusList2021 fetch) so a
+  consumer no longer hand-rolls them to drive `ProofVerifier`. `RuntimeFetchProvider`
+  is the default the middleware uses and replaces the prior internal stub (whose
+  `resolveDID` returned `null`); it refuses private-network targets by default
+  (see **Security**). The verify-proof / anti-MITM examples now consume both.
+- **Per-action policy / step-up gate (`withPolicyGate`).** A new opt-in
+  middleware wrapper that classifies an action's risk (reversibility, blast
+  radius, severity) and consults a pluggable Policy-as-Code `PolicyEngine`:
+  `allow` runs the handler, `deny` returns a `policy_denied` error, and
+  `step_up` returns a `needs_approval` error until N-of-M signed `ApprovalGrant`s
+  — each bound to the request hash (TOCTOU-safe) — are supplied. Ships a
+  fail-closed `DefaultPolicyEngine` and a built-in `RiskClassifier`; OPA/Rego and
+  Cedar adapters are intended follow-ups. Composes after `wrapWithDelegation`;
+  no behavior change unless adopted.
+- **`PolicyEngine` PaC port + `policy/` subsystem** (`PolicyRequest`,
+  `PolicyDecision`, `RiskClassifier`, `DefaultPolicyEngine`, `ApprovalGrant`,
+  `verifyApprovalQuorum`), exported from the package root.
+- **`needs_approval` error** (`NeedsApprovalError`, `createNeedsApprovalError`,
+  `isNeedsApprovalError`) and the `policy_denied` error code.
+- **`bytesToBase64` / `base64ToBytes`** are now re-exported from the package root
+  (standard-base64 byte helpers, alongside the existing base64url variants).
 - **`AuditLogProvider` — pluggable sink for audit-record retention.** A new
   provider (abstract base + `MemoryAuditLogProvider` / `NoopAuditLogProvider`
   defaults, exported from the root and `./providers`) for persisting the frozen
@@ -25,7 +83,31 @@ Versioning: https://semver.org/spec/v2.0.0.html
   meta, so the audit record's `scope` reflects it (was `'-'`). The argument is
   optional and backward-compatible; tool handlers that ignore it are unaffected.
 
-## [1.4.0] - 2026-05-26
+### Changed
+
+- **`ProofMeta.responseHash` is now optional** (`string | undefined`). Denial /
+  step-up proofs carry no response, so code reading `responseHash` must treat it
+  as possibly-absent. `validateDetachedProof` and the `detached-proof` JSON
+  Schema no longer require it (and now permit `outcome`/`reason`).
+- **`CrispScope` `prefix`/`regex` matchers are now enforced** (previously inert —
+  only exact membership in the flat `scopes[]` was checked). A credential
+  declaring a non-exact matcher now grants its pattern set, with ReDoS-safe regex
+  evaluation; flat `scopes[]` remain exact-match (unchanged). **Behavioral
+  change** for any credential that declared a `prefix`/`regex` matcher: it now
+  grants where it previously granted nothing, and a one-time warning is logged on
+  first non-exact use. Re-delegations may not introduce crisp matchers absent
+  from the parent.
+- **`withPolicyGate`'s `scopeMatched` defaults to `false`** (fail-closed): compose
+  it after `wrapWithDelegation` and pass `scopeMatched: true`, or it denies.
+  `withPolicyGate` is an optional member of the `KyaOsMiddleware` interface
+  (additive; structural implementers/mocks are not broken). New in this release,
+  so no prior consumer is affected.
+- **Bundled examples now consume the built `@kya-os/mcp` package** rather than
+  reaching into `src/` via relative paths. Nested example packages (consent-basic,
+  consent-full, context7, brave-search) link the local build via `file:../..`;
+  root-tree examples (node-server, verify-proof, outbound-delegation, statuslist)
+  resolve it by package self-reference. Fixes the context7 example, which had
+  pinned a stale published `@kya-os/mcp@^1.3.0` (pre-`withKyaOs` rename).
 
 ### Spec
 
@@ -52,6 +134,46 @@ Versioning: https://semver.org/spec/v2.0.0.html
   retained in PKCS#8 / JWK references); fixed the one residual _private key_
   usage in §7.
 
+### Security
+
+- **Malformed delegation input no longer crashes.** A malformed `_kyaos_delegation`
+  (non-object, missing `credentialSubject.delegation`, or even a throwing
+  getter/Proxy accessor) previously surfaced as a JSON-RPC internal error (`-32603`);
+  it now returns a clean, signed `delegation_invalid` denial. `validateDelegationChain`
+  shape-checks the leaf and returns `{ valid, reason }` (honouring the
+  `verify*`/`validate*` never-throw contract); `extractDelegationFromVC` fails
+  with a clear error instead of a cryptic `TypeError`; the middleware try/catch is
+  now a pure backstop that logs the detail server-side and returns a generic
+  reason (no internal/stack detail leaks to the client). The invalid-VC-JWT path
+  is now signed as well.
+- **Log-injection / reflection hardening.** Caller-derived values (credential
+  ids, scopes) interpolated into delegation-failure reasons and logs are now
+  stripped of control characters and length-capped before emission, so a hostile
+  credential cannot forge log lines, corrupt a terminal, or reflect raw control
+  bytes into a client response.
+- **`RuntimeFetchProvider` refuses private-network targets by default (SSRF).**
+  did:web resolution and StatusList2021 fetches reject loopback / link-local /
+  RFC-1918 IP-literal hosts (e.g. `did:web:169.254.169.254`, the cloud-metadata
+  endpoint) unless constructed with `{ allowPrivateNetworkHosts: true }`. This
+  is best-effort defense-in-depth for IP literals — not DNS rebinding; run
+  verifiers behind an egress allowlist (`SECURITY.md`).
+- **Signed proofs are now emitted on denial and step-up.** Delegation/scope
+  denials and policy step-ups previously produced no proof; they now attach a
+  signed detached-JWS proof (`outcome: 'denied' | 'step_up_required'`, no
+  `responseHash`), so rejected privileged attempts are non-repudiably auditable.
+- **Fail-closed policy default.** Unclassified ("unknown") high-risk actions are
+  denied by the `DefaultPolicyEngine` rather than forwarded.
+- **Denial/step-up proofs are verifiable end-to-end.** `validateDetachedProof`
+  and `ProofVerifier` accept response-less proofs (the earlier fix only corrected
+  canonical-payload reconstruction); added a real-crypto end-to-end test.
+- **Crisp-scope attenuation.** Re-delegations cannot widen authority via crisp
+  matchers absent from the parent — closes a privilege-escalation path that
+  enforcing the matcher would otherwise have opened.
+- **ReDoS hardening.** The `regex` matcher rejects nested-quantifier patterns and
+  bounds input length. This is a conservative guard, **not** a guarantee — prefer
+  `exact`/`prefix` for untrusted issuers, or evaluate via a linear-time engine.
+  The `prefix` matcher refuses an empty/`*`-only base (no universal grant).
+
 ### Removed
 
 - **BREAKING: removed the three unsafe delegation opt-outs.** The
@@ -71,6 +193,16 @@ Versioning: https://semver.org/spec/v2.0.0.html
   flags. Migration guidance: `SECURITY.md` → Mandatory Delegation Protections.
   Consumers that did not set these flags are unaffected — the reference issuer
   and all bundled examples already emit conformant credentials.
+
+### Known limitations (policy gate — experimental, non-normative)
+
+- Step-up approval grants are **not yet single-use or expiry-bound** (replayable
+  for the same action); a server-issued single-use challenge is a planned follow-up.
+- The default approval-signature verifier **rejects all** — integrators must supply
+  a real verifier; `isValidApprovalSignature: async () => true` is test-only.
+- `policy_denied` / `needs_approval`, the step-up flow, and the now-normative
+  `CrispScope` matcher semantics are **not yet documented in `SPEC.md` /
+  `CONFORMANCE.md`** (tracked as follow-ups).
 
 ## [1.3.2] - 2026-05-26
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -131,7 +131,19 @@ Proof metadata MUST include:
 - `audience`: Session audience
 - `sessionId`: Session identifier
 - `requestHash`: SHA-256 of canonicalized request (`sha256:<hex>`)
-- `responseHash`: SHA-256 of canonicalized response (`sha256:<hex>`)
+
+`responseHash` (SHA-256 of the canonicalized response, `sha256:<hex>`) MUST be
+present on proofs that carry a response body — success proofs and
+`needs_authorization` challenges — and is ABSENT on `denied` / `step_up_required`
+proofs (which have no response body). See SPEC §7.2 / §7.4 and the
+`detached-proof` schema (`responseHash` is intentionally not in `required`).
+
+A verifier that acts on a `needs_authorization` `authorizationUrl` — or
+otherwise relies on the response body — MUST recompute `responseHash` over the
+response it actually received and compare it to the bound value BEFORE trusting
+it. The signature alone proves the proof is authentic, not that the received
+content matches what was signed: an in-path intermediary can leave the signature
+intact while swapping the `authorizationUrl`, and only the recompute detects it.
 
 ---
 
@@ -220,6 +232,12 @@ Audit logging MUST be implemented at Level 3. Implementations MUST record:
 - Delegation verification outcomes (pass/fail), including chain validation results
 - Outbound delegation proof attachments, including the chain string and target audience
 - Any `needs_authorization` hints returned to callers
+
+A conformant implementation MAY satisfy part of this requirement using the
+signed detached-JWS proof attached to each outcome: `denied`, `step_up_required`,
+and `needs_authorization` responses carry a proof whose `meta.outcome` records
+the authorization decision (success proofs omit `outcome`, implying `allowed`).
+Such proofs are themselves tamper-evident signed records.
 
 Audit records MUST be tamper-evident (e.g., append-only log, signed entries, or equivalent) and MUST be retained for at least the duration of the longest-lived delegation in the system.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,3 +78,11 @@ If you set any of the removed flags before 1.4.0:
 
 After migrating, remove the flags from your config; they are no longer recognized.
 
+## Outbound resolution & SSRF (`RuntimeFetchProvider`)
+
+`RuntimeFetchProvider` resolves `did:web` and fetches StatusList2021 credentials over the network, and the target host is named by counterparty-controlled data — the DID or status-list URL embedded in a proof or credential. To blunt server-side request forgery it refuses requests to private / loopback / link-local **IP-literal** hosts by default (e.g. `did:web:169.254.169.254`, the cloud-metadata endpoint; `127.0.0.0/8`; RFC 1918 ranges; IPv6 loopback/link-local/unique-local). This is best-effort defense-in-depth for IP literals only — it does **not** stop a public domain that resolves to an internal address (DNS rebinding).
+
+- **Real mitigation:** run verifier deployments behind an egress allowlist and treat did:web resolution as an outbound request to an untrusted host.
+- **Opt out:** `new RuntimeFetchProvider({ allowPrivateNetworkHosts: true })`, for trusted internal deployments only.
+- The raw `fetch()` escape hatch is intentionally unguarded — it is the caller's responsibility.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -660,10 +660,16 @@ interface ProofMeta {
   audience: string;     // Session audience
   sessionId: string;    // Session identifier
   requestHash: string;  // SHA-256 of canonicalized request
-  responseHash: string; // SHA-256 of canonicalized response
+  responseHash?: string; // SHA-256 of canonicalized response. Present on success
+                         // AND on needs_authorization challenges (binds the
+                         // challenge content, incl. authorizationUrl); ABSENT on
+                         // denial / step-up proofs (no response body).
   scopeId?: string;     // Scope under which the call was made
   delegationRef?: string; // Reference to delegation credential
   clientDid?: string;   // Client's DID if authenticated
+  outcome?: 'allowed' | 'denied' | 'step_up_required' | 'needs_authorization';
+                         // Authorization outcome; ABSENT ⇒ implicitly 'allowed' (success)
+  reason?: string;       // Human-readable reason on a non-'allowed' outcome
 }
 ```
 
@@ -705,6 +711,42 @@ BASE64URL(header) . BASE64URL(payload) . BASE64URL(signature)
   "aud": "did:web:server.example.com",
   "iss": "did:web:server.example.com",
   "nonce": "...",
+  "requestHash": "sha256:...",
+  "responseHash": "sha256:...",
+  "sessionId": "kyaos_...",
+  "sub": "did:web:server.example.com",
+  "ts": 1710288000
+}
+```
+
+**Denial** and **step-up** proofs have no response body, so `responseHash` is
+omitted and `outcome` (plus an optional `reason`) is included instead. Keys
+remain RFC 8785-sorted:
+```json
+{
+  "aud": "did:web:server.example.com",
+  "iss": "did:web:server.example.com",
+  "nonce": "...",
+  "outcome": "denied",
+  "reason": "insufficient_scope",
+  "requestHash": "sha256:...",
+  "sessionId": "kyaos_...",
+  "sub": "did:web:server.example.com",
+  "ts": 1710288000
+}
+```
+
+A **needs_authorization** challenge *does* carry a response body (the consent
+challenge, including the `authorizationUrl`), so its proof includes **both** a
+`responseHash` over that body — binding the URL against tampering / MITM
+substitution — and `outcome: "needs_authorization"`:
+```json
+{
+  "aud": "did:web:server.example.com",
+  "iss": "did:web:server.example.com",
+  "nonce": "...",
+  "outcome": "needs_authorization",
+  "reason": "requires delegation with scope: greeting:restricted",
   "requestHash": "sha256:...",
   "responseHash": "sha256:...",
   "sessionId": "kyaos_...",
@@ -883,14 +925,24 @@ interface NeedsAuthorizationError {
 }
 ```
 
+The `needs_authorization` response is itself **signed**: it carries a detached-JWS
+proof in `_meta` (`outcome: 'needs_authorization'`) whose `responseHash` binds the
+challenge content, including `authorizationUrl` (see §7.4). A client detects a
+substituted consent URL by verifying that proof against the resource's DID and
+recomputing `responseHash` over the challenge it actually received
+(`ProofVerifier.verifyProof(proof, jwk, { request, response })`) — see §11.1.
+
 ### 9.3 Resume Flow
 
 1. Client receives `needs_authorization` error
-2. Client directs user to `authorizationUrl`
-3. User authenticates and grants authorization
-4. Authorization service issues DelegationCredential
-5. Client retries request with `resumeToken` and new delegation
-6. Server validates delegation and processes request
+2. Client verifies the challenge proof against the resource's DID — recomputing
+   `responseHash` over the received content — before trusting `authorizationUrl`
+   (detects a substituted consent URL; §11.1)
+3. Client directs user to `authorizationUrl`
+4. User authenticates and grants authorization
+5. Authorization service issues DelegationCredential
+6. Client retries request with `resumeToken` and new delegation
+7. Server validates delegation and processes request
 
 ---
 
@@ -994,6 +1046,7 @@ and the residual risk an operator carries.
 | **Key compromise** — an agent's secret key is exfiltrated. | Short-lived delegations; explicit revocation; key rotation via DID document update. | Window between compromise and detection. See §11.5. |
 | **Revocation race** — an invocation arrives while a revocation is propagating. | Status-list TTL bounded ≤ 60s for high-privilege scopes; side-channel revocation signals honored immediately; expiry as primary revocation mechanism. See §6.5.2. | Unavoidable Lamport-concurrent race. Operators bound the window; they cannot eliminate it. |
 | **Downgrade** — a client strips KYA-OS headers entirely. | Fail-closed: servers requiring identity MUST reject sessionless calls; `/.well-known/mcp` advertises requirements. See §11.7. | A non-compliant client that the operator has not configured to require identity. |
+| **Consent-URL substitution** — a malicious in-path intermediary swaps the `authorizationUrl` in a `needs_authorization` challenge to phish the user toward an attacker-controlled consent page. | The challenge is signed (`outcome: 'needs_authorization'`); its `responseHash` binds the challenge content incl. the URL (§7.4, §9.2). A client recomputes `responseHash` over the received challenge and verifies the proof against the resource DID, detecting the swap. | A client that does not verify the challenge proof / recompute the hash — the check is the verifier's responsibility (a §11.7-style downgrade). TLS protects the URL in transit; this adds defense against a malicious in-path component. |
 | **Denial of service** | Per-session and per-handshake rate limiting; session caps; external session storage with TTL eviction. See §11.9. | Standard transport-layer DoS exposure (DDoS) is out of scope — operators rely on conventional network defenses. |
 
 ### 11.2 Nonce Replay Attacks

--- a/examples/brave-search-mcp-server/package.json
+++ b/examples/brave-search-mcp-server/package.json
@@ -35,6 +35,7 @@
     "inspector:http": "npx @modelcontextprotocol/inspector --transport http"
   },
   "dependencies": {
+    "@kya-os/mcp": "file:../..",
     "@modelcontextprotocol/sdk": "1.27.1",
     "commander": "14.0.3",
     "dotenv": "17.3.1",

--- a/examples/brave-search-mcp-server/src/server.ts
+++ b/examples/brave-search-mcp-server/src/server.ts
@@ -3,8 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import pkg from '../package.json' with { type: 'json' };
 import { isToolPermittedByUser } from './config.js';
 import { type SmitheryConfig, setOptions } from './config.js';
-import { withKyaOs, generateIdentity } from '../../../src/middleware/index.js';
-import type { KyaOsIdentityConfig } from '../../../src/middleware/index.js';
+import { withKyaOs, generateIdentity, type KyaOsIdentityConfig } from '@kya-os/mcp';
 import { NodeCryptoProvider } from '../../node-server/node-crypto.js';
 export { configSchema } from './config.js';
 

--- a/examples/consent-basic/__tests__/consent-server.test.ts
+++ b/examples/consent-basic/__tests__/consent-server.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
-import type { DelegationCredential } from '../../../src/types/protocol.js';
+import type { DelegationCredential } from '@kya-os/mcp';
 
 let server: ConsentServer;
 

--- a/examples/consent-basic/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-basic/__tests__/delegation-issuer.test.ts
@@ -9,9 +9,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createDelegationIssuerFromIdentity, type DelegationIssuerFactory } from '../src/delegation-issuer.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
-import type { DelegationCredential } from '../../../src/types/protocol.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64, type DelegationCredential } from '@kya-os/mcp';
 
 const crypto = new NodeCryptoProvider();
 

--- a/examples/consent-basic/__tests__/e2e.test.ts
+++ b/examples/consent-basic/__tests__/e2e.test.ts
@@ -9,12 +9,9 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createKyaOsMiddleware, type KyaOsMiddleware } from '../../../src/middleware/with-kya-os.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
-import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
 
 const crypto = new NodeCryptoProvider();
 

--- a/examples/consent-basic/__tests__/server.test.ts
+++ b/examples/consent-basic/__tests__/server.test.ts
@@ -10,11 +10,8 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { createKyaOsMiddleware, type KyaOsMiddleware } from '../../../src/middleware/with-kya-os.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
-import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
 
 const crypto = new NodeCryptoProvider();
 const CONSENT_URL = 'http://localhost:9999/consent';

--- a/examples/consent-basic/package.json
+++ b/examples/consent-basic/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@kya-os/mcp": "file:../..",
     "@modelcontextprotocol/sdk": "^1.12.0"
   },
   "devDependencies": {

--- a/examples/consent-basic/scripts/generate-identity.ts
+++ b/examples/consent-basic/scripts/generate-identity.ts
@@ -15,8 +15,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const IDENTITY_DIR = path.resolve(__dirname, '..', '.kya-os');

--- a/examples/consent-basic/src/consent-server.ts
+++ b/examples/consent-basic/src/consent-server.ts
@@ -16,8 +16,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
 import {
   createDelegationIssuerFromIdentity,
   type AgentIdentityConfig,

--- a/examples/consent-basic/src/delegation-issuer.ts
+++ b/examples/consent-basic/src/delegation-issuer.ts
@@ -11,13 +11,7 @@
  * Related Spec: KYA-OS §3.1 (VC structure), §4.1 (DelegationRecord)
  */
 
-import { DelegationCredentialIssuer } from '../../../src/delegation/vc-issuer.js';
-import type { VCSigningFunction } from '../../../src/delegation/vc-issuer.js';
-import type { Proof, DelegationCredential } from '../../../src/types/protocol.js';
-import { wrapDelegationAsVC } from '../../../src/types/protocol.js';
-import type { CryptoProvider } from '../../../src/providers/base.js';
-import { base64urlEncodeFromBytes } from '../../../src/utils/base64.js';
-import { createUnsignedVCJWT, completeVCJWT } from '../../../src/delegation/utils.js';
+import { DelegationCredentialIssuer, base64urlEncodeFromBytes, createUnsignedVCJWT, completeVCJWT, type VCSigningFunction, type Proof, type DelegationCredential, type CryptoProvider } from '@kya-os/mcp';
 
 export type DelegationFormat = 'embedded-proof' | 'vc-jwt';
 

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -32,9 +32,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { createKyaOsMiddleware, type KyaOsMiddleware } from '../../../src/middleware/with-kya-os.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware } from '@kya-os/mcp';
 import { startConsentServer } from './consent-server.js';
 import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
 
@@ -90,21 +88,23 @@ export class DelegationStore {
 }
 
 /**
- * Intercept needs_authorization responses and reformat as a clickable
- * consent link with URL params (tool, scopes, agent_did, resume_token).
+ * Auto-inject a previously approved delegation on retry (resume-token flow via
+ * the DelegationStore).
  *
- * Also checks the DelegationStore for previously approved delegations
- * and auto-injects them on retry.
+ * The needs_authorization challenge presentation — the clickable markdown consent
+ * link — is produced by the `formatChallenge` hook passed to `wrapWithDelegation`
+ * (see createConsentMcpServer), NOT here. Rendering the link before signing lets
+ * the challenge proof bind a `responseHash` over the link itself, keeping the
+ * authorizationUrl tamper-evident; rewriting the response after signing (as this
+ * wrapper used to) would have broken that binding.
  */
 function formatAsConsentLink(
   toolName: string,
-  consentBaseUrl: string,
-  agentDid: string,
   delegationStore: DelegationStore | undefined,
   handler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
 ): (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult> {
   return async (args, sessionId) => {
-    // Check the delegation store for a previously approved VC (resume token flow).
+    // Resume-token flow: inject a previously approved VC on retry.
     if (!args['_kyaos_delegation'] && delegationStore) {
       const pending = delegationStore.findByTool(toolName);
       if (pending) {
@@ -112,41 +112,7 @@ function formatAsConsentLink(
         return handler({ ...args, _kyaos_delegation: pending.vc }, sessionId);
       }
     }
-
-    const result = await handler(args, sessionId);
-
-    // Intercept needs_authorization JSON and reformat as markdown link
-    const text = result.content?.[0]?.text;
-    if (text && !result.isError) {
-      try {
-        const parsed = JSON.parse(text) as {
-          error?: string;
-          scopes?: string[];
-          resumeToken?: string;
-        };
-        if (parsed.error === 'needs_authorization') {
-          const url = new URL(consentBaseUrl);
-          url.searchParams.set('tool', toolName);
-          url.searchParams.set('scopes', (parsed.scopes ?? []).join(','));
-          url.searchParams.set('agent_did', agentDid);
-          if (parsed.resumeToken) {
-            url.searchParams.set('resume_token', parsed.resumeToken);
-          }
-
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `Authorization required.\n\n[Authorize ${toolName}](${url.toString()})\n\nRetry after authorizing.`,
-            }],
-            isError: false,
-          };
-        }
-      } catch {
-        // Not JSON — pass through
-      }
-    }
-
-    return result;
+    return handler(args, sessionId);
   };
 }
 
@@ -177,7 +143,24 @@ export function createConsentMcpServer(
   // checkout: protected tool — requires delegation with scope cart:write
   const rawCheckoutHandler = kyaos.wrapWithDelegation(
     'checkout',
-    { scopeId: 'cart:write', consentUrl: config.consentUrl },
+    {
+      scopeId: 'cart:write',
+      consentUrl: config.consentUrl,
+      // Render the challenge as a clickable markdown consent link BEFORE signing,
+      // so the challenge proof binds a responseHash over the rendered link
+      // (tamper-evident authorizationUrl). LLM / chat-style MCP clients render it.
+      formatChallenge: (challenge) => {
+        const url = new URL(config.consentUrl);
+        url.searchParams.set('tool', 'checkout');
+        url.searchParams.set('scopes', challenge.scopes.join(','));
+        url.searchParams.set('agent_did', kyaos.identity.did);
+        url.searchParams.set('resume_token', challenge.resumeToken);
+        return [{
+          type: 'text' as const,
+          text: `Authorization required.\n\n[Authorize checkout](${url.toString()})\n\nRetry after authorizing.`,
+        }];
+      },
+    },
     kyaos.wrapWithProof('checkout', async (args) => ({
       content: [{
         type: 'text',
@@ -187,8 +170,6 @@ export function createConsentMcpServer(
   );
   const checkoutHandler = formatAsConsentLink(
     'checkout',
-    config.consentUrl,
-    kyaos.identity.did,
     config.delegationStore,
     rawCheckoutHandler as (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
   );

--- a/examples/consent-full/__tests__/consent-server.test.ts
+++ b/examples/consent-full/__tests__/consent-server.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
-import type { DelegationCredential } from '../../../src/types/protocol.js';
+import type { DelegationCredential } from '@kya-os/mcp';
 
 let server: ConsentServer;
 

--- a/examples/consent-full/__tests__/delegation-issuer.test.ts
+++ b/examples/consent-full/__tests__/delegation-issuer.test.ts
@@ -9,9 +9,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createDelegationIssuerFromIdentity, type DelegationIssuerFactory } from '../src/delegation-issuer.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
-import type { DelegationCredential } from '../../../src/types/protocol.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64, type DelegationCredential } from '@kya-os/mcp';
 
 const crypto = new NodeCryptoProvider();
 

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -9,13 +9,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createKyaOsMiddleware, type KyaOsMiddleware } from '../../../src/middleware/index.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 import type { ToolResult } from '../src/server.js';
-import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
 
 const crypto = new NodeCryptoProvider();
 

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -12,12 +12,9 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createKyaOsMiddleware, type KyaOsMiddleware } from '../../../src/middleware/index.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 import { createConsentFullMcpServer, type ToolResult } from '../src/server.js';
-import type { DelegationCredential, NeedsAuthorizationError } from '../../../src/types/protocol.js';
 
 const crypto = new NodeCryptoProvider();
 const CONSENT_URL = 'http://localhost:9999/consent';

--- a/examples/consent-full/package.json
+++ b/examples/consent-full/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@kya-os/mcp": "file:../..",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@kya-os/consent": "^0.1.37"
   },

--- a/examples/consent-full/pnpm-lock.yaml
+++ b/examples/consent-full/pnpm-lock.yaml
@@ -11,9 +11,12 @@ importers:
       '@kya-os/consent':
         specifier: ^0.1.37
         version: 0.1.37(@types/react@19.2.14)
+      '@kya-os/mcp':
+        specifier: file:../..
+        version: file:../..(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
-        version: 1.27.1(zod@3.25.76)
+        version: 1.27.1(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^20.14.0
@@ -176,6 +179,14 @@ packages:
 
   '@kya-os/consent@0.1.37':
     resolution: {integrity: sha512-BiPwSv8wimsEPF50XOBOyAN4iQDr3lIRkz7k3aQ8aWKnBkQnLqkIRrZ2noK/H9c7fJdte8D67EQdRjwWVa9GbA==}
+
+  '@kya-os/mcp@file:../..':
+    resolution: {directory: ../.., type: directory}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
@@ -593,8 +604,14 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
+  json-canonicalize@2.0.0:
+    resolution: {integrity: sha512-yyrnK/mEm6Na3ChbJUWueXdapueW0p380RUyTW87XGb1ww8l8hU0pRrGC3vSWHe9CxrbPHX2fGUOZpNiHR0IIg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -901,6 +918,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -986,6 +1006,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@kya-os/mcp@file:../..(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))':
+    dependencies:
+      jose: 5.10.0
+      json-canonicalize: 2.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.4.3)
+
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
   '@lit/react@1.0.8(@types/react@19.2.14)':
@@ -996,7 +1024,7 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.5.1
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0
@@ -1013,8 +1041,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -1404,7 +1432,11 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.1: {}
+
+  json-canonicalize@2.0.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -1715,8 +1747,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}

--- a/examples/consent-full/scripts/generate-identity.ts
+++ b/examples/consent-full/scripts/generate-identity.ts
@@ -15,8 +15,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const IDENTITY_DIR = path.resolve(__dirname, '..', '.kya-os');

--- a/examples/consent-full/src/consent-server.ts
+++ b/examples/consent-full/src/consent-server.ts
@@ -25,8 +25,7 @@ import { fileURLToPath } from 'node:url';
 import { generateConsentShell } from '@kya-os/consent/bundle/shell';
 import { CONSENT_BUNDLE } from '@kya-os/consent/bundle/inline';
 import type { ConsentConfig } from '@kya-os/consent/types';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../../src/utils/did-helpers.js';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
 import {
   createDelegationIssuerFromIdentity,
   type AgentIdentityConfig,

--- a/examples/consent-full/src/delegation-issuer.ts
+++ b/examples/consent-full/src/delegation-issuer.ts
@@ -11,12 +11,7 @@
  * Related Spec: KYA-OS §3.1 (VC structure), §4.1 (DelegationRecord)
  */
 
-import { DelegationCredentialIssuer } from '../../../src/delegation/vc-issuer.js';
-import type { VCSigningFunction } from '../../../src/delegation/vc-issuer.js';
-import type { Proof } from '../../../src/types/protocol.js';
-import type { CryptoProvider } from '../../../src/providers/base.js';
-import { base64urlEncodeFromBytes } from '../../../src/utils/base64.js';
-import { createUnsignedVCJWT, completeVCJWT } from '../../../src/delegation/utils.js';
+import { DelegationCredentialIssuer, base64urlEncodeFromBytes, createUnsignedVCJWT, completeVCJWT, type VCSigningFunction, type Proof, type CryptoProvider } from '@kya-os/mcp';
 
 export type DelegationFormat = 'embedded-proof' | 'vc-jwt';
 

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -38,10 +38,10 @@ import {
 import {
   createKyaOsMiddleware,
   generateIdentity,
+  NodeCryptoProvider,
   type KyaOsMiddleware,
   type KyaOsIdentityConfig,
-} from '../../../src/middleware/index.js';
-import { NodeCryptoProvider } from '../../../src/providers/node-crypto.js';
+} from '@kya-os/mcp';
 import { startConsentServer } from './consent-server.js';
 import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
 
@@ -101,21 +101,23 @@ export class DelegationStore {
 }
 
 /**
- * Intercept needs_authorization responses and reformat as a clickable
- * consent link with URL params (tool, scopes, agent_did, resume_token).
+ * Auto-inject a previously approved delegation on retry (resume-token flow via
+ * the DelegationStore).
  *
- * Also checks the DelegationStore for previously approved delegations
- * and auto-injects them on retry.
+ * The needs_authorization challenge presentation — the clickable markdown consent
+ * link — is produced by the `formatChallenge` hook passed to `wrapWithDelegation`
+ * (see createConsentFullMcpServer), NOT here. Rendering the link before signing
+ * lets the challenge proof bind a `responseHash` over the link itself, keeping the
+ * authorizationUrl tamper-evident; rewriting the response after signing (as this
+ * wrapper used to) would have broken that binding.
  */
 function formatAsConsentLink(
   toolName: string,
-  consentBaseUrl: string,
-  agentDid: string,
   delegationStore: DelegationStore | undefined,
   handler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
 ): (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult> {
   return async (args, sessionId) => {
-    // Check the delegation store for a previously approved VC (resume token flow).
+    // Resume-token flow: inject a previously approved VC on retry.
     if (!args['_kyaos_delegation'] && delegationStore) {
       const pending = delegationStore.findByTool(toolName);
       if (pending) {
@@ -123,41 +125,7 @@ function formatAsConsentLink(
         return handler({ ...args, _kyaos_delegation: pending.vc }, sessionId);
       }
     }
-
-    const result = await handler(args, sessionId);
-
-    // Intercept needs_authorization JSON and reformat as markdown link
-    const text = result.content?.[0]?.text;
-    if (text && !result.isError) {
-      try {
-        const parsed = JSON.parse(text) as {
-          error?: string;
-          scopes?: string[];
-          resumeToken?: string;
-        };
-        if (parsed.error === 'needs_authorization') {
-          const url = new URL(consentBaseUrl);
-          url.searchParams.set('tool', toolName);
-          url.searchParams.set('scopes', (parsed.scopes ?? []).join(','));
-          url.searchParams.set('agent_did', agentDid);
-          if (parsed.resumeToken) {
-            url.searchParams.set('resume_token', parsed.resumeToken);
-          }
-
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `Authorization required.\n\n[Authorize ${toolName}](${url.toString()})\n\nRetry after authorizing.`,
-            }],
-            isError: false,
-          };
-        }
-      } catch {
-        // Not JSON — pass through
-      }
-    }
-
-    return result;
+    return handler(args, sessionId);
   };
 }
 
@@ -194,7 +162,24 @@ export function createConsentFullMcpServer(
   // wrapWithDelegation checks _kyaos_delegation in args (why we need raw args)
   const rawCheckoutHandler = kyaos.wrapWithDelegation(
     'checkout',
-    { scopeId: 'cart:write', consentUrl: config.consentUrl },
+    {
+      scopeId: 'cart:write',
+      consentUrl: config.consentUrl,
+      // Render the challenge as a clickable markdown consent link BEFORE signing,
+      // so the challenge proof binds a responseHash over the rendered link
+      // (tamper-evident authorizationUrl). LLM / chat-style MCP clients render it.
+      formatChallenge: (challenge) => {
+        const url = new URL(config.consentUrl);
+        url.searchParams.set('tool', 'checkout');
+        url.searchParams.set('scopes', challenge.scopes.join(','));
+        url.searchParams.set('agent_did', kyaos.identity.did);
+        url.searchParams.set('resume_token', challenge.resumeToken);
+        return [{
+          type: 'text' as const,
+          text: `Authorization required.\n\n[Authorize checkout](${url.toString()})\n\nRetry after authorizing.`,
+        }];
+      },
+    },
     kyaos.wrapWithProof('checkout', async (args) => ({
       content: [{
         type: 'text',
@@ -204,8 +189,6 @@ export function createConsentFullMcpServer(
   );
   const checkoutHandler = formatAsConsentLink(
     'checkout',
-    config.consentUrl,
-    kyaos.identity.did,
     config.delegationStore,
     rawCheckoutHandler as (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
   );

--- a/examples/context7-with-kya-os/package.json
+++ b/examples/context7-with-kya-os/package.json
@@ -10,7 +10,7 @@
     "start:http": "npx tsx src/index.ts --transport http"
   },
   "dependencies": {
-    "@kya-os/mcp": "^1.3.0",
+    "@kya-os/mcp": "file:../..",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^14.0.0",
     "express": "^5.1.0",

--- a/examples/node-server/approval-demo.ts
+++ b/examples/node-server/approval-demo.ts
@@ -1,0 +1,73 @@
+/**
+ * Demo approval-grant signing & verification for the step-up gate.
+ *
+ * withPolicyGate takes an `isValidApprovalSignature` verifier; the package ships
+ * NO default one (it rejects all, fail-closed). This example provides a REAL
+ * Ed25519 verifier (not `async () => true`) so the deny → step-up → approve flow
+ * is end-to-end authentic: an approver signs the canonical grant with a did:key,
+ * and the gate resolves that DID and verifies the signature. A forged grant fails.
+ *
+ * NOTE: the canonical-grant byte layout below is a DEMO convention. A normative,
+ * shipped grant-signing helper is a tracked follow-up (see CHANGELOG known limits).
+ */
+import { canonicalize } from 'json-canonicalize';
+import { NodeCryptoProvider } from './node-crypto.js';
+import {
+  extractPublicKeyFromDidKey,
+  bytesToBase64,
+  base64ToBytes,
+  generateDidKeyFromBase64,
+  type ApprovalGrant,
+} from '@kya-os/mcp';
+
+const crypto = new NodeCryptoProvider();
+
+/** Bytes an approver signs over — every grant field except the signature. */
+function canonicalGrantBytes(g: Omit<ApprovalGrant, 'signature'>): Uint8Array {
+  return new TextEncoder().encode(
+    canonicalize({
+      approvalRequestId: g.approvalRequestId,
+      approverDid: g.approverDid,
+      decision: g.decision,
+      requestHash: g.requestHash,
+      ts: g.ts,
+    }),
+  );
+}
+
+/** Mint a fresh approver did:key and produce a signed ApprovalGrant bound to a requestHash. */
+export async function mintSignedApproval(
+  requestHash: string,
+  opts: { decision?: 'approve' | 'deny'; approvalRequestId?: string } = {},
+): Promise<{ grant: ApprovalGrant; approverDid: string }> {
+  const kp = await crypto.generateKeyPair();
+  const approverDid = generateDidKeyFromBase64(kp.publicKey);
+  const unsigned: Omit<ApprovalGrant, 'signature'> = {
+    approvalRequestId: opts.approvalRequestId ?? `appr-${requestHash.slice(-8)}`,
+    approverDid,
+    requestHash,
+    decision: opts.decision ?? 'approve',
+    ts: Math.floor(Date.now() / 1000),
+  };
+  const sig = await crypto.sign(canonicalGrantBytes(unsigned), kp.privateKey);
+  return { grant: { ...unsigned, signature: bytesToBase64(sig) }, approverDid };
+}
+
+/**
+ * Real `isValidApprovalSignature` for withPolicyGate: resolve the approver's
+ * did:key and verify the grant's Ed25519 signature over the canonical bytes.
+ */
+export async function verifyApprovalGrantSignature(grant: ApprovalGrant): Promise<boolean> {
+  try {
+    const raw = extractPublicKeyFromDidKey(grant.approverDid);
+    if (!raw) return false;
+    const { signature, ...unsigned } = grant;
+    return await crypto.verify(
+      canonicalGrantBytes(unsigned),
+      base64ToBytes(signature),
+      bytesToBase64(raw),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/examples/node-server/issue-approval.ts
+++ b/examples/node-server/issue-approval.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env npx tsx
+/**
+ * Mint a signed step-up approval grant for a `delete_record` call.
+ *
+ * Usage:
+ *   1. Call `delete_record` in the Inspector → you get a `needs_approval` error
+ *      carrying a `requestHash`.
+ *   2. npx tsx examples/node-server/issue-approval.ts <requestHash>
+ *   3. Paste the printed array as the `_kyaos_approvals` argument and re-call
+ *      `delete_record` with the SAME `record` value → it proceeds.
+ */
+import { mintSignedApproval } from './approval-demo.js';
+
+async function main() {
+  const requestHash = process.argv[2];
+  if (!requestHash) {
+    process.stderr.write(
+      'Usage: npx tsx examples/node-server/issue-approval.ts <requestHash>\n' +
+        '  (copy requestHash from the delete_record needs_approval response)\n',
+    );
+    process.exit(1);
+  }
+  const { grant, approverDid } = await mintSignedApproval(requestHash);
+  process.stderr.write(`[issue-approval] Approver DID: ${approverDid}\n`);
+  process.stderr.write('[issue-approval] Paste this as the _kyaos_approvals argument (an ARRAY):\n');
+  process.stdout.write(JSON.stringify([grant], null, 2) + '\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/node-server/issue-delegation.ts
+++ b/examples/node-server/issue-delegation.ts
@@ -10,10 +10,12 @@
  */
 
 import { NodeCryptoProvider } from './node-crypto.js';
-import { generateDidKeyFromBase64 } from '../../src/utils/did-helpers.js';
-import { DelegationCredentialIssuer } from '../../src/delegation/vc-issuer.js';
-import type { Proof } from '../../src/types/protocol.js';
-import { base64urlEncodeFromBytes } from '../../src/utils/base64.js';
+import {
+  generateDidKeyFromBase64,
+  DelegationCredentialIssuer,
+  base64urlEncodeFromBytes,
+  type Proof,
+} from '@kya-os/mcp';
 
 async function main() {
   const crypto = new NodeCryptoProvider();

--- a/examples/node-server/node-crypto.ts
+++ b/examples/node-server/node-crypto.ts
@@ -4,7 +4,7 @@
  */
 
 import { createHash, generateKeyPairSync, sign, verify, randomBytes } from 'node:crypto';
-import { CryptoProvider } from '../../src/providers/base.js';
+import { CryptoProvider } from '@kya-os/mcp';
 
 export class NodeCryptoProvider extends CryptoProvider {
   async sign(data: Uint8Array, privateKeyBase64: string): Promise<Uint8Array> {

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -10,6 +10,8 @@
  * Demonstrates the KYA-OS protocol:
  *   1. greet           — open tool with signed proof (via _meta)
  *   2. restricted_greet — protected tool requiring a W3C Delegation Credential
+ *   3. delete_record    — destructive tool gated by the policy step-up (needs_approval
+ *                         until signed approval grants are supplied in _kyaos_approvals)
  *
  * Sessions are created automatically — no manual handshake needed.
  * In production, KYA-OS-aware clients handle the handshake transparently.
@@ -32,9 +34,9 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { createKyaOsMiddleware } from '../../src/middleware/with-kya-os.js';
-import { generateDidKeyFromBase64 } from '../../src/utils/did-helpers.js';
+import { createKyaOsMiddleware, generateDidKeyFromBase64 } from '@kya-os/mcp';
 import { NodeCryptoProvider } from './node-crypto.js';
+import { verifyApprovalGrantSignature } from './approval-demo.js';
 
 function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
   const server = new Server(
@@ -53,11 +55,46 @@ function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
     'restricted_greet',
     {
       scopeId: 'greeting:restricted',
+      // This minimal example does NOT host a consent page. `consentUrl` is a
+      // placeholder; `formatChallenge` (below) renders an actionable instruction
+      // instead — and the challenge proof binds that rendered text. For a hosted
+      // browser consent flow + page, see examples/consent-full.
       consentUrl: 'https://example.com/consent?scope=greeting:restricted',
+      // Render the needs_authorization challenge as a concrete next step for THIS
+      // (page-less) example, rather than a bare URL the caller can't act on.
+      formatChallenge: (challenge) => [
+        {
+          type: 'text',
+          text:
+            `"restricted_greet" requires a delegation credential (scope: ${challenge.scopes.join(', ')}).\n\n` +
+            `This minimal example does not host a consent page. To authorize:\n` +
+            `  1. Mint a credential:  npx tsx examples/node-server/issue-delegation.ts\n` +
+            `  2. Re-call restricted_greet with "_kyaos_delegation" set to the printed VC.\n\n` +
+            `For a hosted consent page + browser flow, see the consent-full example.`,
+        },
+      ],
     },
     kyaos.wrapWithProof('restricted_greet', async (args) => ({
       content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}! (delegation verified)` }],
     })),
+  );
+
+  // delete_record: a destructive, in-scope action. The policy gate classifies it
+  // (irreversible + prod namespace → catastrophic) and requires per-action human
+  // approval: the first call returns `needs_approval`; supplying signed approval
+  // grant(s) in `_kyaos_approvals` (bound to the call's requestHash) lets it proceed.
+  // scopeMatched:true mimics composition after a verified delegation. The approval
+  // verifier is a REAL Ed25519 check (examples/node-server/approval-demo.ts), not a stub.
+  const deleteRecordHandler = kyaos.withPolicyGate!(
+    'delete_record',
+    kyaos.wrapWithProof('delete_record', async (args) => ({
+      content: [{ type: 'text', text: `Deleted record ${args['record'] ?? '(none)'} — approved.` }],
+    })),
+    {
+      scopeMatched: true,
+      resolveNamespace: () => 'prod',
+      isValidApprovalSignature: verifyApprovalGrantSignature,
+    },
   );
 
   // ── Request handlers ────────────────────────────────────────────
@@ -89,6 +126,21 @@ function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
           },
         },
       },
+      {
+        name: 'delete_record',
+        description:
+          'A destructive action gated by the policy step-up: returns needs_approval until signed approval grants are supplied in _kyaos_approvals.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            record: { type: 'string', description: 'Record id to delete' },
+            _kyaos_approvals: {
+              type: 'array',
+              description: 'Signed approval grants (from issue-approval.ts), bound to this call\'s requestHash',
+            },
+          },
+        },
+      },
     ],
   }));
 
@@ -108,6 +160,10 @@ function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
     // ── Protected tools (delegation required) ───────────────────
     if (name === 'restricted_greet') {
       return restrictedGreetHandler(args as Record<string, unknown>);
+    }
+
+    if (name === 'delete_record') {
+      return deleteRecordHandler(args as Record<string, unknown>);
     }
 
     return {

--- a/examples/outbound-delegation/demo.ts
+++ b/examples/outbound-delegation/demo.ts
@@ -17,7 +17,7 @@ import {
   type DelegationRecord,
   type SessionContext,
   type VCSigningFunction,
-} from '../../src/index.js';
+} from '@kya-os/mcp';
 
 // ---------------------------------------------------------------------------
 // NodeCryptoProvider — Ed25519 operations using node:crypto

--- a/examples/statuslist/__tests__/e2e.test.ts
+++ b/examples/statuslist/__tests__/e2e.test.ts
@@ -12,22 +12,20 @@
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { NodeCryptoProvider } from "../../../src/providers/node-crypto.js";
-import { generateDidKeyFromBase64 } from "../../../src/utils/did-helpers.js";
-import { DelegationCredentialIssuer } from "../../../src/delegation/vc-issuer.js";
 import {
+  NodeCryptoProvider,
+  generateDidKeyFromBase64,
+  DelegationCredentialIssuer,
   StatusList2021Manager,
+  MemoryStatusListStorage,
+  DelegationCredentialVerifier,
+  createDidKeyResolver,
+  base64urlEncodeFromBytes,
   type StatusListStorageProvider,
-} from "../../../src/delegation/statuslist-manager.js";
-import { MemoryStatusListStorage } from "../../../src/delegation/storage/memory-statuslist-storage.js";
-import { DelegationCredentialVerifier } from "../../../src/delegation/vc-verifier.js";
-import { createDidKeyResolver } from "../../../src/delegation/did-key-resolver.js";
-import { base64urlEncodeFromBytes } from "../../../src/utils/base64.js";
-import type {
-  DelegationCredential,
-  CredentialStatus,
-  Proof,
-} from "../../../src/types/protocol.js";
+  type DelegationCredential,
+  type CredentialStatus,
+  type Proof,
+} from "@kya-os/mcp";
 
 const crypto = new NodeCryptoProvider();
 

--- a/examples/verify-proof/README.md
+++ b/examples/verify-proof/README.md
@@ -1,8 +1,19 @@
 # `@kya-os/mcp` Proof Verification
 
-Verifies a DetachedProof JSON using did:key resolution.
+Verifies a DetachedProof JSON using did:key resolution, and demonstrates
+content binding (anti-MITM).
 
-## Usage
+## Files
+
+- `verify.ts` — CLI that verifies a single DetachedProof (signature, replay, skew).
+- `anti-mitm-demo.ts` — self-contained demo: a signed `needs_authorization`
+  challenge whose `authorizationUrl` is detected as tampered when swapped.
+
+Both wire `ProofVerifier` from the package's shipped providers —
+`NodeCryptoProvider`, `SystemClockProvider`, `RuntimeFetchProvider`, and
+`MemoryNonceCacheProvider` — so nothing is hand-rolled.
+
+## Verify a proof
 
 ```bash
 # From a file
@@ -10,12 +21,41 @@ npx tsx examples/verify-proof/verify.ts proof.json
 
 # From stdin
 echo '{"jws":"...","meta":{...}}' | npx tsx examples/verify-proof/verify.ts
+
+# Or via the package script
+pnpm example:verify-proof proof.json
 ```
 
-## What It Does
+It parses the proof, resolves the signer DID, verifies the Ed25519 JWS
+signature, checks the nonce against replay, checks timestamp skew (5 min), and
+prints `VALID` / `INVALID` (exit 1 on failure).
 
-1. Parses the DetachedProof JSON (JWS + metadata)
-2. Resolves the DID in the proof metadata to extract the public key
-3. Verifies the JWS signature using Ed25519
-4. Checks timestamp freshness (within 5-minute skew)
-5. Prints the verification result
+## Anti-MITM content binding
+
+```bash
+npx tsx examples/verify-proof/anti-mitm-demo.ts
+# or
+pnpm example:anti-mitm
+```
+
+A resource server answers an unauthorized tool call with a `needs_authorization`
+challenge that embeds a consent URL, and signs a proof binding a `responseHash`
+over that challenge content. The verifier opts into content binding by passing
+the received request/response:
+
+```ts
+verifier.verifyProof(proof, jwk, { request, response });
+```
+
+The demo shows three outcomes:
+
+1. **genuine content** → `VALID` — the client received exactly what was signed.
+2. **MITM-swapped URL** → `REJECTED: CONTENT_BINDING_MISMATCH` — an in-path
+   intermediary swapped the `authorizationUrl`; the signature is still valid, but
+   the recomputed `responseHash` no longer matches.
+3. **response not supplied** → `REJECTED: CONTENT_BINDING_MISMATCH` — fail-closed:
+   a `responseHash`-bound proof verified without its response is rejected, not
+   waved through.
+
+The signature alone proves the proof is *authentic*; only recomputing the hash
+over the received content proves it *matches what was signed*.

--- a/examples/verify-proof/anti-mitm-demo.ts
+++ b/examples/verify-proof/anti-mitm-demo.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env npx tsx
+/**
+ * Anti-MITM content-binding demo.
+ *
+ * A resource server answers an unauthorized tool call with a needs_authorization
+ * challenge that embeds a consent URL, and signs a detached-JWS proof binding a
+ * responseHash over that challenge content. ProofVerifier's content binding —
+ * verifyProof(proof, jwk, { request, response }) — recomputes the response hash
+ * over what the client ACTUALLY received and rejects a swapped consent URL with
+ * CONTENT_BINDING_MISMATCH, even though the proof's signature is still valid.
+ *
+ *   npx tsx examples/verify-proof/anti-mitm-demo.ts
+ */
+import {
+  ProofGenerator,
+  ProofVerifier,
+  NodeCryptoProvider,
+  MemoryNonceCacheProvider,
+  SystemClockProvider,
+  RuntimeFetchProvider,
+  generateDidKeyFromBase64,
+  base64urlEncodeFromBytes,
+} from '@kya-os/mcp';
+
+async function main() {
+  const crypto = new NodeCryptoProvider();
+  const kp = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(kp.publicKey);
+  const kid = `${did}#${did.replace('did:key:', '')}`;
+
+  // ── Server side: sign the challenge bound to the consent URL ──────────────
+  const gen = new ProofGenerator(
+    { did, kid, privateKey: kp.privateKey, publicKey: kp.publicKey },
+    crypto,
+  );
+  const request = { method: 'tools/call', params: { name: 'restricted_greet' } };
+  const challenge = {
+    error: 'needs_authorization',
+    message: 'requires delegation with scope: greeting:restricted',
+    authorizationUrl: 'https://issuer.example/consent?scope=greeting:restricted',
+    scopes: ['greeting:restricted'],
+  };
+  const genuineContent = [{ type: 'text', text: JSON.stringify(challenge) }];
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const session = {
+    sessionId: 'sess_demo',
+    audience: did,
+    nonce: base64urlEncodeFromBytes(await crypto.randomBytes(16)),
+    timestamp: nowSec,
+    createdAt: nowSec,
+    lastActivity: nowSec,
+    ttlMinutes: 30,
+    identityState: 'anonymous' as const,
+  };
+  const proof = await gen.generateProof(request, { data: genuineContent }, session, {
+    outcome: 'needs_authorization',
+    reason: challenge.message,
+  });
+
+  // ── Client side: verify with content binding ──────────────────────────────
+  const makeVerifier = () =>
+    new ProofVerifier({
+      cryptoProvider: crypto,
+      clockProvider: new SystemClockProvider(),
+      nonceCacheProvider: new MemoryNonceCacheProvider(),
+      fetchProvider: new RuntimeFetchProvider(),
+      timestampSkewSeconds: 300,
+    });
+
+  const jwk = await makeVerifier().fetchPublicKeyFromDID(did);
+  if (!jwk) throw new Error('could not resolve signer did:key');
+
+  console.log('Server signed challenge authorizationUrl:');
+  console.log('   ', challenge.authorizationUrl);
+  console.log('Proof binds responseHash:', proof.meta.responseHash);
+  console.log();
+
+  // 1) Genuine — client received exactly what the server signed.
+  const genuine = await makeVerifier().verifyProof(proof, jwk, {
+    request,
+    response: { data: genuineContent },
+  });
+  console.log(
+    '[1] genuine content       ->',
+    genuine.valid ? 'VALID' : `INVALID (${genuine.errorCode})`,
+  );
+
+  // 2) MITM — an in-path intermediary swaps the consent URL in the delivered content.
+  const swappedContent = [
+    {
+      type: 'text',
+      text: JSON.stringify({ ...challenge, authorizationUrl: 'https://attacker.example/consent' }),
+    },
+  ];
+  const mitm = await makeVerifier().verifyProof(proof, jwk, {
+    request,
+    response: { data: swappedContent },
+  });
+  console.log(
+    '[2] MITM-swapped URL      ->',
+    mitm.valid ? 'VALID (BUG — should reject!)' : `REJECTED: ${mitm.errorCode} (MITM detected)`,
+  );
+
+  // 3) Fail-closed — caller omits the response on a responseHash-bound proof.
+  const noResponse = await makeVerifier().verifyProof(proof, jwk, { request });
+  console.log(
+    '[3] response not supplied ->',
+    noResponse.valid ? 'VALID (BUG — should reject!)' : `REJECTED: ${noResponse.errorCode} (fail-closed)`,
+  );
+
+  console.log();
+  const ok = genuine.valid && !mitm.valid && !noResponse.valid;
+  console.log(ok ? 'Anti-MITM content binding: WORKING.' : 'Anti-MITM content binding: FAILED.');
+  if (!ok) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Error:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/examples/verify-proof/tsconfig.json
+++ b/examples/verify-proof/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist",
+    "noEmit": true,
     "rootDir": "."
   },
   "include": ["*.ts"]

--- a/examples/verify-proof/verify.ts
+++ b/examples/verify-proof/verify.ts
@@ -2,7 +2,10 @@
 /**
  * KYA-OS Proof Verification Example
  *
- * Verifies a DetachedProof JSON from stdin or file argument.
+ * Verifies a DetachedProof JSON from stdin or a file argument: resolves the
+ * signer's DID, checks the JWS signature, nonce-replay, and timestamp skew.
+ * (To additionally detect content substitution — e.g. a swapped consent URL —
+ * verify with the received request/response; see anti-mitm-demo.ts.)
  *
  * Usage:
  *   echo '{"jws":"...","meta":{...}}' | npx tsx examples/verify-proof/verify.ts
@@ -10,72 +13,61 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { ProofVerifier, type ProofVerifierConfig } from '../../src/proof/verifier.js';
-import { createDidKeyResolver } from '../../src/delegation/did-key-resolver.js';
-import { CryptoProvider } from '../../src/providers/base.js';
-import { createHash, verify as cryptoVerify } from 'node:crypto';
-
-class NodeCryptoProvider extends CryptoProvider {
-  async sign(): Promise<Uint8Array> { throw new Error('Not needed for verification'); }
-  async verify(data: Uint8Array, signature: Uint8Array, publicKeyBase64: string): Promise<boolean> {
-    const keyBuffer = Buffer.from(publicKeyBase64, 'base64');
-    const derPrefix = Buffer.from([0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00]);
-    const derKey = Buffer.concat([derPrefix, keyBuffer.subarray(0, 32)]);
-    return cryptoVerify(undefined, Buffer.from(data), { key: derKey, format: 'der', type: 'spki' }, Buffer.from(signature));
-  }
-  async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> { throw new Error('Not needed'); }
-  async hash(data: Uint8Array): Promise<string> {
-    return `sha256:${createHash('sha256').update(data).digest('hex')}`;
-  }
-  async randomBytes(): Promise<Uint8Array> { throw new Error('Not needed'); }
-}
+import {
+  ProofVerifier,
+  NodeCryptoProvider,
+  MemoryNonceCacheProvider,
+  SystemClockProvider,
+  RuntimeFetchProvider,
+  type DetachedProof,
+} from '@kya-os/mcp';
 
 async function main() {
   let input: string;
-
   if (process.argv[2]) {
     input = readFileSync(process.argv[2], 'utf-8');
   } else if (!process.stdin.isTTY) {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) {
-      chunks.push(chunk);
+      chunks.push(chunk as Buffer);
     }
     input = Buffer.concat(chunks).toString('utf-8');
   } else {
-    console.error('Usage: npx tsx verify.ts <proof.json>');
-    console.error('   or: echo \'{"jws":"...","meta":{...}}\' | npx tsx verify.ts');
+    console.error('Usage: npx tsx verify.ts <proof.json>   (or pipe the proof JSON on stdin)');
     process.exit(1);
   }
 
-  const proof = JSON.parse(input);
-  console.log('Proof DID:', proof.meta?.did);
-  console.log('Proof KID:', proof.meta?.kid);
-  console.log('Session:', proof.meta?.sessionId);
-  console.log('Timestamp:', new Date((proof.meta?.ts ?? 0) * 1000).toISOString());
+  const proof = JSON.parse(input) as DetachedProof;
+  console.log('Proof DID: ', proof.meta?.did);
+  console.log('Key ID:    ', proof.meta?.kid);
+  console.log('Session:   ', proof.meta?.sessionId);
+  console.log('Outcome:   ', proof.meta?.outcome ?? 'allowed (success)');
+  console.log('Timestamp: ', new Date((proof.meta?.ts ?? 0) * 1000).toISOString());
 
-  const crypto = new NodeCryptoProvider();
-  const didResolver = createDidKeyResolver();
+  const verifier = new ProofVerifier({
+    cryptoProvider: new NodeCryptoProvider(),
+    clockProvider: new SystemClockProvider(),
+    nonceCacheProvider: new MemoryNonceCacheProvider(),
+    fetchProvider: new RuntimeFetchProvider(),
+    timestampSkewSeconds: 300, // generous for offline verification
+  });
 
-  const config: ProofVerifierConfig = {
-    cryptoProvider: crypto,
-    fetchPublicKeyFromDID: async (did: string) => {
-      const result = didResolver(did);
-      if (!result) return null;
-      return result.publicKeyJwk;
-    },
-    timestampSkewSeconds: 300, // 5 minutes — generous for offline verification
-  };
+  // Resolve the signer's public key from its DID (did:key resolved offline).
+  const jwk = await verifier.fetchPublicKeyFromDID(proof.meta.did);
+  if (!jwk) {
+    console.log('\nVerification result: INVALID (could not resolve signer DID)');
+    process.exit(1);
+  }
 
-  const verifier = new ProofVerifier(config);
-  const result = await verifier.verifyProofDetached(proof);
-
+  const result = await verifier.verifyProof(proof, jwk);
   console.log('\nVerification result:', result.valid ? 'VALID' : 'INVALID');
   if (!result.valid) {
-    console.log('Error:', result.error?.code, '-', result.error?.message);
+    console.log('Reason:', result.errorCode, '-', result.reason);
+    process.exit(1);
   }
 }
 
 main().catch((err) => {
-  console.error('Error:', err.message);
+  console.error('Error:', err instanceof Error ? err.message : String(err));
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "demo": "bash scripts/demo.sh",
     "example:server": "npx tsx examples/node-server/server.ts",
-    "example:inspector": "npx @modelcontextprotocol/inspector npx tsx examples/node-server/server.ts --stdio"
+    "example:inspector": "npx @modelcontextprotocol/inspector npx tsx examples/node-server/server.ts --stdio",
+    "example:verify-proof": "npx tsx examples/verify-proof/verify.ts",
+    "example:anti-mitm": "npx tsx examples/verify-proof/anti-mitm-demo.ts"
   },
   "dependencies": {
     "jose": "^5.6.3",

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -20,7 +20,7 @@
   "$defs": {
     "ProofMeta": {
       "type": "object",
-      "required": ["did", "kid", "ts", "nonce", "audience", "sessionId", "requestHash", "responseHash"],
+      "required": ["did", "kid", "ts", "nonce", "audience", "sessionId", "requestHash"],
       "properties": {
         "did": {
           "type": "string",
@@ -60,7 +60,7 @@
         "responseHash": {
           "type": "string",
           "pattern": "^sha256:[a-f0-9]{64}$",
-          "description": "SHA-256 hash of JCS-canonicalized response. Format: 'sha256:<64 hex chars>'."
+          "description": "SHA-256 hash of JCS-canonicalized response. Absent on denial / step-up proofs (no response). Format: 'sha256:<64 hex chars>'."
         },
         "scopeId": {
           "type": "string",
@@ -74,6 +74,15 @@
           "type": "string",
           "pattern": "^did:.+$",
           "description": "Optional client DID for multi-party scenarios."
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["allowed", "denied", "step_up_required", "needs_authorization"],
+          "description": "Authorization outcome. Present on denial / step-up / needs-authorization proofs; absent (implicitly 'allowed') on success proofs."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason accompanying a denied / step-up / needs-authorization outcome."
         }
       },
       "additionalProperties": false

--- a/src/__tests__/providers/runtime-fetch.test.ts
+++ b/src/__tests__/providers/runtime-fetch.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RuntimeFetchProvider } from '../../providers/runtime-fetch.js';
+import { NodeCryptoProvider } from '../../providers/node-crypto.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+
+describe('RuntimeFetchProvider', () => {
+  let provider: RuntimeFetchProvider;
+
+  beforeEach(() => {
+    provider = new RuntimeFetchProvider();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('resolveDID', () => {
+    it('resolves a did:key locally, with no network, to an Ed25519 publicKeyJwk', async () => {
+      const crypto = new NodeCryptoProvider();
+      const kp = await crypto.generateKeyPair();
+      const did = generateDidKeyFromBase64(kp.publicKey);
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const doc = await provider.resolveDID(did);
+
+      expect(doc).not.toBeNull();
+      expect(doc?.id).toBe(did);
+      expect(doc?.verificationMethod?.[0]?.publicKeyJwk).toMatchObject({
+        kty: 'OKP',
+        crv: 'Ed25519',
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns null for an unsupported DID method', async () => {
+      expect(await provider.resolveDID('did:example:abc')).toBeNull();
+    });
+
+    it('resolves a did:web over the HTTPS .well-known fetch path', async () => {
+      const did = 'did:web:example.com';
+      const didDoc = {
+        id: did,
+        verificationMethod: [
+          { id: `${did}#key-1`, type: 'Ed25519VerificationKey2020', controller: did },
+        ],
+      };
+      const fetchSpy = vi.fn(async (url: string) => {
+        expect(url).toBe('https://example.com/.well-known/did.json');
+        return new Response(JSON.stringify(didDoc), { status: 200 });
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const doc = await provider.resolveDID(did);
+
+      expect(doc?.id).toBe(did);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when did:web resolution fails (non-ok response)', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 404 })));
+      expect(await provider.resolveDID('did:web:example.com')).toBeNull();
+    });
+  });
+
+  describe('fetch', () => {
+    it('delegates to the global fetch with url and options', async () => {
+      const res = new Response('ok', { status: 200 });
+      const fetchSpy = vi.fn(async () => res);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const out = await provider.fetch('https://x.test/y', { method: 'GET' });
+
+      expect(out).toBe(res);
+      expect(fetchSpy).toHaveBeenCalledWith('https://x.test/y', { method: 'GET' });
+    });
+
+    it('throws when no global fetch is available', async () => {
+      vi.stubGlobal('fetch', undefined);
+      await expect(provider.fetch('https://x.test')).rejects.toThrow(/fetch is not available/i);
+    });
+  });
+
+  describe('fetchStatusList', () => {
+    const cred = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      id: 'https://issuer.test/status/1',
+      type: ['VerifiableCredential', 'StatusList2021Credential'],
+      issuer: 'did:web:issuer.test',
+      issuanceDate: '2026-01-01T00:00:00Z',
+      credentialSubject: {
+        type: 'StatusList2021',
+        statusPurpose: 'revocation',
+        encodedList: 'H4sIAAAAAAAA',
+      },
+    };
+
+    it('fetches and returns a StatusList2021Credential', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(cred), { status: 200 })));
+      const out = await provider.fetchStatusList('https://issuer.test/status/1');
+      expect(out?.credentialSubject.encodedList).toBe('H4sIAAAAAAAA');
+    });
+
+    it('returns null on a non-ok response', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('x', { status: 500 })));
+      expect(await provider.fetchStatusList('https://issuer.test/status/1')).toBeNull();
+    });
+
+    it('returns null when the payload is not a StatusList2021Credential', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(JSON.stringify({ id: 'x', type: ['Other'] }), { status: 200 })),
+      );
+      expect(await provider.fetchStatusList('https://issuer.test/status/1')).toBeNull();
+    });
+
+    it('returns null (never throws) when the underlying fetch rejects', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+      expect(await provider.fetchStatusList('https://issuer.test/status/1')).toBeNull();
+    });
+  });
+
+  describe('fetchDelegationChain', () => {
+    it('returns an empty array (no remote chain resolution is shipped)', async () => {
+      expect(await provider.fetchDelegationChain('urn:delegation:1')).toEqual([]);
+    });
+  });
+
+  describe('SSRF guard (private/loopback targets blocked by default)', () => {
+    it('refuses a did:web whose host is the link-local metadata IP, without fetching', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+      expect(await provider.resolveDID('did:web:169.254.169.254')).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('refuses loopback and RFC1918 did:web hosts by default, without fetching', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+      expect(await provider.resolveDID('did:web:127.0.0.1')).toBeNull();
+      expect(await provider.resolveDID('did:web:10.0.0.5')).toBeNull();
+      expect(await provider.resolveDID('did:web:192.168.1.1')).toBeNull();
+      expect(await provider.resolveDID('did:web:172.16.0.9')).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('refuses a status list on a private host by default, without fetching', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+      expect(await provider.fetchStatusList('http://169.254.169.254/status')).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('still resolves public did:web hosts (domain names are not IP-blocked)', async () => {
+      const did = 'did:web:example.com';
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          new Response(
+            JSON.stringify({
+              id: did,
+              verificationMethod: [
+                { id: `${did}#k`, type: 'Ed25519VerificationKey2020', controller: did },
+              ],
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      expect((await provider.resolveDID(did))?.id).toBe(did);
+    });
+
+    it('allows private targets when explicitly opted in', async () => {
+      const open = new RuntimeFetchProvider({ allowPrivateNetworkHosts: true });
+      const did = 'did:web:127.0.0.1';
+      const fetchSpy = vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            id: did,
+            verificationMethod: [
+              { id: `${did}#k`, type: 'Ed25519VerificationKey2020', controller: did },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+      expect((await open.resolveDID(did))?.id).toBe(did);
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/providers/system-clock.test.ts
+++ b/src/__tests__/providers/system-clock.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SystemClockProvider } from '../../providers/system-clock.js';
+
+describe('SystemClockProvider', () => {
+  let clock: SystemClockProvider;
+
+  beforeEach(() => {
+    clock = new SystemClockProvider();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('now', () => {
+    it('returns the current wall-clock time in ms', () => {
+      expect(clock.now()).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
+    });
+  });
+
+  describe('isWithinSkew', () => {
+    // The verifier calls isWithinSkew(proof.meta.ts * 1000, skew) — the arg is MS.
+    it('returns true inside the skew window', () => {
+      expect(clock.isWithinSkew(clock.now() - 4000, 5)).toBe(true);
+      expect(clock.isWithinSkew(clock.now() + 4000, 5)).toBe(true);
+    });
+    it('is inclusive at exactly the boundary', () => {
+      expect(clock.isWithinSkew(clock.now() - 5000, 5)).toBe(true);
+    });
+    it('returns false outside the skew window (past and future)', () => {
+      expect(clock.isWithinSkew(clock.now() - 6000, 5)).toBe(false);
+      expect(clock.isWithinSkew(clock.now() + 6000, 5)).toBe(false);
+    });
+  });
+
+  describe('hasExpired', () => {
+    it('reports expiry relative to now (ms epoch)', () => {
+      expect(clock.hasExpired(clock.now() - 1)).toBe(true);
+      expect(clock.hasExpired(clock.now() + 1000)).toBe(false);
+    });
+    it('is not expired exactly at now', () => {
+      expect(clock.hasExpired(clock.now())).toBe(false);
+    });
+  });
+
+  describe('calculateExpiry', () => {
+    it('adds ttlSeconds (converted to ms) to now', () => {
+      expect(clock.calculateExpiry(60)).toBe(clock.now() + 60_000);
+    });
+  });
+
+  describe('format', () => {
+    it('renders ISO-8601', () => {
+      expect(clock.format(clock.now())).toBe('2026-01-01T00:00:00.000Z');
+    });
+  });
+});

--- a/src/delegation/__tests__/scope-matcher.test.ts
+++ b/src/delegation/__tests__/scope-matcher.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { matchScope, scopeSatisfies } from '../scope-matcher.js';
+
+describe('matchScope', () => {
+  it('exact: matches identical strings only', () => {
+    expect(matchScope('repo:write', 'exact', 'repo:write')).toBe(true);
+    expect(matchScope('repo:write', 'exact', 'repo:write:extra')).toBe(false);
+  });
+
+  it('prefix: matches when value starts with the pattern (trailing * optional)', () => {
+    expect(matchScope('repo:', 'prefix', 'repo:write')).toBe(true);
+    expect(matchScope('repo:*', 'prefix', 'repo:write')).toBe(true);
+    expect(matchScope('repo:', 'prefix', 'billing:write')).toBe(false);
+  });
+
+  it('prefix: refuses an empty / "*"-only base (no universal grant)', () => {
+    expect(matchScope('', 'prefix', 'anything')).toBe(false);
+    expect(matchScope('*', 'prefix', 'anything')).toBe(false);
+  });
+
+  it('regex: matches anchored pattern', () => {
+    expect(matchScope('repo:(read|write)', 'regex', 'repo:write')).toBe(true);
+    expect(matchScope('repo:(read|write)', 'regex', 'repo:delete')).toBe(false);
+  });
+
+  it('regex: rejects nested-quantifier (ReDoS-prone) patterns fast, without executing them', () => {
+    // Intentional ReDoS bait. The dangerous quantifier is assembled from a
+    // runtime char rather than written as a static regex literal, so analyzers
+    // don't flag the test fixture itself — the whole point is that matchScope
+    // REJECTS these before ever compiling or running them.
+    const q = String.fromCharCode(43); // '+'
+    const nestedQuantifier = `(a${q})${q}$`; // (a+)+$
+    const boundedRepetition = `(.{1,9})${q}`; // (.{1,9})+
+    const start = Date.now();
+    expect(matchScope(nestedQuantifier, 'regex', 'a'.repeat(40) + '!')).toBe(false);
+    expect(matchScope(boundedRepetition, 'regex', 'a'.repeat(50))).toBe(false);
+    // If these were executed they would backtrack for many seconds; the guard
+    // must reject them near-instantly.
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('regex: rejects over-long patterns and values', () => {
+    expect(matchScope('a'.repeat(300), 'regex', 'a')).toBe(false);
+    expect(matchScope('abc', 'regex', 'a'.repeat(300))).toBe(false);
+  });
+
+  it('regex: invalid pattern returns false, never throws', () => {
+    expect(matchScope('repo:[', 'regex', 'repo:write')).toBe(false);
+  });
+});
+
+// Minimal credential shape; cast through unknown to avoid importing the full type surface in tests.
+const cred = (
+  scopes: string[],
+  crisp?: { resource: string; matcher: 'exact' | 'prefix' | 'regex' }[],
+) =>
+  ({
+    credentialSubject: {
+      delegation: {
+        scopes,
+        constraints: { ...(crisp ? { crisp: { scopes: crisp } } : {}) },
+      },
+    },
+  }) as unknown as Parameters<typeof scopeSatisfies>[1];
+
+describe('scopeSatisfies', () => {
+  it('flat scopes stay EXACT (no silent widening)', () => {
+    expect(scopeSatisfies('repo:write', cred(['repo:write'])).satisfied).toBe(true);
+    expect(scopeSatisfies('repo:write:x', cred(['repo:write'])).satisfied).toBe(false);
+  });
+
+  it('honors crisp.scopes prefix matcher and flags non-exact use', () => {
+    const r = scopeSatisfies('repo:write', cred([], [{ resource: 'repo:', matcher: 'prefix' }]));
+    expect(r.satisfied).toBe(true);
+    expect(r.usedNonExactMatcher).toBe(true);
+  });
+
+  it('exact crisp matcher does not flag non-exact use', () => {
+    const r = scopeSatisfies('repo:write', cred([], [{ resource: 'repo:write', matcher: 'exact' }]));
+    expect(r.satisfied).toBe(true);
+    expect(r.usedNonExactMatcher).toBe(false);
+  });
+
+  it('denies when nothing matches', () => {
+    expect(scopeSatisfies('billing:write', cred(['repo:write'])).satisfied).toBe(false);
+  });
+});

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -15,6 +15,7 @@ export * from './utils.js';
 export * from './outbound-proof.js';
 export * from './outbound-headers.js';
 export * from './audience-validator.js';
+export * from './scope-matcher.js';
 export {
   createDidKeyResolver,
   resolveDidKeySync,
@@ -28,6 +29,7 @@ export {
   isDidWeb,
   parseDidWeb,
   didWebToUrl,
+  buildDidWebDocument,
 } from './did-web-resolver.js';
 export { MemoryStatusListStorage } from './storage/memory-statuslist-storage.js';
 export { MemoryDelegationGraphStorage } from './storage/memory-graph-storage.js';

--- a/src/delegation/scope-matcher.ts
+++ b/src/delegation/scope-matcher.ts
@@ -1,0 +1,99 @@
+import type { DelegationCredential, CrispScope } from '../types/protocol.js';
+
+const MAX_REGEX_LEN = 256;
+const MAX_VALUE_LEN = 256;
+
+/**
+ * Conservative detector for the classic catastrophic-backtracking shape — a
+ * quantified group whose body also contains a quantifier, e.g. `(a+)+`, `(a*)*`,
+ * `(.{1,9})+`. This is a heuristic reject, NOT a proof of safety.
+ */
+const NESTED_QUANTIFIER = /\([^()]*[+*?{][^()]*\)\s*[+*{]/;
+
+export type ScopeMatcher = 'exact' | 'prefix' | 'regex';
+
+/**
+ * Match a single requested scope/resource value against a pattern by matcher kind.
+ *
+ * - `exact`  : strict string equality.
+ * - `prefix` : value starts with the pattern (a single trailing `*` is optional sugar).
+ *              An empty base ('' or lone '*') matches nothing — it will NOT grant
+ *              universal scope.
+ * - `regex`  : anchored full-string match; never throws (invalid patterns → false).
+ *
+ * SECURITY: the regex pattern is supplied by the credential ISSUER. JS `RegExp`
+ * is not linear-time, so this guards against the common catastrophic-backtracking
+ * shapes (nested quantifiers) and bounds input length — but it is a conservative
+ * mitigation, not a guarantee. Deployments accepting `regex` matchers from
+ * untrusted issuers should prefer `exact`/`prefix` or evaluate via a linear-time
+ * engine (e.g. RE2).
+ */
+export function matchScope(pattern: string, matcher: ScopeMatcher, value: string): boolean {
+  switch (matcher) {
+    case 'exact':
+      return pattern === value;
+    case 'prefix': {
+      const base = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+      // Refuse to grant universal scope via an empty/`*`-only prefix.
+      if (base.length === 0) return false;
+      return value.startsWith(base);
+    }
+    case 'regex': {
+      if (pattern.length > MAX_REGEX_LEN || value.length > MAX_VALUE_LEN) return false;
+      if (NESTED_QUANTIFIER.test(pattern)) return false;
+      try {
+        return new RegExp(`^(?:${pattern})$`).test(value);
+      } catch {
+        return false;
+      }
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Flat exact-match scope set: delegation.scopes ∪ constraints.scopes.
+ * Null-safe by design: scopeSatisfies is a public, never-throw predicate, so a
+ * structurally malformed credential (missing constraints) yields an empty set
+ * rather than a TypeError.
+ */
+function flatScopes(credential: DelegationCredential): string[] {
+  const d = credential?.credentialSubject?.delegation;
+  return [...(d?.scopes ?? []), ...(d?.constraints?.scopes ?? [])];
+}
+
+/** Opt-in CrispScope[] entries (constraints.crisp.scopes), if any. Null-safe. */
+function crispScopes(credential: DelegationCredential): CrispScope[] {
+  return credential?.credentialSubject?.delegation?.constraints?.crisp?.scopes ?? [];
+}
+
+export interface ScopeSatisfaction {
+  satisfied: boolean;
+  /**
+   * True when satisfaction came via a non-exact (prefix|regex) CrispScope matcher.
+   * Callers should surface a warning — non-exact matchers widen effective authority.
+   */
+  usedNonExactMatcher: boolean;
+}
+
+/**
+ * Decide whether a required scope id is satisfied by a credential.
+ *
+ * Flat `scopes[]` are matched EXACTLY (backwards-compatible). The opt-in
+ * `constraints.crisp.scopes[]` entries are honored per their declared matcher.
+ */
+export function scopeSatisfies(
+  requiredScopeId: string,
+  credential: DelegationCredential,
+): ScopeSatisfaction {
+  if (flatScopes(credential).includes(requiredScopeId)) {
+    return { satisfied: true, usedNonExactMatcher: false };
+  }
+  for (const cs of crispScopes(credential)) {
+    if (matchScope(cs.resource, cs.matcher, requiredScopeId)) {
+      return { satisfied: true, usedNonExactMatcher: cs.matcher !== 'exact' };
+    }
+  }
+  return { satisfied: false, usedNonExactMatcher: false };
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,6 +27,7 @@ export const KYA_OS_ERROR_CODES = {
   // Delegation errors
   needs_authorization: "needs_authorization",
   insufficient_scope: "insufficient_scope",
+  policy_denied: "policy_denied",
   delegation_expired: "delegation_expired",
   delegation_not_yet_valid: "delegation_not_yet_valid",
   delegation_revoked: "delegation_revoked",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,12 @@ export {
   type KyaOsErrorResponse,
 } from './errors.js';
 
-// Encoding utilities (RFC 4648 base64url, byte variants)
+// Encoding utilities (RFC 4648 base64url + standard base64, byte variants)
 export {
   base64urlEncodeFromBytes,
   base64urlDecodeToBytes,
+  bytesToBase64,
+  base64ToBytes,
 } from './utils/base64.js';
 
 // Protocol types
@@ -51,6 +53,7 @@ export type {
   AuditContext,
   AuditEventContext,
   NeedsAuthorizationError,
+  NeedsApprovalError,
   AuthorizationDisplay,
   CrispBudget,
   CrispScope,
@@ -65,6 +68,8 @@ export {
   validateDetachedProof,
   createNeedsAuthorizationError,
   isNeedsAuthorizationError,
+  createNeedsApprovalError,
+  isNeedsApprovalError,
   DELEGATION_CREDENTIAL_CONTEXT,
   DEFAULT_SESSION_TTL_MINUTES,
   DEFAULT_TIMESTAMP_SKEW_SECONDS,
@@ -264,6 +269,8 @@ export {
 } from './providers/memory.js';
 
 export { NodeCryptoProvider } from './providers/node-crypto.js';
+export { SystemClockProvider } from './providers/system-clock.js';
+export { RuntimeFetchProvider } from './providers/runtime-fetch.js';
 
 export {
   AuditLogProvider,
@@ -286,6 +293,15 @@ export {
   generateIdentity,
   type WithKyaOsOptions,
 } from './middleware/index.js';
+
+// Policy-as-Code subsystem + step-up gate
+export * from './policy/index.js';
+export {
+  matchScope,
+  scopeSatisfies,
+  type ScopeMatcher,
+  type ScopeSatisfaction,
+} from './delegation/scope-matcher.js';
 
 // Logging
 export {

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -84,6 +84,7 @@ async function issueDelegationVC(options?: {
   parentId?: string;
   credentialStatus?: CredentialStatus;
   subjectDid?: string;
+  crispScopes?: { resource: string; matcher: 'exact' | 'prefix' | 'regex' }[];
 }): Promise<DelegationCredential> {
   const issuerIdentity = options?.issuer ?? await createDelegationIssuer();
 
@@ -95,6 +96,7 @@ async function issueDelegationVC(options?: {
       parentId: options?.parentId,
       constraints: {
         scopes: options?.scopes ?? [],
+        ...(options?.crispScopes ? { crisp: { scopes: options.crispScopes } } : {}),
         ...(options?.audience !== undefined && { audience: options.audience }),
         notAfter: Math.floor(Date.now() / 1000) + 3600,
       },
@@ -430,6 +432,287 @@ describe('createKyaOsMiddleware', () => {
       expect(parsed.error).toBe('insufficient_scope');
     });
 
+    it('emits a signed denial proof (outcome=denied) on insufficient scope', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      const hs = await kyaos.handleHandshake({
+        nonce: 'test-nonce-denial',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const vc = await issueDelegationVC({ scopes: ['wrong:scope'] });
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _kyaos_delegation: vc }, sessionId);
+
+      expect(result.isError).toBe(true);
+      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
+      expect(meta?.proof?.meta?.['outcome']).toBe('denied');
+      expect(meta?.proof?.meta?.['responseHash']).toBeUndefined();
+    });
+
+    it('emits a signed proof (outcome=needs_authorization) on the no-delegation challenge', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      const hs = await kyaos.handleHandshake({
+        nonce: 'test-nonce-needsauth',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ name: 'world' }, sessionId);
+
+      // The challenge content is unchanged (still the needs_authorization JSON)...
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('needs_authorization');
+      expect(parsed.authorizationUrl).toBe('https://example.com/consent');
+
+      // ...and now carries a signed proof that BINDS the challenge content via
+      // responseHash (covering the authorizationUrl) — option B, anti-MITM.
+      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
+      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+    });
+
+    it('renders the challenge via formatChallenge and binds the proof over THAT content', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      const hs = await kyaos.handleHandshake({
+        nonce: 'test-nonce-fmtchallenge',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        {
+          scopeId: 'test:scope',
+          consentUrl: 'https://example.com/consent',
+          // Render a markdown consent link (as the consent-* examples do for
+          // LLM clients) instead of the default JSON challenge.
+          formatChallenge: (challenge) => [
+            {
+              type: 'text',
+              text: `Authorize at https://example.com/c?token=${challenge.resumeToken}`,
+            },
+          ],
+        },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ name: 'world' }, sessionId);
+
+      // The emitted content is the custom rendering, not the JSON challenge.
+      expect(result.content[0].text).toContain('Authorize at https://example.com/c?token=');
+      expect(() => JSON.parse(result.content[0].text)).toThrow();
+
+      // The proof binds a responseHash over the rendered content (so a verifier
+      // hashing what the client received matches) with outcome=needs_authorization.
+      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
+      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+    });
+
+    it('falls back to the default JSON challenge when formatChallenge throws (no -32603)', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      const hs = await kyaos.handleHandshake({
+        nonce: 'test-nonce-fmtthrows',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        {
+          scopeId: 'test:scope',
+          consentUrl: 'https://example.com/consent',
+          // A buggy renderer must never escalate to a JSON-RPC -32603 crash: the
+          // challenge degrades to the default JSON shape, still proof-bound.
+          formatChallenge: () => {
+            throw new Error('boom in formatChallenge');
+          },
+        },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ name: 'world' }, sessionId);
+
+      // Degrades to the default needs_authorization JSON, not an internal error.
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('needs_authorization');
+      expect(parsed.authorizationUrl).toBe('https://example.com/consent');
+
+      // Still carries a signed proof binding the (default) challenge content.
+      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
+      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+    });
+
+    it('returns delegation_invalid (not a crash) for structurally malformed delegations', async () => {
+      const { middleware: kyaos } = await createTestMiddleware();
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      // Each previously threw "Cannot read properties of undefined (reading 'delegation')"
+      // (object branch) or was already handled (string branch). None may crash.
+      const malformed: unknown[] = [
+        { bogus: true },
+        { credentialSubject: {} },
+        { credentialSubject: { delegation: null } },
+        42,
+        ['x'],
+        'not-a-jwt',
+      ];
+      for (const bad of malformed) {
+        const result = await handler({ _kyaos_delegation: bad });
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.error).toBe('delegation_invalid');
+      }
+    });
+
+    it('attaches a signed denial proof (outcome=denied) for a malformed delegation', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      const hs = await kyaos.handleHandshake({
+        nonce: 'test-nonce-malformed',
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _kyaos_delegation: { bogus: true } }, sessionId);
+      expect(result.isError).toBe(true);
+      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
+      expect(meta?.proof?.meta?.['outcome']).toBe('denied');
+    });
+
+    it('returns delegation_invalid (not a crash) when a delegation accessor throws', async () => {
+      const { middleware: kyaos } = await createTestMiddleware();
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      // A getter that throws on property access must not escape as MCP -32603.
+      const throwingDelegation = {};
+      Object.defineProperty(throwingDelegation, 'credentialSubject', {
+        get() {
+          throw new Error('boom');
+        },
+        enumerable: true,
+      });
+
+      const result = await handler({ _kyaos_delegation: throwingDelegation });
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+    });
+
+    it('sanitizes control characters from caller-derived values in the client reason', async () => {
+      const { middleware: kyaos } = await createTestMiddleware();
+      const vc = await issueDelegationVC({ scopes: ['test:scope'] });
+      // A hostile credential embeds control chars (NUL, ESC, newline) in its id.
+      // Tampering the id invalidates the signature; the resulting reason must not
+      // reflect raw control chars into the client response (log-injection /
+      // terminal-corruption risk). Built via fromCharCode to keep source ASCII.
+      const ctrl = String.fromCharCode(0, 27, 10);
+      (vc as unknown as { credentialSubject: { delegation: { id: string } } })
+        .credentialSubject.delegation.id = `evil${ctrl}id`;
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+      const result = await handler({ _kyaos_delegation: vc });
+
+      expect(result.isError).toBe(true);
+      const reason = JSON.parse(result.content[0].text).reason as string;
+      const hasControlChar = [...reason].some((c) => {
+        const o = c.charCodeAt(0);
+        return o < 0x20 || (o >= 0x7f && o <= 0x9f);
+      });
+      expect(hasControlChar).toBe(false);
+      expect(reason).toContain(String.fromCharCode(0xfffd));
+    });
+
+    it('returns delegation_invalid (not a crash) for a constraints-less leaf', async () => {
+      const { middleware: kyaos } = await createTestMiddleware();
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+      // A hand-crafted leaf with NO constraints. The leaf shape guard rejects it
+      // with delegation_invalid; without the guard, the constraints-less VC would
+      // reach scopeSatisfies (which runs OUTSIDE the wrapper's backstop) and throw
+      // a raw TypeError surfaced as MCP -32603. scopeSatisfies is also null-safe.
+      const malformedLeaf = {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        type: ['VerifiableCredential'],
+        credentialSubject: {
+          id: 'did:key:zSubject',
+          delegation: {
+            id: 'leaf-no-constraints',
+            issuerDid: 'did:key:zIssuer',
+            subjectDid: 'did:key:zSubject',
+            parentId: 'parent-1',
+            status: 'active',
+          },
+        },
+        proof: { type: 'Ed25519Signature2020', proofValue: 'x' },
+      } as unknown as DelegationCredential;
+
+      const result = await handler({ _kyaos_delegation: malformedLeaf });
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+    });
+
+    it('should accept when scope is granted via a crisp.scopes prefix matcher', async () => {
+      const { middleware: kyaos } = await createTestMiddleware();
+      const vc = await issueDelegationVC({
+        scopes: [],
+        crispScopes: [{ resource: 'test:', matcher: 'prefix' }],
+      });
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async (args) => ({
+          content: [{ type: 'text', text: `Called: ${JSON.stringify(args)}` }],
+        }),
+      );
+
+      const result = await handler({ _kyaos_delegation: vc, name: 'DIF' });
+
+      expect(result.isError).toBeUndefined();
+    });
+
     it('should accept and call handler when VC has correct scope and valid signature', async () => {
       const { middleware: kyaos } = await createTestMiddleware();
       const vc = await issueDelegationVC({ scopes: ['test:scope', 'other:scope'] });
@@ -558,6 +841,50 @@ describe('createKyaOsMiddleware', () => {
       expect(parsed.reason).toContain('widens scopes');
     });
 
+    it('should reject re-delegations that introduce crisp scope matchers absent from the parent', async () => {
+      const parentIssuer = await createDelegationIssuer();
+      const childIssuer = await createDelegationIssuer();
+      const leafSubject = (await createDelegationIssuer()).did;
+
+      // Audience binding on re-delegations is mandatory, so the middleware must
+      // exist first to supply its DID as the re-delegation's audience.
+      let parentVcRef!: DelegationCredential;
+      const { middleware: kyaos, did: serverDid } = await createTestMiddleware({
+        delegation: { resolveDelegationChain: async () => [parentVcRef] },
+      });
+
+      const parentVc = await issueDelegationVC({
+        issuer: parentIssuer,
+        scopes: ['test:scope'],
+        subjectDid: childIssuer.did,
+      });
+      parentVcRef = parentVc;
+
+      // Flat scopes do NOT widen, but the child sneaks in a crisp prefix matcher
+      // with an empty resource that would match every scope — privilege escalation.
+      const childVc = await issueDelegationVC({
+        issuer: childIssuer,
+        scopes: ['test:scope'],
+        crispScopes: [{ resource: 'admin:', matcher: 'prefix' }],
+        parentId: parentVc.credentialSubject.delegation.id,
+        subjectDid: leafSubject,
+        audience: serverDid,
+      });
+
+      const handler = kyaos.wrapWithDelegation(
+        'my-tool',
+        { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+        async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+      );
+
+      const result = await handler({ _kyaos_delegation: childVc });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe('delegation_invalid');
+      expect(parsed.reason).toContain('crisp scope matcher');
+    });
+
     it('should accept did:web issuers when a fetch-backed resolver is available', async () => {
       const did = 'did:web:issuer.example.com';
       const kid = `${did}#key-1`;
@@ -677,5 +1004,88 @@ describe('createKyaOsMiddleware', () => {
 
       expect(proof1.meta.sessionId).toBe(proof2.meta.sessionId);
     });
+  });
+});
+
+describe('withPolicyGate', () => {
+  const text = (r: { content: Array<{ text: string }> }) => r.content[0].text;
+
+  it('allows a reversible, low-severity action', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const handler = kyaos.withPolicyGate!('repo.read', async (args) => ({
+      content: [{ type: 'text', text: `ran:${JSON.stringify(args)}` }],
+    }), { scopeMatched: true });
+    const result = await handler({ id: 1 });
+    expect(result.isError).toBeUndefined();
+    expect(text(result)).toContain('ran:');
+  });
+
+  it('denies an unclassified (unknown) action — fail-closed', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const handler = kyaos.withPolicyGate!('frobnicate', async () => ({
+      content: [{ type: 'text', text: 'ran' }],
+    }), { scopeMatched: true });
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(text(result)).error).toBe('policy_denied');
+  });
+
+  it('requires step-up (needs_approval) for a destructive prod action', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const handler = kyaos.withPolicyGate(
+      'db.drop',
+      async () => ({ content: [{ type: 'text', text: 'ran' }] }),
+      { resolveNamespace: () => 'prod', scopeMatched: true },
+    );
+    const result = await handler({ table: 'users' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(text(result));
+    expect(body.error).toBe('needs_approval');
+    expect(typeof body.requestHash).toBe('string');
+    expect(body.quorum.n).toBe(1);
+  });
+
+  it('proceeds once a valid approval grant bound to the requestHash is supplied', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const handler = kyaos.withPolicyGate(
+      'db.drop',
+      async (args) => ({ content: [{ type: 'text', text: `ran:${JSON.stringify(args)}` }] }),
+      { resolveNamespace: () => 'prod', isValidApprovalSignature: async () => true, scopeMatched: true },
+    );
+
+    const first = await handler({ table: 'users' });
+    const { requestHash } = JSON.parse(text(first));
+
+    const grant = {
+      approvalRequestId: 'r1',
+      approverDid: 'did:example:approver',
+      requestHash,
+      decision: 'approve',
+      ts: 1,
+      signature: 'sig',
+    };
+    const second = await handler({ table: 'users', _kyaos_approvals: [grant] });
+    expect(second.isError).toBeUndefined();
+    expect(text(second)).toContain('ran:');
+  });
+
+  it('rejects an approval grant bound to a different requestHash (TOCTOU)', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const handler = kyaos.withPolicyGate(
+      'db.drop',
+      async () => ({ content: [{ type: 'text', text: 'ran' }] }),
+      { resolveNamespace: () => 'prod', isValidApprovalSignature: async () => true, scopeMatched: true },
+    );
+    const grant = {
+      approvalRequestId: 'r1',
+      approverDid: 'did:example:approver',
+      requestHash: 'sha256:WRONG',
+      decision: 'approve',
+      ts: 1,
+      signature: 'sig',
+    };
+    const result = await handler({ table: 'users', _kyaos_approvals: [grant] });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(text(result)).error).toBe('needs_approval');
   });
 });

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -17,8 +17,9 @@
 
 import {
   type CryptoProvider,
-  FetchProvider,
+  type FetchProvider,
 } from "../providers/base.js";
+import { RuntimeFetchProvider } from "../providers/runtime-fetch.js";
 import { AuditLogProvider, NoopAuditLogProvider } from "../providers/audit-log.js";
 import {
   SessionManager,
@@ -39,15 +40,23 @@ import {
   type StatusListResolver,
 } from "../delegation/vc-verifier.js";
 import { createDidKeyResolver } from "../delegation/did-key-resolver.js";
+import { scopeSatisfies } from "../delegation/scope-matcher.js";
 import { createDidWebResolver } from "../delegation/did-web-resolver.js";
 import { verifyDelegationAudience } from "../delegation/audience-validator.js";
 import {
   createNeedsAuthorizationError,
+  createNeedsApprovalError,
   extractDelegationFromVC,
   type DelegationCredential,
   type DelegationRecord,
+  type NeedsAuthorizationError,
 } from "../types/protocol.js";
 import { logger } from "../logging/index.js";
+import { RiskClassifier } from "../policy/classifier.js";
+import { DefaultPolicyEngine } from "../policy/default-engine.js";
+import { verifyApprovalQuorum, type ApprovalGrant } from "../policy/approval.js";
+import type { PolicyEngine } from "../policy/engine.js";
+import type { PolicyRequest } from "../policy/types.js";
 import { KYA_OS_ERROR_CODES } from "../errors.js";
 import { canonicalizeJSON, parseVCJWT } from "../delegation/utils.js";
 import { base64urlDecodeToBytes, base64urlEncodeFromBytes, bytesToBase64 } from "../utils/base64.js";
@@ -219,31 +228,36 @@ export interface KyaOsMiddleware {
     config: {
       scopeId: string;
       consentUrl: string;
+      /**
+       * Optional presentation hook for the `needs_authorization` challenge.
+       * Given the structured challenge, return the tool-response content to emit
+       * (e.g. a markdown "Authorize" link for LLM / chat-style MCP clients that
+       * won't parse raw JSON). The signed challenge proof binds a `responseHash`
+       * over WHATEVER this returns, so the `authorizationUrl` stays tamper-evident
+       * regardless of presentation. Defaults to the structured challenge as JSON.
+       */
+      formatChallenge?: (
+        challenge: NeedsAuthorizationError,
+      ) => Array<{ type: "text"; text: string }>;
     },
     handler: KyaOsToolHandler,
   ): KyaOsToolHandler;
-}
 
-class RuntimeFetchProvider extends FetchProvider {
-  async resolveDID(): Promise<null> {
-    return null;
-  }
-
-  async fetchStatusList(): Promise<null> {
-    return null;
-  }
-
-  async fetchDelegationChain(): Promise<DelegationRecord[]> {
-    return [];
-  }
-
-  async fetch(url: string, options?: unknown): Promise<Response> {
-    if (typeof globalThis.fetch !== "function") {
-      throw new Error("Global fetch is not available in this runtime");
-    }
-
-    return globalThis.fetch(url, options as RequestInit);
-  }
+  /**
+   * Wrap a tool handler with a per-action policy / step-up gate.
+   *
+   * Compose after `wrapWithDelegation`. Classifies the action's risk and asks a
+   * pluggable PolicyEngine: allow → run handler; deny → signed denial proof;
+   * step_up → `needs_approval` until N-of-M signed approval grants (bound to the
+   * request hash) are supplied.
+   */
+  // Optional so external structural implementers / mocks of KyaOsMiddleware are
+  // not broken by this additive method.
+  withPolicyGate?(
+    toolName: string,
+    handler: KyaOsToolHandler,
+    opts?: PolicyGateOptions,
+  ): KyaOsToolHandler;
 }
 
 function getDelegationScopes(credential: DelegationCredential): string[] {
@@ -253,11 +267,91 @@ function getDelegationScopes(credential: DelegationCredential): string[] {
     scopes.add(scope);
   }
 
-  for (const scope of credential.credentialSubject.delegation.constraints.scopes ?? []) {
+  for (const scope of credential.credentialSubject.delegation.constraints?.scopes ?? []) {
     scopes.add(scope);
   }
 
   return Array.from(scopes);
+}
+
+/**
+ * Strip control characters and cap length on caller-derived values before they
+ * are interpolated into client-facing reasons or log lines. A hostile
+ * credential could otherwise embed newlines / control chars in an id or scope to
+ * forge or corrupt log entries (log injection) or break a terminal. The fixed
+ * parts of a reason contain no control chars, so sanitizing the whole assembled
+ * string at the emission boundary is equivalent to sanitizing each interpolated
+ * value, and is idempotent.
+ */
+function sanitizeForMessage(value: unknown, maxLen = 256): string {
+  const s = typeof value === "string" ? value : String(value);
+  // Replace C0/C1 control chars (incl. CR, LF, TAB, ESC, DEL) with U+FFFD so a
+  // hostile id/scope cannot forge log lines or break a terminal. Filtered by
+  // code point to keep this source ASCII-only (no literal control chars).
+  let out = "";
+  for (const ch of s) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "\uFFFD" : ch;
+  }
+  return out.length > maxLen ? `${out.slice(0, maxLen)}\u2026` : out;
+}
+
+export interface PolicyGateOptions {
+  /** Policy decision engine. Defaults to a fail-closed DefaultPolicyEngine. */
+  engine?: PolicyEngine;
+  /** Risk classifier. Defaults to the built-in RiskClassifier. */
+  classifier?: RiskClassifier;
+  /** Derive the resource namespace from the tool args (defaults to the tool name). */
+  resolveNamespace?: (args: Record<string, unknown>) => string;
+  /** Tool-arg key carrying approval grants on resume. Default "_kyaos_approvals". */
+  approvalsArgKey?: string;
+  /** Verifier for approval-grant signatures (identity-layer). Default: reject all. */
+  isValidApprovalSignature?: (grant: ApprovalGrant) => Promise<boolean>;
+  /**
+   * Whether a prior step already authorized this action's scope/identity.
+   *
+   * Defaults to FALSE (fail-closed): used standalone, withPolicyGate enforces no
+   * scope or identity, so it must NOT be trusted to allow on its own. When you
+   * compose it AFTER wrapWithDelegation (the expected usage), pass
+   * `scopeMatched: true` to signal that the delegated scope was already verified.
+   * Note: principal facts are projected from the (unverified) `_kyaos_delegation`
+   * arg on a best-effort basis and must not be treated as authenticated unless
+   * wrapWithDelegation ran first.
+   */
+  scopeMatched?: boolean;
+}
+
+/** Best-effort projection of a delegation VC into policy principal facts. */
+function extractPolicyPrincipal(del: unknown): {
+  agentDid: string;
+  responsibleParty?: string;
+  delegatedScopes: string[];
+} {
+  if (!del || typeof del !== "object") {
+    return { agentDid: "unknown", delegatedScopes: [] };
+  }
+  try {
+    const vc = del as DelegationCredential;
+    const subject = vc.credentialSubject as unknown as {
+      id?: string;
+      delegation?: { subjectDid?: string; controller?: string };
+    };
+    const agentDid = subject?.delegation?.subjectDid ?? subject?.id ?? "unknown";
+    const responsibleParty = subject?.delegation?.controller;
+    let delegatedScopes: string[] = [];
+    try {
+      delegatedScopes = getDelegationScopes(vc);
+    } catch {
+      delegatedScopes = [];
+    }
+    return {
+      agentDid,
+      ...(responsibleParty ? { responsibleParty } : {}),
+      delegatedScopes,
+    };
+  } catch {
+    return { agentDid: "unknown", delegatedScopes: [] };
+  }
 }
 
 function validateScopeAttenuation(
@@ -267,6 +361,26 @@ function validateScopeAttenuation(
   const parentScopes = getDelegationScopes(parentCredential);
   const childScopes = getDelegationScopes(childCredential);
   const childDelegation = childCredential.credentialSubject.delegation;
+
+  // CRISP matcher attenuation: getDelegationScopes does NOT see constraints.crisp.scopes,
+  // so a re-delegation could otherwise widen authority by introducing a broad
+  // prefix/regex matcher (e.g. resource:"" matches every scope). Require the child's
+  // crisp matchers to be a subset of the parent's (by matcher+resource). Fail closed.
+  const crispKey = (s: { resource: string; matcher: string }): string => `${s.matcher}\u0000${s.resource}`;
+  const parentCrisp = new Set(
+    (parentCredential.credentialSubject.delegation.constraints.crisp?.scopes ?? []).map(crispKey),
+  );
+  const widenedCrisp = (childDelegation.constraints.crisp?.scopes ?? []).filter(
+    (s) => !parentCrisp.has(crispKey(s)),
+  );
+  if (widenedCrisp.length > 0) {
+    return {
+      valid: false,
+      reason: `Delegation ${childDelegation.id} introduces crisp scope matcher(s) absent from parent ${parentCredential.credentialSubject.delegation.id}: ${widenedCrisp
+        .map((s) => `${s.matcher}:${s.resource}`)
+        .join(", ")}`,
+    };
+  }
 
   if (parentScopes.length === 0) {
     return { valid: true };
@@ -621,9 +735,75 @@ export function createKyaOsMiddleware(
     };
   }
 
+  /**
+   * Attach a signed proof recording an authorization OUTCOME to a response, so
+   * rejected or pending privileged attempts leave a verifiable, non-repudiable
+   * forensic record (these previously produced no proof). Used for `denied`,
+   * `step_up_required`, and `needs_authorization` outcomes.
+   *
+   * When `responseData` is provided (e.g. the `needs_authorization` challenge
+   * content), the proof binds a `responseHash` over it — so the signed proof
+   * also attests the response body (notably the consent `authorizationUrl`),
+   * letting a verifier detect a tampered/MITM-swapped URL. Pure denials and
+   * step-ups pass no `responseData` (there is no response body to bind).
+   *
+   * Best-effort: if no session can be resolved or proof generation fails, the
+   * original response is returned unchanged.
+   */
+  async function attachOutcomeProof(
+    response: Awaited<ReturnType<KyaOsToolHandler>>,
+    toolName: string,
+    args: Record<string, unknown>,
+    sessionId: string | undefined,
+    reason: string,
+    outcome: "denied" | "step_up_required" | "needs_authorization" = "denied",
+    paramsOverride?: Record<string, unknown>,
+    responseData?: unknown,
+  ): Promise<Awaited<ReturnType<KyaOsToolHandler>>> {
+    try {
+      const resolvedSessionId = sessionId ?? (await ensureSession());
+      if (!resolvedSessionId) return response;
+      const session = await sessionManager.getSession(resolvedSessionId);
+      if (!session) return response;
+
+      // Prefer the caller's already-stripped args so the signed requestHash
+      // matches the needs_approval / resumeToken requestHash exactly.
+      let cleanArgs: Record<string, unknown>;
+      if (paramsOverride !== undefined) {
+        cleanArgs = paramsOverride;
+      } else {
+        cleanArgs = {};
+        for (const [k, v] of Object.entries(args)) {
+          if (k !== "_kyaos_delegation") cleanArgs[k] = v;
+        }
+      }
+
+      const request: ToolRequest = { method: toolName, params: cleanArgs };
+      const proofResponse: ToolResponse | undefined =
+        responseData !== undefined ? { data: responseData } : undefined;
+      const proof = await proofGenerator.generateProof(request, proofResponse, session, {
+        outcome,
+        reason: sanitizeForMessage(reason),
+      });
+      response._meta = { ...(response._meta ?? {}), proof };
+    } catch (error) {
+      logger.error("[kya-os] Outcome proof generation failed", {
+        tool: toolName,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return response;
+  }
+
   function wrapWithDelegation(
     toolName: string,
-    config: { scopeId: string; consentUrl: string },
+    config: {
+      scopeId: string;
+      consentUrl: string;
+      formatChallenge?: (
+        challenge: NeedsAuthorizationError,
+      ) => Array<{ type: "text"; text: string }>;
+    },
     handler: KyaOsToolHandler,
   ): KyaOsToolHandler {
     const didKeyResolver = createDidKeyResolver();
@@ -713,7 +893,7 @@ export function createKyaOsMiddleware(
       content: [
         {
           type: "text" as const,
-          text: JSON.stringify({ error, reason }),
+          text: JSON.stringify({ error, reason: sanitizeForMessage(reason) }),
         },
       ],
       isError: true,
@@ -723,6 +903,31 @@ export function createKyaOsMiddleware(
       leafCredential: DelegationCredential,
       options?: { skipSignature?: boolean },
     ): Promise<{ valid: boolean; reason?: string }> => {
+      // Shape guard (validate* never-throw contract): a structurally malformed
+      // leaf returns a { valid, reason } result rather than letting
+      // extractDelegationFromVC OR the downstream scopeSatisfies check throw.
+      // Requires both credentialSubject.delegation AND .constraints (the
+      // verifier's own invariant) — the legacy-unsafe path can reach
+      // scopeSatisfies, which runs OUTSIDE the wrapper's try/catch backstop, so a
+      // constraints-less leaf must be rejected here. A hostile getter/Proxy
+      // accessor still throws → caught by the backstop, by design.
+      const leafDelegationObj = (
+        leafCredential?.credentialSubject as
+          | { delegation?: { constraints?: unknown } }
+          | undefined
+      )?.delegation;
+      if (
+        !leafDelegationObj ||
+        typeof leafDelegationObj !== "object" ||
+        !leafDelegationObj.constraints ||
+        typeof leafDelegationObj.constraints !== "object"
+      ) {
+        return {
+          valid: false,
+          reason:
+            "Malformed delegation credential: missing credentialSubject.delegation or its constraints",
+        };
+      }
       const leafDelegation = extractDelegationFromVC(leafCredential);
       let chain: DelegationCredential[] = [leafCredential];
 
@@ -899,9 +1104,41 @@ export function createKyaOsMiddleware(
           scopes: [config.scopeId],
         });
 
-        return {
-          content: [{ type: "text", text: JSON.stringify(authError) }],
-        };
+        // Sign the challenge (outcome=needs_authorization). The proof binds a
+        // responseHash over the EMITTED challenge content — including the
+        // authorizationUrl. A verifier that recomputes the response hash over the
+        // content it received (ProofVerifier.verifyProof(proof, jwk, { request,
+        // response })) thereby detects a tampered/MITM-swapped consent URL; the
+        // signature alone proves authenticity, not content-match. config.format-
+        // Challenge lets a server render the challenge (e.g. a markdown link for
+        // LLM clients) BEFORE signing, so the proof binds exactly what the client
+        // receives. A throwing hook falls back to the default challenge (never
+        // -32603). Best-effort: attachOutcomeProof no-ops if no session resolves.
+        const defaultChallengeContent = [
+          { type: "text" as const, text: JSON.stringify(authError) },
+        ];
+        let challengeContent = defaultChallengeContent;
+        if (config.formatChallenge) {
+          try {
+            challengeContent = config.formatChallenge(authError);
+          } catch (error) {
+            logger.error("[kya-os] formatChallenge threw; using the default challenge", {
+              tool: toolName,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            challengeContent = defaultChallengeContent;
+          }
+        }
+        return attachOutcomeProof(
+          { content: challengeContent },
+          toolName,
+          args,
+          sessionId,
+          authError.message,
+          "needs_authorization",
+          undefined,
+          challengeContent,
+        );
       }
 
       // Accept delegation as either a JSON object (embedded proof) or a
@@ -912,8 +1149,14 @@ export function createKyaOsMiddleware(
       if (typeof delegationArg === "string") {
         const parsed = parseVCJWT(delegationArg);
         if (!parsed || !parsed.payload.vc) {
-          return buildDelegationErrorResponse(
-            KYA_OS_ERROR_CODES.delegation_invalid,
+          return attachOutcomeProof(
+            buildDelegationErrorResponse(
+              KYA_OS_ERROR_CODES.delegation_invalid,
+              "Invalid VC-JWT format",
+            ),
+            toolName,
+            args,
+            sessionId,
             "Invalid VC-JWT format",
           );
         }
@@ -929,31 +1172,66 @@ export function createKyaOsMiddleware(
         vc = delegationArg as DelegationCredential;
       }
 
-      // For VC-JWTs, skip the embedded proof/signature check — the JWT
-      // envelope signature is the proof. Basic checks (schema, expiry,
-      // status, scopes) still apply.
-      const verificationResult = await validateDelegationChain(vc, {
-        skipSignature: isVCJWT,
-      });
+      // For VC-JWTs the embedded-signature check is skipped (the JWT envelope
+      // signature is the proof); schema/expiry/status/scope checks still apply.
+      // validateDelegationChain performs the shape check and returns
+      // { valid, reason } for malformed input, never throwing on normal or
+      // structurally-malformed credentials. This try/catch is therefore a PURE
+      // BACKSTOP — it fires only on a truly unexpected throw (e.g. a hostile
+      // getter/Proxy accessor or a provider fault): it logs the detail
+      // server-side and returns a GENERIC reason, so no internal/implementation
+      // detail (stack, raw error text) leaks to the client or the signed proof.
+      const verificationResult = await (async (): Promise<{
+        valid: boolean;
+        reason?: string;
+      }> => {
+        try {
+          return await validateDelegationChain(vc, { skipSignature: isVCJWT });
+        } catch (error) {
+          logger.error("[kya-os] Unexpected error verifying delegation", {
+            tool: toolName,
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+          return { valid: false, reason: "Delegation credential could not be verified" };
+        }
+      })();
 
       if (!verificationResult.valid) {
+        const reason = verificationResult.reason ?? "Unknown delegation validation error";
         logger.warn(
-          `[kya-os] Delegation verification failed for "${toolName}": ${verificationResult.reason}`,
+          `[kya-os] Delegation verification failed for "${toolName}": ${sanitizeForMessage(reason)}`,
         );
-        return buildDelegationErrorResponse(
-          KYA_OS_ERROR_CODES.delegation_invalid,
-          verificationResult.reason ?? "Unknown delegation validation error",
+        return attachOutcomeProof(
+          buildDelegationErrorResponse(KYA_OS_ERROR_CODES.delegation_invalid, reason),
+          toolName,
+          args,
+          sessionId,
+          reason,
         );
       }
 
-      const scopes = getDelegationScopes(vc);
-      if (!scopes.includes(config.scopeId)) {
+      // Safe to call directly: the structural guard + validateDelegationChain
+      // above guarantee a well-formed credential here, and scopeSatisfies is
+      // bounded (ReDoS-guarded) and returns rather than throws.
+      const scopeResult = scopeSatisfies(config.scopeId, vc);
+      if (scopeResult.usedNonExactMatcher) {
+        logger.warn(
+          `[kya-os] Scope "${config.scopeId}" for "${toolName}" granted via a non-exact ` +
+            `(prefix/regex) matcher. Verify this is intended — non-exact matchers widen authority.`,
+        );
+      }
+      if (!scopeResult.satisfied) {
+        const reason = `Required scope "${config.scopeId}" not in delegation scopes`;
         logger.warn(
           `[kya-os] Delegation missing required scope "${config.scopeId}" for "${toolName}"`,
         );
-        return buildDelegationErrorResponse(
-          KYA_OS_ERROR_CODES.insufficient_scope,
-          `Required scope "${config.scopeId}" not in delegation scopes`,
+        return attachOutcomeProof(
+          buildDelegationErrorResponse(KYA_OS_ERROR_CODES.insufficient_scope, reason),
+          toolName,
+          args,
+          sessionId,
+          reason,
         );
       }
 
@@ -970,6 +1248,127 @@ export function createKyaOsMiddleware(
     };
   }
 
+  const defaultRiskClassifier = new RiskClassifier();
+  const defaultPolicyEngine: PolicyEngine = new DefaultPolicyEngine();
+
+  /**
+   * Per-action policy / step-up gate. Composed AFTER wrapWithDelegation (which
+   * enforces identity + scope); this wrapper adds the PROPORTIONALITY layer:
+   * classify the action's risk, ask a pluggable PolicyEngine, and either allow,
+   * deny (with a signed denial proof), or require N-of-M human approval
+   * (needs_approval) before the handler runs. It forces a decision point — it
+   * does not itself supply judgment.
+   */
+  function withPolicyGate(
+    toolName: string,
+    handler: KyaOsToolHandler,
+    opts: PolicyGateOptions = {},
+  ): KyaOsToolHandler {
+    const engine = opts.engine ?? defaultPolicyEngine;
+    const classifier = opts.classifier ?? defaultRiskClassifier;
+    const approvalsKey = opts.approvalsArgKey ?? "_kyaos_approvals";
+    const isValidApprovalSignature =
+      opts.isValidApprovalSignature ?? (async () => false);
+
+    return async (args: Record<string, unknown>, sessionId?: string) => {
+      const controlKeys = new Set(["_kyaos_delegation", approvalsKey]);
+      const cleanArgs: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(args)) {
+        if (!controlKeys.has(k)) cleanArgs[k] = v;
+      }
+
+      const namespace = opts.resolveNamespace?.(args) ?? toolName;
+      const risk = classifier.classify({ toolName, namespace });
+      const principal = extractPolicyPrincipal(args["_kyaos_delegation"]);
+
+      const policyRequest: PolicyRequest = {
+        principal: {
+          agentDid: principal.agentDid,
+          ...(principal.responsibleParty
+            ? { responsibleParty: principal.responsibleParty }
+            : {}),
+        },
+        action: { toolName },
+        resource: { namespace },
+        context: {
+          delegatedScopes: principal.delegatedScopes,
+          scopeMatched: opts.scopeMatched ?? false,
+          humanApprovals: [],
+          ...risk,
+        },
+      };
+
+      const decision = await engine.evaluate(policyRequest);
+
+      if (decision.decision === "allow") {
+        return handler(cleanArgs, sessionId);
+      }
+
+      if (decision.decision === "deny") {
+        const denied: Awaited<ReturnType<KyaOsToolHandler>> = {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: KYA_OS_ERROR_CODES.policy_denied,
+                reason: sanitizeForMessage(decision.reason),
+              }),
+            },
+          ],
+          isError: true,
+        };
+        return attachOutcomeProof(
+          denied,
+          toolName,
+          args,
+          sessionId,
+          decision.reason,
+          "denied",
+          cleanArgs,
+        );
+      }
+
+      // step_up: verify any supplied approval grants, bound to this exact action.
+      const requestHash = await proofGenerator.hashRequest({
+        method: toolName,
+        params: cleanArgs,
+      });
+      const grants = Array.isArray(args[approvalsKey])
+        ? (args[approvalsKey] as ApprovalGrant[])
+        : [];
+      const quorumResult = await verifyApprovalQuorum(
+        grants,
+        requestHash,
+        decision.quorum,
+        isValidApprovalSignature,
+      );
+      if (quorumResult.satisfied) {
+        return handler(cleanArgs, sessionId);
+      }
+
+      const needsApproval = createNeedsApprovalError({
+        message: `Tool "${toolName}" requires ${decision.quorum.n}-of-N approval before it may proceed (${sanitizeForMessage(decision.reason)}).`,
+        resumeToken: `step_up:${requestHash}`,
+        expiresAt: Math.floor(Date.now() / 1000) + 300,
+        requestHash,
+        quorum: decision.quorum,
+      });
+      const stepUp: Awaited<ReturnType<KyaOsToolHandler>> = {
+        content: [{ type: "text", text: JSON.stringify(needsApproval) }],
+        isError: true,
+      };
+      return attachOutcomeProof(
+        stepUp,
+        toolName,
+        args,
+        sessionId,
+        decision.reason,
+        "step_up_required",
+        cleanArgs,
+      );
+    };
+  }
+
   return {
     identity: config.identity,
     sessionManager,
@@ -980,5 +1379,6 @@ export function createKyaOsMiddleware(
     handleHandshake,
     wrapWithProof,
     wrapWithDelegation,
+    withPolicyGate,
   };
 }

--- a/src/policy/__tests__/approval.test.ts
+++ b/src/policy/__tests__/approval.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { verifyApprovalQuorum, type ApprovalGrant } from '../approval.js';
+
+const grant = (over: Partial<ApprovalGrant> = {}): ApprovalGrant => ({
+  approvalRequestId: 'r1',
+  approverDid: 'did:example:a',
+  requestHash: 'sha256:abc',
+  decision: 'approve',
+  ts: 1,
+  signature: 'sig',
+  ...over,
+});
+
+const validSig = async () => true;
+
+describe('verifyApprovalQuorum', () => {
+  it('is satisfied by N distinct approvers over the same requestHash', async () => {
+    const grants = [grant({ approverDid: 'did:a' }), grant({ approverDid: 'did:b' })];
+    const r = await verifyApprovalQuorum(grants, 'sha256:abc', { n: 2, approvers: [] }, validSig);
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('is not satisfied with too few approvers', async () => {
+    const r = await verifyApprovalQuorum([grant({ approverDid: 'did:a' })], 'sha256:abc', { n: 2, approvers: [] }, validSig);
+    expect(r.satisfied).toBe(false);
+  });
+
+  it('rejects grants bound to a different requestHash (TOCTOU guard)', async () => {
+    const grants = [grant({ approverDid: 'did:a', requestHash: 'sha256:OTHER' }), grant({ approverDid: 'did:b', requestHash: 'sha256:OTHER' })];
+    const r = await verifyApprovalQuorum(grants, 'sha256:abc', { n: 2, approvers: [] }, validSig);
+    expect(r.satisfied).toBe(false);
+  });
+
+  it('counts duplicate approver DIDs once', async () => {
+    const grants = [grant({ approverDid: 'did:a' }), grant({ approverDid: 'did:a' })];
+    const r = await verifyApprovalQuorum(grants, 'sha256:abc', { n: 2, approvers: [] }, validSig);
+    expect(r.satisfied).toBe(false);
+  });
+
+  it('ignores deny grants and invalid signatures', async () => {
+    const grants = [grant({ approverDid: 'did:a', decision: 'deny' }), grant({ approverDid: 'did:b' })];
+    const denyCounted = await verifyApprovalQuorum(grants, 'sha256:abc', { n: 2, approvers: [] }, validSig);
+    expect(denyCounted.satisfied).toBe(false);
+
+    const badSig = await verifyApprovalQuorum([grant({ approverDid: 'did:a' })], 'sha256:abc', { n: 1, approvers: [] }, async () => false);
+    expect(badSig.satisfied).toBe(false);
+  });
+
+  it('treats a non-positive quorum as never-satisfiable (misconfiguration guard)', async () => {
+    const zero = await verifyApprovalQuorum([], 'sha256:abc', { n: 0, approvers: [] }, validSig);
+    expect(zero.satisfied).toBe(false);
+    const neg = await verifyApprovalQuorum(
+      [grant()],
+      'sha256:abc',
+      { n: -1, approvers: [] },
+      validSig,
+    );
+    expect(neg.satisfied).toBe(false);
+  });
+
+  it('enforces the allowed-approver allowlist', async () => {
+    const grants = [grant({ approverDid: 'did:outsider' })];
+    const r = await verifyApprovalQuorum(grants, 'sha256:abc', { n: 1, approvers: ['did:insider'] }, validSig);
+    expect(r.satisfied).toBe(false);
+  });
+});

--- a/src/policy/__tests__/classifier.test.ts
+++ b/src/policy/__tests__/classifier.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { RiskClassifier } from '../classifier.js';
+
+const c = new RiskClassifier();
+
+describe('RiskClassifier', () => {
+  it('flags destructive verbs as irreversible/high (catastrophic in prod)', () => {
+    const prod = c.classify({ toolName: 'db.drop', namespace: 'prod' });
+    expect(prod.reversibility).toBe('irreversible');
+    expect(prod.severity).toBe('catastrophic');
+
+    const nonProd = c.classify({ toolName: 'db.delete', namespace: 'scratch' });
+    expect(nonProd.reversibility).toBe('irreversible');
+    expect(nonProd.severity).toBe('high');
+  });
+
+  it('treats reads as reversible/low', () => {
+    expect(c.classify({ toolName: 'repo.read', namespace: 'x' }).severity).toBe('low');
+    expect(c.classify({ toolName: 'files.list', namespace: 'x' }).reversibility).toBe('reversible');
+  });
+
+  it('classifies unknown verbs as unknown (fail-closed upstream)', () => {
+    const r = c.classify({ toolName: 'frobnicate', namespace: 'x' });
+    expect(r.severity).toBe('unknown');
+    expect(r.reversibility).toBe('unknown');
+  });
+
+  it('honors a complete per-tool hint override', () => {
+    const ch = new RiskClassifier({
+      hints: { 'safe.delete': { reversibility: 'reversible', blastRadius: 'record', severity: 'low' } },
+    });
+    const r = ch.classify({ toolName: 'safe.delete', namespace: 'prod' });
+    expect(r.severity).toBe('low');
+    expect(r.reversibility).toBe('reversible');
+  });
+});

--- a/src/policy/__tests__/default-engine.test.ts
+++ b/src/policy/__tests__/default-engine.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { DefaultPolicyEngine } from '../default-engine.js';
+import type { PolicyRequest, RiskAssessment } from '../types.js';
+
+function req(over: Partial<RiskAssessment> & { scopeMatched?: boolean; humanApprovals?: string[] } = {}): PolicyRequest {
+  const { scopeMatched = true, humanApprovals = [], ...risk } = over;
+  return {
+    principal: { agentDid: 'did:example:agent' },
+    action: { toolName: 't' },
+    resource: { namespace: 'n' },
+    context: {
+      delegatedScopes: [],
+      scopeMatched,
+      humanApprovals,
+      reversibility: 'reversible',
+      blastRadius: 'record',
+      severity: 'low',
+      ...risk,
+    },
+  };
+}
+
+describe('DefaultPolicyEngine', () => {
+  const engine = new DefaultPolicyEngine();
+
+  it('denies when scope is not matched', async () => {
+    expect((await engine.evaluate(req({ scopeMatched: false }))).decision).toBe('deny');
+  });
+
+  it('denies unclassified (unknown) actions — fail-closed', async () => {
+    expect((await engine.evaluate(req({ severity: 'unknown' }))).decision).toBe('deny');
+    expect((await engine.evaluate(req({ reversibility: 'unknown' }))).decision).toBe('deny');
+  });
+
+  it('requires step-up for irreversible/catastrophic actions with no approvals', async () => {
+    const d = await engine.evaluate(req({ reversibility: 'irreversible', severity: 'catastrophic' }));
+    expect(d.decision).toBe('step_up');
+    if (d.decision === 'step_up') expect(d.quorum.n).toBe(1);
+  });
+
+  it('allows a dangerous action once quorum is met', async () => {
+    const d = await engine.evaluate(
+      req({ severity: 'catastrophic', reversibility: 'irreversible', humanApprovals: ['did:example:approver'] }),
+    );
+    expect(d.decision).toBe('allow');
+  });
+
+  it('allows an in-scope reversible low-severity action', async () => {
+    expect((await engine.evaluate(req())).decision).toBe('allow');
+  });
+
+  it('honors a configured quorum greater than 1', async () => {
+    const e2 = new DefaultPolicyEngine({ stepUpQuorum: 2 });
+    const one = await e2.evaluate(
+      req({ reversibility: 'irreversible', severity: 'high', humanApprovals: ['did:a'] }),
+    );
+    expect(one.decision).toBe('step_up');
+    const two = await e2.evaluate(
+      req({ reversibility: 'irreversible', severity: 'high', humanApprovals: ['did:a', 'did:b'] }),
+    );
+    expect(two.decision).toBe('allow');
+  });
+});

--- a/src/policy/approval.ts
+++ b/src/policy/approval.ts
@@ -1,0 +1,62 @@
+/**
+ * Step-up approval grants and quorum verification.
+ *
+ * A step-up suspends a high-risk action until N-of-M approvers each sign a
+ * grant bound to the EXACT requestHash of the suspended action. Binding to the
+ * requestHash defeats the TOCTOU swap where a human approves one action and a
+ * different one is forwarded.
+ */
+export interface ApprovalGrant {
+  approvalRequestId: string;
+  approverDid: string;
+  /** MUST equal the suspended action's requestHash. */
+  requestHash: string;
+  decision: 'approve' | 'deny';
+  ts: number;
+  /** Verified by the caller-supplied `isValidSignature` (identity-layer concern). */
+  signature: string;
+}
+
+export interface QuorumResult {
+  satisfied: boolean;
+  reason?: string;
+}
+
+export interface Quorum {
+  n: number;
+  /** Allowed approver DIDs; empty = any identity may approve. */
+  approvers: string[];
+}
+
+/**
+ * Quorum is satisfied iff at least `quorum.n` DISTINCT approvers each signed an
+ * `approve` grant over EXACTLY `requestHash`, drawn from `quorum.approvers`
+ * (empty = any), with a signature accepted by `isValidSignature`.
+ */
+export async function verifyApprovalQuorum(
+  grants: ApprovalGrant[],
+  requestHash: string,
+  quorum: Quorum,
+  isValidSignature: (g: ApprovalGrant) => Promise<boolean>,
+): Promise<QuorumResult> {
+  // A non-positive quorum is a misconfiguration (e.g. a third-party engine
+  // returning {n:0}); treat it as never-satisfiable rather than auto-passing.
+  if (quorum.n <= 0) {
+    return { satisfied: false, reason: 'invalid_quorum:n<=0' };
+  }
+
+  const approvers = new Set<string>();
+
+  for (const g of grants) {
+    if (g.decision !== 'approve') continue;
+    if (g.requestHash !== requestHash) continue; // TOCTOU guard
+    if (quorum.approvers.length > 0 && !quorum.approvers.includes(g.approverDid)) continue;
+    if (!(await isValidSignature(g))) continue;
+    approvers.add(g.approverDid);
+  }
+
+  if (approvers.size >= quorum.n) {
+    return { satisfied: true };
+  }
+  return { satisfied: false, reason: `quorum_not_met:${approvers.size}/${quorum.n}` };
+}

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -1,0 +1,110 @@
+import type { RiskAssessment } from './types.js';
+
+export interface Invocation {
+  toolName: string;
+  namespace: string;
+}
+
+/**
+ * Verbs denoting sensitive/destructive operations. Seeded from the intent of
+ * the previously-dead `hasSensitiveScopes` helper, but applied to the resolved
+ * ACT (tool verb) rather than the grant string.
+ */
+export const SENSITIVE_VERBS = [
+  'delete',
+  'drop',
+  'destroy',
+  'remove',
+  'terminate',
+  'transfer',
+  'payment',
+  'admin',
+  'execute',
+  'modify',
+  'write',
+  'rotate',
+  'revoke',
+] as const;
+
+const READ_VERBS = ['read', 'get', 'list', 'describe', 'search', 'query'] as const;
+
+export interface RiskClassifierOptions {
+  /** Per-tool overrides keyed by exact toolName (a complete RiskAssessment wins outright). */
+  hints?: Record<string, Partial<RiskAssessment>>;
+}
+
+/**
+ * Classifies a tool invocation by reversibility, blast radius, and severity.
+ *
+ * HEURISTIC, best-effort — not a security boundary. It tokenizes the WHOLE tool
+ * name (all path segments, split on . : / _ - and camelCase) and matches verbs as
+ * WHOLE TOKENS (so `rewrite`/`underwrite` no longer match `write`, and `admin` in
+ * `admin.users.read` is still seen). An unrecognized verb → `unknown`, which the
+ * DefaultPolicyEngine fails closed (deny).
+ *
+ * KNOWN LIMITS, by design:
+ * - It over-flags reads whose name contains a sensitive verb token (e.g.
+ *   `list_payment_methods` → step-up). That is the safe direction.
+ * - It does NOT understand that some reads are sensitive: `vault.getSecrets`
+ *   classifies as a low-risk read and is allowed. Do NOT rely on the default
+ *   classifier to gate read-sensitive tools — supply an explicit hint or a
+ *   custom classifier for those.
+ */
+export class RiskClassifier {
+  constructor(private readonly options: RiskClassifierOptions = {}) {}
+
+  classify(invocation: Invocation): RiskAssessment {
+    const hint = this.options.hints?.[invocation.toolName];
+    if (hint?.reversibility && hint.blastRadius && hint.severity) {
+      return {
+        reversibility: hint.reversibility,
+        blastRadius: hint.blastRadius,
+        severity: hint.severity,
+      };
+    }
+
+    const tokens = tokenize(invocation.toolName);
+    const prod = isProd(invocation.namespace);
+
+    let base: RiskAssessment;
+    if (tokens.some((t) => (SENSITIVE_VERBS as readonly string[]).includes(t))) {
+      base = {
+        reversibility: 'irreversible',
+        blastRadius: prod ? 'environment' : 'resource',
+        severity: prod ? 'catastrophic' : 'high',
+      };
+    } else if (tokens.some((t) => (READ_VERBS as readonly string[]).includes(t))) {
+      base = { reversibility: 'reversible', blastRadius: 'record', severity: 'low' };
+    } else {
+      base = { reversibility: 'unknown', blastRadius: 'unknown', severity: 'unknown' };
+    }
+
+    return { ...base, ...stripUndefined(hint) };
+  }
+}
+
+/** Split a tool name (or namespace) into lowercase tokens across all path
+ *  segments, separators (. : / _ - whitespace) and camelCase boundaries. */
+function tokenize(name: string): string[] {
+  return name
+    .split(/[.:/_\-\s]+/)
+    .flatMap((seg) => seg.replace(/([a-z0-9])([A-Z])/g, '$1 $2').split(/\s+/))
+    .map((t) => t.toLowerCase())
+    .filter(Boolean);
+}
+
+/** True only when the namespace contains a whole `prod`/`production` token
+ *  (not a substring like `product`/`reproduce`). */
+function isProd(namespace: string): boolean {
+  const t = tokenize(namespace);
+  return t.includes('prod') || t.includes('production');
+}
+
+function stripUndefined<T extends object>(o?: T): Partial<T> {
+  if (!o) return {};
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(o)) {
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}

--- a/src/policy/default-engine.ts
+++ b/src/policy/default-engine.ts
@@ -1,0 +1,53 @@
+import type { PolicyEngine } from './engine.js';
+import type { PolicyRequest, PolicyDecision } from './types.js';
+
+export interface DefaultPolicyConfig {
+  /** Approvals required for a step-up. Default 1. */
+  stepUpQuorum?: number;
+  /** Allowed approver DIDs; empty/undefined = any identity may approve. */
+  stepUpApprovers?: string[];
+}
+
+/**
+ * Zero-dependency reference PolicyEngine. Fail-closed:
+ *  - scope not matched          → deny
+ *  - unclassified (unknown)     → deny
+ *  - irreversible/high/catastrophic → step_up (or allow once quorum met)
+ *  - otherwise                  → allow
+ *
+ * Production deployments are expected to swap in an OPA/Rego or Cedar adapter;
+ * this engine encodes the same fail-closed posture as a sensible default.
+ */
+export class DefaultPolicyEngine implements PolicyEngine {
+  constructor(private readonly cfg: DefaultPolicyConfig = {}) {}
+
+  async evaluate(req: PolicyRequest): Promise<PolicyDecision> {
+    const { severity, reversibility, scopeMatched, humanApprovals } = req.context;
+
+    if (!scopeMatched) {
+      return { decision: 'deny', reason: 'scope_not_matched' };
+    }
+    if (severity === 'unknown' || reversibility === 'unknown') {
+      return { decision: 'deny', reason: 'unclassified_high_risk' };
+    }
+
+    const dangerous =
+      reversibility === 'irreversible' ||
+      severity === 'catastrophic' ||
+      severity === 'high';
+
+    if (dangerous) {
+      const n = this.cfg.stepUpQuorum ?? 1;
+      if (humanApprovals.length >= n) {
+        return { decision: 'allow' };
+      }
+      return {
+        decision: 'step_up',
+        quorum: { n, approvers: this.cfg.stepUpApprovers ?? [] },
+        reason: 'destructive_action_requires_approval',
+      };
+    }
+
+    return { decision: 'allow' };
+  }
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,12 @@
+import type { PolicyRequest, PolicyDecision } from './types.js';
+
+/**
+ * Policy-as-Code decision port. KYA-OS owns the fact/context projection
+ * (PolicyRequest) and the step-up orchestration; the engine renders the
+ * allow / deny / step_up decision. Implement this interface to back the gate
+ * with OPA/Rego, Cedar, or any other policy evaluator. A zero-dependency
+ * DefaultPolicyEngine ships in this package.
+ */
+export interface PolicyEngine {
+  evaluate(req: PolicyRequest): Promise<PolicyDecision>;
+}

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js';
+export * from './engine.js';
+export * from './classifier.js';
+export * from './default-engine.js';
+export * from './approval.js';

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Policy subsystem types (KYA-OS Policy-as-Code seam).
+ *
+ * KYA-OS projects a stable fact/context shape; a pluggable PolicyEngine renders
+ * the decision. These types are the contract — engine implementations (built-in,
+ * or adapters for OPA/Rego, Cedar, etc.) consume PolicyRequest and return
+ * PolicyDecision.
+ */
+
+export type Reversibility =
+  | 'reversible'
+  | 'reversible-with-effort'
+  | 'irreversible'
+  | 'unknown';
+
+export type BlastRadius =
+  | 'record'
+  | 'resource'
+  | 'collection'
+  | 'tenant'
+  | 'environment'
+  | 'global'
+  | 'unknown';
+
+export type Severity = 'none' | 'low' | 'medium' | 'high' | 'catastrophic' | 'unknown';
+
+export interface RiskAssessment {
+  reversibility: Reversibility;
+  blastRadius: BlastRadius;
+  severity: Severity;
+}
+
+export interface PolicyRequest {
+  principal: { agentDid: string; responsibleParty?: string };
+  action: { toolName: string };
+  resource: { namespace: string };
+  context: {
+    /** Union of delegation.scopes ∪ constraints.scopes ∪ matched crisp scopes. */
+    delegatedScopes: string[];
+    /** Live CRISP budget remaining, if a budget applies. */
+    budgetRemaining?: number;
+    /** Whether the delegated scope already authorized this action. */
+    scopeMatched: boolean;
+    /** Approver DIDs collected after a step-up round-trip (empty on first pass). */
+    humanApprovals: string[];
+  } & RiskAssessment;
+}
+
+export type PolicyDecision =
+  | { decision: 'allow' }
+  | { decision: 'deny'; reason: string }
+  | { decision: 'step_up'; quorum: { n: number; approvers: string[] }; reason: string };

--- a/src/proof/__tests__/proof-generator.test.ts
+++ b/src/proof/__tests__/proof-generator.test.ts
@@ -56,6 +56,31 @@ describe("ProofGenerator", () => {
     proofGenerator = new ProofGenerator(mockIdentity, cryptoProvider);
   });
 
+  describe("Denial proofs", () => {
+    it("generates a verifiable denial proof without a responseHash", async () => {
+      const request: ToolRequest = { method: "tool", params: { x: 1 } };
+      const proof = await proofGenerator.generateProof(
+        request,
+        undefined,
+        mockSession,
+        { outcome: "denied", reason: "insufficient_scope" },
+      );
+      expect(proof.meta.outcome).toBe("denied");
+      expect(proof.meta.reason).toBe("insufficient_scope");
+      expect(proof.meta.responseHash).toBeUndefined();
+      expect(await proofGenerator.verifyProof(proof, request)).toBe(true);
+    });
+
+    it("still includes responseHash and verifies for allowed proofs (backward compat)", async () => {
+      const request: ToolRequest = { method: "tool", params: { x: 1 } };
+      const response: ToolResponse = { data: { ok: true } };
+      const proof = await proofGenerator.generateProof(request, response, mockSession);
+      expect(proof.meta.responseHash).toBeTruthy();
+      expect(proof.meta.outcome).toBeUndefined();
+      expect(await proofGenerator.verifyProof(proof, request, response)).toBe(true);
+    });
+  });
+
   describe("Canonical Hash Generation", () => {
     it("should generate consistent hashes for same request/response", async () => {
       const request: ToolRequest = {

--- a/src/proof/__tests__/verifier.integration.test.ts
+++ b/src/proof/__tests__/verifier.integration.test.ts
@@ -87,6 +87,191 @@ describe('ProofVerifier (real crypto)', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('verifies a denial proof (no responseHash, signed outcome/reason) end-to-end', async () => {
+    const { verifier } = makeVerifier();
+    const gen = new ProofGenerator(
+      { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+      crypto
+    );
+    const session = {
+      sessionId: 'sess_denial',
+      audience: 'did:web:server.example.com',
+      nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      timestamp: Math.floor(Date.now() / 1000),
+      createdAt: Math.floor(Date.now() / 1000),
+      lastActivity: Math.floor(Date.now() / 1000),
+      ttlMinutes: 30,
+      identityState: 'anonymous' as const,
+    };
+    const proof = await gen.generateProof(
+      { method: 'tools/call', params: { name: 'db.drop' } },
+      undefined,
+      session,
+      { outcome: 'denied', reason: 'insufficient_scope' }
+    );
+    expect(proof.meta.responseHash).toBeUndefined();
+    expect(proof.meta.outcome).toBe('denied');
+
+    const jwk = getJwk(agent);
+    // Verifies cleanly through the full standalone pipeline (structure + signature).
+    expect((await verifier.verifyProof(proof, jwk)).valid).toBe(true);
+
+    // outcome/reason are signed-over: tampering the reason invalidates the proof
+    // (fresh verifier to avoid a nonce-replay false negative).
+    const tampered = { ...proof, meta: { ...proof.meta, reason: 'totally_different' } };
+    const { verifier: v2 } = makeVerifier();
+    expect((await v2.verifyProof(tampered, jwk)).valid).toBe(false);
+  });
+
+  it('verifies a needs_authorization challenge proof bound to the challenge content (responseHash) end-to-end', async () => {
+    const { verifier } = makeVerifier();
+    const gen = new ProofGenerator(
+      { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+      crypto
+    );
+    const session = {
+      sessionId: 'sess_needsauth',
+      audience: 'did:web:server.example.com',
+      nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      timestamp: Math.floor(Date.now() / 1000),
+      createdAt: Math.floor(Date.now() / 1000),
+      lastActivity: Math.floor(Date.now() / 1000),
+      ttlMinutes: 30,
+      identityState: 'anonymous' as const,
+    };
+    // The challenge content carries the authorizationUrl; binding it via
+    // responseHash lets a verifier detect a tampered / MITM-swapped consent URL.
+    const challengeContent = [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          error: 'needs_authorization',
+          authorizationUrl: 'https://issuer.example/consent',
+          scopes: ['greeting:restricted'],
+        }),
+      },
+    ];
+    const proof = await gen.generateProof(
+      { method: 'tools/call', params: { name: 'restricted_greet' } },
+      { data: challengeContent },
+      session,
+      { outcome: 'needs_authorization', reason: 'requires delegation with scope: greeting:restricted' }
+    );
+    expect(proof.meta.outcome).toBe('needs_authorization');
+    expect(proof.meta.responseHash).toBeDefined();
+
+    const jwk = getJwk(agent);
+    expect((await verifier.verifyProof(proof, jwk)).valid).toBe(true);
+
+    // A MITM swapping the consent URL changes the bound responseHash; the proof
+    // then fails verification (fresh verifier avoids a nonce-replay false negative).
+    const tampered = { ...proof, meta: { ...proof.meta, responseHash: 'sha256:deadbeefdeadbeef' } };
+    const { verifier: v2 } = makeVerifier();
+    expect((await v2.verifyProof(tampered, jwk)).valid).toBe(false);
+  });
+
+  it('detects a MITM-swapped consent URL via expected-content binding (real anti-MITM)', async () => {
+    const gen = new ProofGenerator(
+      { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+      crypto
+    );
+    const session = {
+      sessionId: 'sess_mitm',
+      audience: 'did:web:server.example.com',
+      nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      timestamp: Math.floor(Date.now() / 1000),
+      createdAt: Math.floor(Date.now() / 1000),
+      lastActivity: Math.floor(Date.now() / 1000),
+      ttlMinutes: 30,
+      identityState: 'anonymous' as const,
+    };
+    const request = { method: 'tools/call', params: { name: 'restricted_greet' } };
+    const genuine = [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          error: 'needs_authorization',
+          authorizationUrl: 'https://issuer.example/consent',
+          scopes: ['greeting:restricted'],
+        }),
+      },
+    ];
+    const proof = await gen.generateProof(request, { data: genuine }, session, {
+      outcome: 'needs_authorization',
+      reason: 'requires delegation',
+    });
+    const jwk = getJwk(agent);
+
+    // The genuine content the server signed → verifies WITH content binding.
+    const ok = makeVerifier().verifier;
+    expect(
+      (await ok.verifyProof(proof, jwk, { request, response: { data: genuine } })).valid
+    ).toBe(true);
+
+    // A malicious in-path intermediary swaps the consent URL in the delivered content.
+    // The proof is still authentically signed (signature intact), but the bound
+    // responseHash no longer matches the received content → CONTENT_BINDING_MISMATCH.
+    // This is the actual anti-MITM detection — over received CONTENT, not over the
+    // signed meta. A fresh verifier avoids a nonce-replay false negative.
+    const swapped = [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          error: 'needs_authorization',
+          authorizationUrl: 'https://attacker.example/consent',
+          scopes: ['greeting:restricted'],
+        }),
+      },
+    ];
+    const v2 = makeVerifier().verifier;
+    const result = await v2.verifyProof(proof, jwk, { request, response: { data: swapped } });
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe('CONTENT_BINDING_MISMATCH');
+  });
+
+  it('fails closed when a responseHash-bound proof is verified with only a request (no response)', async () => {
+    // The needs_authorization proof binds the URL-bearing content via responseHash.
+    // A caller who supplies only { request } must NOT receive valid — the request
+    // is identical for a genuine and a MITM'd challenge, so the swapped URL would
+    // otherwise go silently unchecked. Fail-closed: the response is required.
+    const gen = new ProofGenerator(
+      { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+      crypto
+    );
+    const session = {
+      sessionId: 'sess_failclosed',
+      audience: 'did:web:server.example.com',
+      nonce: `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      timestamp: Math.floor(Date.now() / 1000),
+      createdAt: Math.floor(Date.now() / 1000),
+      lastActivity: Math.floor(Date.now() / 1000),
+      ttlMinutes: 30,
+      identityState: 'anonymous' as const,
+    };
+    const request = { method: 'tools/call', params: { name: 'restricted_greet' } };
+    const content = [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          error: 'needs_authorization',
+          authorizationUrl: 'https://issuer.example/consent',
+          scopes: ['greeting:restricted'],
+        }),
+      },
+    ];
+    const proof = await gen.generateProof(request, { data: content }, session, {
+      outcome: 'needs_authorization',
+      reason: 'requires delegation',
+    });
+    expect(proof.meta.responseHash).toBeDefined();
+
+    const jwk = getJwk(agent);
+    // Only the request supplied — the URL-bearing responseHash cannot be checked.
+    const result = await makeVerifier().verifier.verifyProof(proof, jwk, { request });
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe('CONTENT_BINDING_MISMATCH');
+  });
+
   it('should reject proof signed by a different key', async () => {
     const { verifier } = makeVerifier();
     const proof = await generateProof(agent);

--- a/src/proof/__tests__/verifier.test.ts
+++ b/src/proof/__tests__/verifier.test.ts
@@ -131,6 +131,33 @@ describe('ProofVerifier Security', () => {
   });
 
   describe('Nonce Replay Protection', () => {
+    it('reconstructs the canonical payload for denial proofs (outcome/reason, no responseHash)', () => {
+      const denialMeta = {
+        did: 'did:key:z123',
+        kid: 'did:key:z123#z123',
+        ts: 1,
+        nonce: 'n',
+        audience: 'aud',
+        sessionId: 's',
+        requestHash: 'sha256:' + 'a'.repeat(64),
+        outcome: 'denied' as const,
+        reason: 'insufficient_scope',
+      };
+      const payload = proofVerifier.buildCanonicalPayload(denialMeta);
+      expect(payload).toContain('"outcome":"denied"');
+      expect(payload).toContain('"reason":"insufficient_scope"');
+      expect(payload).not.toContain('responseHash');
+
+      const allowedPayload = proofVerifier.buildCanonicalPayload({
+        ...denialMeta,
+        responseHash: 'sha256:' + 'b'.repeat(64),
+        outcome: undefined,
+        reason: undefined,
+      });
+      expect(allowedPayload).toContain('responseHash');
+      expect(allowedPayload).not.toContain('outcome');
+    });
+
     it('should prevent nonce replay attacks', async () => {
       const proof = createValidProof();
 

--- a/src/proof/errors.ts
+++ b/src/proof/errors.ts
@@ -17,6 +17,10 @@ export const PROOF_VERIFICATION_ERROR_CODES = {
   NONCE_REPLAY_DETECTED: "NONCE_REPLAY_DETECTED",
   TIMESTAMP_SKEW_EXCEEDED: "TIMESTAMP_SKEW_EXCEEDED",
   TIMESTAMP_INVALID: "TIMESTAMP_INVALID",
+  // Content binding: the proof's signature is valid, but the recomputed hash of
+  // the request/response the verifier actually received does not match the hash
+  // bound in the (authentic) proof — i.e. the content was substituted in transit.
+  CONTENT_BINDING_MISMATCH: "CONTENT_BINDING_MISMATCH",
 
   // Signature errors
   INVALID_JWS_SIGNATURE: "INVALID_JWS_SIGNATURE",

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -13,7 +13,6 @@ import { canonicalize } from 'json-canonicalize';
 import type {
   DetachedProof,
   ProofMeta,
-  CanonicalHashes,
   SessionContext,
 } from '../types/protocol.js';
 import type { CryptoProvider } from '../providers/base.js';
@@ -45,6 +44,48 @@ export interface ProofOptions {
   scopeId?: string;
   delegationRef?: string;
   clientDid?: string;
+  outcome?: 'allowed' | 'denied' | 'step_up_required' | 'needs_authorization';
+  reason?: string;
+}
+
+/**
+ * Compute the canonical request/response hashes that bind a proof to a specific
+ * invocation. This is the SINGLE source of truth for that hashing — used by both
+ * the signer (`ProofGenerator`) and the verifier (`ProofVerifier`), so the two
+ * cannot drift. `requestHash` = SHA-256 over RFC 8785 `canonicalize({method,params})`;
+ * `responseHash` = SHA-256 over `canonicalize(response.data)` (omitted when there
+ * is no response body, e.g. denial / step-up proofs).
+ *
+ * Note: RFC 8785 (via json-canonicalize) drops object members whose value is
+ * `undefined`, so a field set to `undefined` hashes identically to that field
+ * being absent. Bind only over values that are actually present; never rely on
+ * the presence of an `undefined`-valued key to distinguish two payloads.
+ *
+ * @param hash - a byte → `sha256:<hex>` function (bind a `CryptoProvider.hash`)
+ */
+export async function computeCanonicalHashes(
+  request: ToolRequest,
+  response: ToolResponse | undefined,
+  hash: (bytes: Uint8Array) => Promise<string>,
+): Promise<{ requestHash: string; responseHash?: string }> {
+  const canonicalRequest = {
+    method: request.method,
+    ...(request.params ? { params: request.params } : {}),
+  };
+  const requestHash = await hash(
+    new TextEncoder().encode(
+      canonicalize(canonicalRequest as Parameters<typeof canonicalize>[0]),
+    ),
+  );
+  if (response === undefined) {
+    return { requestHash };
+  }
+  const responseHash = await hash(
+    new TextEncoder().encode(
+      canonicalize(response.data as Parameters<typeof canonicalize>[0]),
+    ),
+  );
+  return { requestHash, responseHash };
 }
 
 export class ProofGenerator {
@@ -71,7 +112,7 @@ export class ProofGenerator {
    */
   async generateProof(
     request: ToolRequest,
-    response: ToolResponse,
+    response: ToolResponse | undefined,
     session: SessionContext,
     options: ProofOptions = {}
   ): Promise<DetachedProof> {
@@ -85,7 +126,9 @@ export class ProofGenerator {
       audience: session.audience,
       sessionId: session.sessionId,
       requestHash: hashes.requestHash,
-      responseHash: hashes.responseHash,
+      ...(hashes.responseHash !== undefined
+        ? { responseHash: hashes.responseHash }
+        : {}),
       ...options,
     };
 
@@ -94,30 +137,21 @@ export class ProofGenerator {
     return { jws, meta };
   }
 
+  /**
+   * Compute the canonical request hash for an invocation, independent of any
+   * response. Used to bind step-up approval grants to a specific action.
+   */
+  async hashRequest(request: ToolRequest): Promise<string> {
+    return (await this.generateCanonicalHashes(request)).requestHash;
+  }
+
   private async generateCanonicalHashes(
     request: ToolRequest,
-    response: ToolResponse
-  ): Promise<CanonicalHashes> {
-    const canonicalRequest = {
-      method: request.method,
-      ...(request.params ? { params: request.params } : {}),
-    };
-    const canonicalResponse = response.data;
-
-    const requestHash = await this.generateSHA256Hash(canonicalRequest);
-    const responseHash = await this.generateSHA256Hash(canonicalResponse);
-
-    return { requestHash, responseHash };
-  }
-
-  private async generateSHA256Hash(data: unknown): Promise<string> {
-    const canonicalJson = this.canonicalizeJSON(data);
-    const encoded = new TextEncoder().encode(canonicalJson);
-    return this.cryptoProvider.hash(encoded);
-  }
-
-  private canonicalizeJSON(obj: unknown): string {
-    return canonicalize(obj as Parameters<typeof canonicalize>[0]);
+    response?: ToolResponse
+  ): Promise<{ requestHash: string; responseHash?: string }> {
+    return computeCanonicalHashes(request, response, (bytes) =>
+      this.cryptoProvider.hash(bytes),
+    );
   }
 
   private async generateJWS(meta: ProofMeta): Promise<string> {
@@ -130,13 +164,15 @@ export class ProofGenerator {
         sub: meta.did,
         iss: meta.did,
         requestHash: meta.requestHash,
-        responseHash: meta.responseHash,
+        ...(meta.responseHash !== undefined && { responseHash: meta.responseHash }),
         ts: meta.ts,
         nonce: meta.nonce,
         sessionId: meta.sessionId,
         ...(meta.scopeId && { scopeId: meta.scopeId }),
         ...(meta.delegationRef && { delegationRef: meta.delegationRef }),
         ...(meta.clientDid && { clientDid: meta.clientDid }),
+        ...(meta.outcome && { outcome: meta.outcome }),
+        ...(meta.reason && { reason: meta.reason }),
       };
 
       // Use canonicalized JSON (RFC 8785) for deterministic payload serialization.
@@ -183,16 +219,21 @@ export class ProofGenerator {
   async verifyProof(
     proof: DetachedProof,
     request: ToolRequest,
-    response: ToolResponse
+    response?: ToolResponse
   ): Promise<boolean> {
     try {
       const expectedHashes = await this.generateCanonicalHashes(request, response);
 
-      if (
-        proof.meta.requestHash !== expectedHashes.requestHash ||
-        proof.meta.responseHash !== expectedHashes.responseHash
-      ) {
+      if (proof.meta.requestHash !== expectedHashes.requestHash) {
         return false;
+      }
+      if (proof.meta.responseHash !== undefined) {
+        if (
+          expectedHashes.responseHash === undefined ||
+          proof.meta.responseHash !== expectedHashes.responseHash
+        ) {
+          return false;
+        }
       }
 
       const publicKeyJwk = this.base64PublicKeyToJWK(this.identity.publicKey);

--- a/src/proof/verifier.ts
+++ b/src/proof/verifier.ts
@@ -22,6 +22,11 @@ import {
   type ProofVerificationErrorCode,
 } from "./errors.js";
 import { logger } from "../logging/index.js";
+import {
+  computeCanonicalHashes,
+  type ToolRequest,
+  type ToolResponse,
+} from "./generator.js";
 
 export interface ProofVerificationResult {
   valid: boolean;
@@ -54,9 +59,11 @@ export class ProofVerifier {
   private fetch: FetchProvider;
   private timestampSkewSeconds: number;
   private nonceTtlSeconds: number;
+  private cryptoProvider: CryptoProvider;
 
   constructor(config: ProofVerifierConfig) {
     this.cryptoService = new CryptoService(config.cryptoProvider);
+    this.cryptoProvider = config.cryptoProvider;
     this.clock = config.clockProvider;
     this.nonceCache = config.nonceCacheProvider;
     this.fetch = config.fetchProvider;
@@ -89,15 +96,32 @@ export class ProofVerifier {
   }
 
   /**
-   * Verify a DetachedProof
-   * Automatically reconstructs canonical payload from proof.meta for signature verification
+   * Verify a DetachedProof.
+   *
+   * Reconstructs the canonical payload from proof.meta and checks the JWS
+   * signature, nonce replay, and timestamp skew — proving the proof is AUTHENTIC
+   * (signed by the holder of `kid`). On its own this does NOT confirm that the
+   * request/response the verifier actually received matches what was signed. To
+   * detect content substitution (e.g. a MITM-swapped `authorizationUrl` in a
+   * needs_authorization challenge), pass `expected`: the request you sent and the
+   * response you received are re-hashed via the SAME canonical hashing the signer
+   * used (computeCanonicalHashes) and compared to the bound requestHash/
+   * responseHash. A mismatch fails with CONTENT_BINDING_MISMATCH.
+   *
    * @param proof - The proof to verify
    * @param publicKeyJwk - Ed25519 public key in JWK format (from DID document)
+   * @param expected - Optional content binding: the `request` you sent and the
+   *   `response` you received. Their canonical hashes MUST match the proof's
+   *   bound hashes. FAIL-CLOSED: if the proof binds a `responseHash` (success and
+   *   needs_authorization proofs), `response` is REQUIRED — omitting it fails with
+   *   CONTENT_BINDING_MISMATCH, so the URL-bearing body cannot go silently
+   *   unverified.
    * @returns Verification result
    */
   async verifyProof(
     proof: DetachedProof,
-    publicKeyJwk: Ed25519JWK
+    publicKeyJwk: Ed25519JWK,
+    expected?: { request: ToolRequest; response?: ToolResponse }
   ): Promise<ProofVerificationResult> {
     try {
       // Reconstruct canonical payload from proof meta
@@ -106,7 +130,7 @@ export class ProofVerifier {
         canonicalPayloadString
       );
 
-      return await this.runVerificationPipeline(proof, publicKeyJwk, canonicalPayloadBytes);
+      return await this.runVerificationPipeline(proof, publicKeyJwk, canonicalPayloadBytes, expected);
     } catch (error) {
       return this.handleVerificationError(error);
     }
@@ -144,7 +168,8 @@ export class ProofVerifier {
   private async runVerificationPipeline(
     proof: DetachedProof,
     publicKeyJwk: Ed25519JWK,
-    canonicalPayloadBytes: Uint8Array
+    canonicalPayloadBytes: Uint8Array,
+    expected?: { request: ToolRequest; response?: ToolResponse }
   ): Promise<ProofVerificationResult> {
     // 1. Validate proof structure
     const structureValidation = await this.validateProofStructure(proof);
@@ -181,12 +206,83 @@ export class ProofVerifier {
       return signatureValidation;
     }
 
+    // 4b. Content binding (optional): the signature proves the proof is
+    // AUTHENTIC, but not that the request/response WE received matches what was
+    // signed. When the caller supplies what it actually saw, recompute the
+    // canonical hashes and confirm they match the bound hashes — this is what
+    // turns the signed proof into substitution detection (e.g. a MITM-swapped
+    // consent URL). Checked before caching the nonce so a mismatch does not burn
+    // the nonce for a legitimate retry.
+    if (expected !== undefined) {
+      const bindingValidation = await this.validateContentBinding(
+        validatedProof,
+        expected
+      );
+      if (!bindingValidation.valid) {
+        return bindingValidation;
+      }
+    }
+
     // 5. Add nonce to cache to prevent replay (scoped to agent DID)
     await this.addNonceToCache(
       validatedProof.meta.nonce,
       validatedProof.meta.did
     );
 
+    return { valid: true };
+  }
+
+  /**
+   * Recompute the canonical hashes of the request/response the verifier actually
+   * received (via the same hashing the signer used) and compare to the proof's
+   * bound hashes. Fails CONTENT_BINDING_MISMATCH on any divergence — the check
+   * that makes a signed proof tamper-evident against content substitution.
+   * @private
+   */
+  private async validateContentBinding(
+    proof: DetachedProof,
+    expected: { request: ToolRequest; response?: ToolResponse }
+  ): Promise<ProofVerificationResult> {
+    const { requestHash, responseHash } = await computeCanonicalHashes(
+      expected.request,
+      expected.response,
+      (bytes) => this.cryptoProvider.hash(bytes)
+    );
+    if (proof.meta.requestHash !== requestHash) {
+      return {
+        valid: false,
+        reason:
+          "Request hash mismatch: the proof does not bind the request you supplied",
+        errorCode: PROOF_VERIFICATION_ERROR_CODES.CONTENT_BINDING_MISMATCH,
+      };
+    }
+    // Response binding (FAIL-CLOSED): proof.meta.responseHash is the ONLY thing
+    // that binds the response body — including a needs_authorization challenge's
+    // authorizationUrl. It MUST be checked whenever the proof carries one.
+    // Gating the comparison on `expected.response !== undefined` would let a
+    // caller who supplies only `request` get { valid: true } while the swapped
+    // URL went unverified (the requestHash is identical for a genuine and a
+    // MITM'd challenge). So: if the proof binds a responseHash the caller MUST
+    // supply the response; if it binds none, the caller must not supply one.
+    const proofBindsResponse = proof.meta.responseHash !== undefined;
+    const callerSuppliedResponse = expected.response !== undefined;
+    if (proofBindsResponse !== callerSuppliedResponse) {
+      return {
+        valid: false,
+        reason: proofBindsResponse
+          ? "Proof binds a response (responseHash present) but no response was supplied to verify against — pass expected.response"
+          : "A response was supplied but the proof binds none — content/proof mismatch",
+        errorCode: PROOF_VERIFICATION_ERROR_CODES.CONTENT_BINDING_MISMATCH,
+      };
+    }
+    if (proofBindsResponse && proof.meta.responseHash !== responseHash) {
+      return {
+        valid: false,
+        reason:
+          "Response hash mismatch: received content differs from what the server signed (possible substitution / MITM)",
+        errorCode: PROOF_VERIFICATION_ERROR_CODES.CONTENT_BINDING_MISMATCH,
+      };
+    }
     return { valid: true };
   }
 
@@ -463,7 +559,8 @@ export class ProofVerifier {
 
       // Custom KYA-OS proof claims
       requestHash: meta.requestHash,
-      responseHash: meta.responseHash,
+      // responseHash is absent on denial / step-up proofs (no response).
+      ...(meta.responseHash !== undefined && { responseHash: meta.responseHash }),
       ts: meta.ts,
       nonce: meta.nonce,
       sessionId: meta.sessionId,
@@ -472,6 +569,8 @@ export class ProofVerifier {
       ...(meta.scopeId && { scopeId: meta.scopeId }),
       ...(meta.delegationRef && { delegationRef: meta.delegationRef }),
       ...(meta.clientDid && { clientDid: meta.clientDid }),
+      ...(meta.outcome && { outcome: meta.outcome }),
+      ...(meta.reason && { reason: meta.reason }),
     };
 
     // Canonicalize the reconstructed payload using the same function as proof generation

--- a/src/providers/audit-log.ts
+++ b/src/providers/audit-log.ts
@@ -34,7 +34,7 @@ export function buildAuditRecord(context: AuditContext): AuditRecord {
     did: context.identity.did,
     kid: context.identity.kid,
     reqHash: context.requestHash,
-    resHash: context.responseHash,
+    resHash: context.responseHash ?? "-",
     verified: context.verified,
     scope: context.scopeId ?? "-",
   };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -15,6 +15,8 @@ export {
 } from './memory.js';
 
 export { NodeCryptoProvider } from './node-crypto.js';
+export { SystemClockProvider } from './system-clock.js';
+export { RuntimeFetchProvider } from './runtime-fetch.js';
 
 export {
   AuditLogProvider,

--- a/src/providers/runtime-fetch.ts
+++ b/src/providers/runtime-fetch.ts
@@ -1,0 +1,201 @@
+/**
+ * Runtime FetchProvider
+ *
+ * Network-capable `FetchProvider` for any runtime that exposes a global
+ * `fetch` (Node 18+, Deno, Bun, Cloudflare Workers, browsers). It resolves
+ * DIDs (did:key locally, did:web over HTTPS), fetches StatusList2021 credentials,
+ * and exposes the raw `fetch` escape hatch the delegation resolvers build on.
+ *
+ * Security (SSRF): `resolveDID` (did:web) and `fetchStatusList` issue outbound
+ * HTTPS GETs to hosts named by counterparty-controlled data — the DID or
+ * status-list URL embedded in a proof or credential. To blunt SSRF, requests to
+ * private / loopback / link-local IP-literal hosts (e.g. did:web:169.254.169.254,
+ * the cloud-metadata endpoint) are refused by default. This is best-effort
+ * defense-in-depth for IP literals only: it does NOT stop a public domain that
+ * resolves to an internal address (DNS rebinding). Run verifiers behind an egress
+ * allowlist. Pass `{ allowPrivateNetworkHosts: true }` for trusted internal use.
+ * The raw `fetch()` escape hatch is intentionally unguarded — it is the caller's
+ * responsibility.
+ *
+ * @example
+ * ```typescript
+ * import { ProofVerifier, RuntimeFetchProvider, SystemClockProvider, NodeCryptoProvider, MemoryNonceCacheProvider } from '@kya-os/mcp';
+ *
+ * const verifier = new ProofVerifier({
+ *   cryptoProvider: new NodeCryptoProvider(),
+ *   clockProvider: new SystemClockProvider(),
+ *   nonceCacheProvider: new MemoryNonceCacheProvider(),
+ *   fetchProvider: new RuntimeFetchProvider(), // resolves the signer's did:key / did:web
+ * });
+ * ```
+ */
+
+import { FetchProvider } from "./base.js";
+import { createDidKeyResolver } from "../delegation/did-key-resolver.js";
+import {
+  createDidWebResolver,
+  isDidWeb,
+  didWebToUrl,
+} from "../delegation/did-web-resolver.js";
+import type { DIDDocument } from "../delegation/vc-verifier.js";
+import type {
+  StatusList2021Credential,
+  DelegationRecord,
+} from "../types/protocol.js";
+
+export interface RuntimeFetchProviderOptions {
+  /**
+   * Allow outbound requests to private / loopback / link-local IP-literal hosts.
+   * Default `false` (such hosts are refused to blunt SSRF). Enable only for
+   * trusted internal deployments.
+   */
+  allowPrivateNetworkHosts?: boolean;
+}
+
+export class RuntimeFetchProvider extends FetchProvider {
+  private readonly didKeyResolver = createDidKeyResolver();
+  private didWebResolver: ReturnType<typeof createDidWebResolver> | undefined;
+  private readonly allowPrivateNetworkHosts: boolean;
+
+  constructor(options?: RuntimeFetchProviderOptions) {
+    super();
+    this.allowPrivateNetworkHosts =
+      options?.allowPrivateNetworkHosts ?? false;
+  }
+
+  /**
+   * Resolve a DID to its DID Document. did:key is decoded locally (no network);
+   * did:web is fetched from its HTTPS `/.well-known/did.json`. Returns null for
+   * unsupported methods, a blocked (private-network) did:web host, or any
+   * resolution failure (never throws).
+   */
+  async resolveDID(did: string): Promise<DIDDocument | null> {
+    if (did.startsWith("did:key:")) {
+      return this.didKeyResolver.resolve(did);
+    }
+    if (isDidWeb(did)) {
+      if (this.isBlockedTarget(didWebToUrl(did))) {
+        return null;
+      }
+      // createDidWebResolver(this) only calls this.fetch() — never resolveDID —
+      // so passing `this` does not recurse. Cache it to reuse its doc cache.
+      if (!this.didWebResolver) {
+        this.didWebResolver = createDidWebResolver(this);
+      }
+      return this.didWebResolver.resolve(did);
+    }
+    return null;
+  }
+
+  /**
+   * Fetch and validate a StatusList2021 credential by URL. Returns null on a
+   * blocked (private-network) host, non-ok response, malformed payload, or
+   * transport error (never throws). Bit decoding is the verifier's job — this
+   * only retrieves the credential.
+   */
+  async fetchStatusList(url: string): Promise<StatusList2021Credential | null> {
+    if (this.isBlockedTarget(url)) {
+      return null;
+    }
+    try {
+      const res = await this.fetch(url);
+      if (!res.ok) {
+        return null;
+      }
+      const json: unknown = await res.json();
+      return isStatusList2021Credential(json) ? json : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * No remote delegation-chain wire format is defined: chains are assembled from
+   * a populated delegation graph, not fetched by id. Returns [] so consumers
+   * treat the chain as locally supplied.
+   */
+  async fetchDelegationChain(_id: string): Promise<DelegationRecord[]> {
+    return [];
+  }
+
+  /** Raw HTTP escape hatch — delegates to the runtime's global `fetch`. */
+  async fetch(url: string, options?: unknown): Promise<Response> {
+    if (typeof globalThis.fetch !== "function") {
+      throw new Error("Global fetch is not available in this runtime");
+    }
+    return globalThis.fetch(url, options as RequestInit);
+  }
+
+  /** True when SSRF protection should refuse `url` (a private IP-literal host). */
+  private isBlockedTarget(url: string | null): boolean {
+    if (this.allowPrivateNetworkHosts || url === null) {
+      return false;
+    }
+    let hostname: string;
+    try {
+      hostname = new URL(url).hostname;
+    } catch {
+      return false;
+    }
+    return isPrivateOrLoopbackHost(hostname);
+  }
+}
+
+/** Structural guard: a JSON payload is a StatusList2021 credential. */
+function isStatusList2021Credential(
+  value: unknown,
+): value is StatusList2021Credential {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const cred = value as Record<string, unknown>;
+  if (
+    !Array.isArray(cred["type"]) ||
+    !cred["type"].includes("StatusList2021Credential")
+  ) {
+    return false;
+  }
+  const subject = cred["credentialSubject"];
+  if (typeof subject !== "object" || subject === null) {
+    return false;
+  }
+  const s = subject as Record<string, unknown>;
+  return s["type"] === "StatusList2021" && typeof s["encodedList"] === "string";
+}
+
+/**
+ * True if `hostname` is a private / loopback / link-local IP LITERAL. Domain
+ * names return false (DNS-resolution-based SSRF is out of scope here — use an
+ * egress allowlist). Covers the common IPv4 ranges plus IPv6 loopback /
+ * link-local / unique-local literals.
+ */
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  let h = hostname.toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) {
+    h = h.slice(1, -1); // URL.hostname brackets IPv6 literals
+  }
+  if (h.includes(":")) {
+    // IPv6 literal
+    return (
+      h === "::1" || // loopback
+      h === "::" || // unspecified
+      h.startsWith("fe80:") || // link-local
+      h.startsWith("fc") || // unique-local fc00::/7
+      h.startsWith("fd")
+    );
+  }
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
+  if (!m) {
+    return false; // domain name, not an IP literal
+  }
+  const a = Number(m[1]);
+  const b = Number(m[2]);
+  return (
+    a === 127 || // loopback 127.0.0.0/8
+    a === 10 || // private 10.0.0.0/8
+    a === 0 || // 0.0.0.0/8 (unspecified / this-host)
+    (a === 169 && b === 254) || // link-local 169.254.0.0/16 (cloud metadata)
+    (a === 192 && b === 168) || // private 192.168.0.0/16
+    (a === 172 && b >= 16 && b <= 31) // private 172.16.0.0/12
+  );
+}

--- a/src/providers/system-clock.ts
+++ b/src/providers/system-clock.ts
@@ -1,0 +1,54 @@
+/**
+ * System ClockProvider
+ *
+ * Wall-clock `ClockProvider` backed by `Date.now()`. The default clock for any
+ * runtime with a trustworthy system time — pair it with `ProofVerifier`,
+ * `SessionManager`, or anything else that needs a clock.
+ *
+ * For deterministic tests, supply your own controllable `ClockProvider` instead.
+ *
+ * @example
+ * ```typescript
+ * import { ProofVerifier, SystemClockProvider, NodeCryptoProvider } from '@kya-os/mcp';
+ *
+ * const verifier = new ProofVerifier({
+ *   cryptoProvider: new NodeCryptoProvider(),
+ *   clockProvider: new SystemClockProvider(),
+ *   // ...nonceCacheProvider, fetchProvider
+ * });
+ * ```
+ */
+
+import { ClockProvider } from "./base.js";
+
+export class SystemClockProvider extends ClockProvider {
+  /** Current time as a millisecond epoch timestamp. */
+  now(): number {
+    return Date.now();
+  }
+
+  /**
+   * True if `timestamp` is within ±`skewSeconds` of now.
+   *
+   * Note: `timestamp` is MILLISECONDS — `ProofVerifier` calls this with
+   * `proof.meta.ts * 1000` (proof timestamps are in seconds).
+   */
+  isWithinSkew(timestamp: number, skewSeconds: number): boolean {
+    return Math.abs(Date.now() - timestamp) <= skewSeconds * 1000;
+  }
+
+  /** True once now is strictly past `expiresAt` (ms epoch). */
+  hasExpired(expiresAt: number): boolean {
+    return Date.now() > expiresAt;
+  }
+
+  /** Absolute ms-epoch expiry for a relative TTL in seconds. */
+  calculateExpiry(ttlSeconds: number): number {
+    return Date.now() + ttlSeconds * 1000;
+  }
+
+  /** ISO-8601 rendering of a ms-epoch timestamp. */
+  format(timestamp: number): string {
+    return new Date(timestamp).toISOString();
+  }
+}

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -208,7 +208,18 @@ export function wrapDelegationAsVC(
  * Extract a DelegationRecord from a DelegationCredential.
  */
 export function extractDelegationFromVC(vc: DelegationCredential): DelegationRecord {
-  const delegation = vc.credentialSubject.delegation;
+  // Defensive: callers may pass an untrusted/loosely-typed value. Fail with a
+  // clear, controlled error instead of a cryptic "Cannot read properties of
+  // undefined (reading 'delegation')" when the credential is structurally
+  // malformed. validate*-style callers should shape-check first and return
+  // { valid, reason } rather than relying on this throw — see
+  // validateDelegationChain, which never throws on a malformed leaf.
+  const delegation = vc?.credentialSubject?.delegation;
+  if (!delegation || typeof delegation !== 'object') {
+    throw new Error(
+      'extractDelegationFromVC: credential is missing credentialSubject.delegation',
+    );
+  }
 
   let signature = '';
   if (vc.proof) {
@@ -429,10 +440,12 @@ export interface ProofMeta {
   audience: string;
   sessionId: string;
   requestHash: string;
-  responseHash: string;
+  responseHash?: string;
   scopeId?: string;
   delegationRef?: string;
   clientDid?: string;
+  outcome?: 'allowed' | 'denied' | 'step_up_required' | 'needs_authorization';
+  reason?: string;
 }
 
 export interface DetachedProof {
@@ -474,7 +487,7 @@ export interface AuditContext {
     [key: string]: unknown;
   };
   requestHash: string;
-  responseHash: string;
+  responseHash?: string;
   verified: 'yes' | 'no';
   scopeId?: string;
 }
@@ -540,6 +553,47 @@ export function isNeedsAuthorizationError(error: unknown): error is NeedsAuthori
   );
 }
 
+/**
+ * Returned when an in-scope action is high-risk and requires per-action,
+ * N-of-M human (or second-identity) approval before it may proceed. The
+ * client collects approval grants bound to `requestHash` and resumes via
+ * `resumeToken`. Mirrors NeedsAuthorizationError, but gates a specific
+ * destructive action rather than session-level authorization.
+ */
+export interface NeedsApprovalError {
+  error: 'needs_approval';
+  message: string;
+  resumeToken: string;
+  expiresAt: number;
+  /** Approval grants MUST be bound to this requestHash (TOCTOU guard). */
+  requestHash: string;
+  quorum: { n: number; approvers: string[] };
+  context?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export function createNeedsApprovalError(config: {
+  message: string;
+  resumeToken: string;
+  expiresAt: number;
+  requestHash: string;
+  quorum: { n: number; approvers: string[] };
+  context?: Record<string, unknown>;
+}): NeedsApprovalError {
+  return {
+    error: 'needs_approval',
+    ...config,
+  };
+}
+
+export function isNeedsApprovalError(error: unknown): error is NeedsApprovalError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as Record<string, unknown>)['error'] === 'needs_approval'
+  );
+}
+
 // ============================================================================
 // DetachedProof validation
 // ============================================================================
@@ -587,20 +641,41 @@ export function validateDetachedProof(proof: unknown): {
     return { success: false, error: { message: 'meta.ts must be a positive integer' } };
   }
 
-  // Validate hash fields
-  const hashFields = ['requestHash', 'responseHash'] as const;
-  for (const field of hashFields) {
-    if (typeof m[field] !== 'string' || !HASH_REGEX.test(m[field] as string)) {
-      return { success: false, error: { message: `meta.${field} must match sha256:<64 hex chars>` } };
-    }
+  // Validate hash fields: requestHash is always required. responseHash is
+  // absent on denial / step-up proofs (no response) and validated only when present.
+  if (typeof m['requestHash'] !== 'string' || !HASH_REGEX.test(m['requestHash'] as string)) {
+    return { success: false, error: { message: 'meta.requestHash must match sha256:<64 hex chars>' } };
+  }
+  if (
+    m['responseHash'] !== undefined &&
+    (typeof m['responseHash'] !== 'string' || !HASH_REGEX.test(m['responseHash'] as string))
+  ) {
+    return {
+      success: false,
+      error: { message: 'meta.responseHash must match sha256:<64 hex chars> when present' },
+    };
   }
 
   // Optional string fields
-  const optionalStrings = ['scopeId', 'delegationRef', 'clientDid'] as const;
+  const optionalStrings = ['scopeId', 'delegationRef', 'clientDid', 'reason'] as const;
   for (const field of optionalStrings) {
     if (m[field] !== undefined && typeof m[field] !== 'string') {
       return { success: false, error: { message: `meta.${field} must be a string if present` } };
     }
+  }
+
+  // Optional outcome enum (present on denial / step-up / needs-authorization proofs)
+  if (
+    m['outcome'] !== undefined &&
+    !['allowed', 'denied', 'step_up_required', 'needs_authorization'].includes(m['outcome'] as string)
+  ) {
+    return {
+      success: false,
+      error: {
+        message:
+          'meta.outcome must be one of allowed | denied | step_up_required | needs_authorization',
+      },
+    };
   }
 
   return {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    // Run only the main working tree: skip any nested git worktrees a
+    // contributor may have checked out under these dirs (each holds a full repo
+    // copy whose tests would otherwise be collected twice). No-op on a clean
+    // checkout / CI, where these dirs do not exist.
+    exclude: [...configDefaults.exclude, '**/.worktrees/**', '**/.claude/**'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
Ports the KYA-OS authorization primitives developed upstream (vouched/kya-os/mcp) into `@kya-os/mcp`. Minor release (1.4.0) — additive over 1.3.x except the one note below.

## What

- **Per-action policy / step-up gate** (`withPolicyGate`): risk classification + pluggable `PolicyEngine`, N-of-M signed approvals, fail-closed default.
- **Scope-matcher enforcement**: exact / prefix / regex; crisp matchers now honored (ReDoS-safe), attenuation-only on re-delegation.
- **Signed `needs_authorization` challenge + verifier content binding**: the challenge binds its `authorizationUrl` via `responseHash`; `verifyProof(proof, jwk, { request, response })` recomputes over the received content → `CONTENT_BINDING_MISMATCH`, making a MITM-swapped consent URL tamper-evident.
- **Concrete providers**: `SystemClockProvider` + `RuntimeFetchProvider` (did:key local, did:web over HTTPS, StatusList2021 fetch; private/loopback/link-local IP-literal targets refused by default — SSRF, opt-out available). `ProofVerifier` consumers no longer hand-roll a clock/fetch.
- Examples migrated to the built package; runnable anti-MITM demo (`pnpm example:anti-mitm`).

## Note

Removes the `allowLegacyUnsafeDelegation` escape hatch — the only behavioral break is for an integrator who set it (they must now wire `resolveDelegationChain` / `statusListResolver`); everything else is additive.

## Validation

996 tests, typecheck, lint, and build green. `package.json` is left at 1.3.2; the 1.4.0 bump is applied at release.
