### PR TITLE
feat(policy): expose buildPolicyRequest projection and ./policy export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to @kya-os/mcp will be documented here.
 Format: https://keepachangelog.com/en/1.0.0/
 Versioning: https://semver.org/spec/v2.0.0.html
 
+## [1.5.0] - 2026-06-01
+
+Exposes the policy-request projection as a reusable primitive and adds a
+dedicated `./policy` entry point, so hosts beyond the bundled middleware (for
+example a gateway) can build a `PolicyRequest` from their own resolved facts
+without copying internal logic. Additive over 1.4.x.
+
+### Added
+
+- **`buildPolicyRequest(input)` projection helper.** Pure, transport-agnostic
+  assembly of resolved facts — principal, delegated scopes, risk, scope-match,
+  and optional approvals / budget — into the canonical `PolicyRequest` a
+  `PolicyEngine` evaluates. Lets any host present an identical request contract
+  to the engine instead of re-deriving the shape.
+- **`./policy` subpath export.** The policy seam (`PolicyRequest`,
+  `PolicyDecision`, `PolicyEngine`, `DefaultPolicyEngine`, `RiskClassifier`,
+  `buildPolicyRequest`) is now importable directly from `@kya-os/mcp/policy`,
+  alongside the existing re-export from the package root.
+
+### Changed
+
+- The bundled per-action policy gate now builds its `PolicyRequest` via
+  `buildPolicyRequest` rather than an inline literal. No behavior change.
+
 ## [1.4.0] - 2026-05-31
 
 Ports the KYA-OS authorization primitives developed upstream (xmcp-i) into

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",
@@ -42,6 +42,10 @@
     "./middleware": {
       "types": "./dist/middleware/index.d.ts",
       "default": "./dist/middleware/index.js"
+    },
+    "./policy": {
+      "types": "./dist/policy/index.d.ts",
+      "default": "./dist/policy/index.js"
     },
     "./schemas/*.json": "./schemas/*.json",
     "./package.json": "./package.json"

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -56,7 +56,7 @@ import { RiskClassifier } from "../policy/classifier.js";
 import { DefaultPolicyEngine } from "../policy/default-engine.js";
 import { verifyApprovalQuorum, type ApprovalGrant } from "../policy/approval.js";
 import type { PolicyEngine } from "../policy/engine.js";
-import type { PolicyRequest } from "../policy/types.js";
+import { buildPolicyRequest } from "../policy/projection.js";
 import { KYA_OS_ERROR_CODES } from "../errors.js";
 import { canonicalizeJSON, parseVCJWT } from "../delegation/utils.js";
 import { base64urlDecodeToBytes, base64urlEncodeFromBytes, bytesToBase64 } from "../utils/base64.js";
@@ -1281,7 +1281,7 @@ export function createKyaOsMiddleware(
       const risk = classifier.classify({ toolName, namespace });
       const principal = extractPolicyPrincipal(args["_kyaos_delegation"]);
 
-      const policyRequest: PolicyRequest = {
+      const policyRequest = buildPolicyRequest({
         principal: {
           agentDid: principal.agentDid,
           ...(principal.responsibleParty
@@ -1290,13 +1290,10 @@ export function createKyaOsMiddleware(
         },
         action: { toolName },
         resource: { namespace },
-        context: {
-          delegatedScopes: principal.delegatedScopes,
-          scopeMatched: opts.scopeMatched ?? false,
-          humanApprovals: [],
-          ...risk,
-        },
-      };
+        delegatedScopes: principal.delegatedScopes,
+        scopeMatched: opts.scopeMatched ?? false,
+        risk,
+      });
 
       const decision = await engine.evaluate(policyRequest);
 

--- a/src/policy/__tests__/projection.test.ts
+++ b/src/policy/__tests__/projection.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { buildPolicyRequest } from "../projection.js";
+import type { RiskAssessment } from "../types.js";
+
+const risk: RiskAssessment = {
+  reversibility: "reversible",
+  blastRadius: "record",
+  severity: "low",
+};
+
+describe("buildPolicyRequest", () => {
+  it("projects resolved facts into the canonical PolicyRequest shape", () => {
+    const request = buildPolicyRequest({
+      principal: { agentDid: "did:example:agent" },
+      action: { toolName: "send_email" },
+      resource: { namespace: "mail" },
+      delegatedScopes: ["send:mail"],
+      scopeMatched: true,
+      risk,
+    });
+
+    expect(request).toEqual({
+      principal: { agentDid: "did:example:agent" },
+      action: { toolName: "send_email" },
+      resource: { namespace: "mail" },
+      context: {
+        delegatedScopes: ["send:mail"],
+        scopeMatched: true,
+        humanApprovals: [],
+        reversibility: "reversible",
+        blastRadius: "record",
+        severity: "low",
+      },
+    });
+  });
+
+  it("includes responsibleParty only when supplied", () => {
+    const without = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: false,
+      risk,
+    });
+    expect("responsibleParty" in without.principal).toBe(false);
+
+    const withParty = buildPolicyRequest({
+      principal: { agentDid: "did:a", responsibleParty: "did:org" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: false,
+      risk,
+    });
+    expect(withParty.principal.responsibleParty).toBe("did:org");
+  });
+
+  it("defaults humanApprovals to empty and preserves supplied approvals", () => {
+    const defaulted = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: true,
+      risk,
+    });
+    expect(defaulted.context.humanApprovals).toEqual([]);
+
+    const supplied = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: true,
+      risk,
+      humanApprovals: ["did:approver"],
+    });
+    expect(supplied.context.humanApprovals).toEqual(["did:approver"]);
+  });
+
+  it("includes budgetRemaining only when supplied", () => {
+    const without = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: true,
+      risk,
+    });
+    expect("budgetRemaining" in without.context).toBe(false);
+
+    const withBudget = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: true,
+      risk,
+      budgetRemaining: 42,
+    });
+    expect(withBudget.context.budgetRemaining).toBe(42);
+  });
+
+  it("carries the risk assessment through into context", () => {
+    const request = buildPolicyRequest({
+      principal: { agentDid: "did:a" },
+      action: { toolName: "t" },
+      resource: { namespace: "n" },
+      delegatedScopes: [],
+      scopeMatched: true,
+      risk: {
+        reversibility: "irreversible",
+        blastRadius: "tenant",
+        severity: "catastrophic",
+      },
+    });
+    expect(request.context.reversibility).toBe("irreversible");
+    expect(request.context.blastRadius).toBe("tenant");
+    expect(request.context.severity).toBe("catastrophic");
+  });
+});

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -2,4 +2,5 @@ export * from './types.js';
 export * from './engine.js';
 export * from './classifier.js';
 export * from './default-engine.js';
+export * from './projection.js';
 export * from './approval.js';

--- a/src/policy/projection.ts
+++ b/src/policy/projection.ts
@@ -1,0 +1,61 @@
+import type { PolicyRequest, RiskAssessment } from './types.js';
+
+/**
+ * Resolved facts a host gathers before projecting a {@link PolicyRequest}.
+ *
+ * Intentionally decoupled from any one transport: the bundled middleware
+ * resolves these from a delegation credential, but a gateway (or any other
+ * host) can resolve them however it likes and reuse the same projection, so
+ * every caller presents an identical request contract to the PolicyEngine.
+ */
+export interface PolicyRequestInput {
+  /** The acting agent and, when known, the accountable party behind it. */
+  principal: { agentDid: string; responsibleParty?: string };
+  /** The resolved action (tool) being invoked. */
+  action: { toolName: string };
+  /** The resource the action targets. */
+  resource: { namespace: string };
+  /** Scopes the delegation chain grants the agent. */
+  delegatedScopes: string[];
+  /** Whether a prior step already matched the action to a delegated scope. */
+  scopeMatched: boolean;
+  /** Risk classification of the action. */
+  risk: RiskAssessment;
+  /** Approver DIDs gathered after a step-up round-trip. Defaults to none. */
+  humanApprovals?: string[];
+  /** Remaining CRISP budget, when a budget applies. */
+  budgetRemaining?: number;
+}
+
+/**
+ * Assemble resolved facts into the neutral {@link PolicyRequest} a PolicyEngine
+ * evaluates. Pure and transport-agnostic: callers resolve the facts (principal,
+ * scopes, risk) however their host dictates, and this renders the canonical
+ * request shape — keeping the contract presented to the engine identical across
+ * the bundled middleware, a gateway, and any other host.
+ *
+ * `responsibleParty` and `budgetRemaining` are emitted only when supplied, so
+ * the request never carries undefined optional keys; `humanApprovals` defaults
+ * to an empty list (the first-pass, pre-approval state).
+ */
+export function buildPolicyRequest(input: PolicyRequestInput): PolicyRequest {
+  return {
+    principal: {
+      agentDid: input.principal.agentDid,
+      ...(input.principal.responsibleParty
+        ? { responsibleParty: input.principal.responsibleParty }
+        : {}),
+    },
+    action: { toolName: input.action.toolName },
+    resource: { namespace: input.resource.namespace },
+    context: {
+      delegatedScopes: input.delegatedScopes,
+      scopeMatched: input.scopeMatched,
+      humanApprovals: input.humanApprovals ?? [],
+      ...input.risk,
+      ...(input.budgetRemaining !== undefined
+        ? { budgetRemaining: input.budgetRemaining }
+        : {}),
+    },
+  };
+}


### PR DESCRIPTION
Lifts the PolicyRequest assembly out of the bundled middleware into a pure, transport-agnostic buildPolicyRequest helper in the policy module, so a gateway or other host can project a PolicyRequest from its own resolved facts without copying internal logic. Adds the ./policy subpath export. Bumps `@kya-os/mcp` to `1.5.0`.

The per-action gate now calls buildPolicyRequest instead of an inline literal while behavior is unchanged.