### PR TITLE
feat(providers): GrantStore provider + MemoryGrantStore reference impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versioning: https://semver.org/spec/v2.0.0.html
 - A deterministic, network-free in-memory OIDC example exercising the full
   authorization path. Additive; no new runtime dependency (zod, jose, Web
   Crypto only).
+- `GrantStore` provider + `MemoryGrantStore` reference implementation: the
+  post-approval counterpart to `ResumeTokenStore`. A grant binds to the agent
+  DID (durable authority) and optionally to a session (the confused-deputy-safe,
+  no-paste retry convenience — a grant bound to one session is never returned to
+  another). Soft revocation, TTL cleanup, lookup by agent or session. The memory
+  impl is the dev/reference store; production injects Redis / a Durable Object /
+  a database behind the same interface (mirroring `NonceCacheProvider`).
 
 ## [1.5.0] - 2026-06-01
 

--- a/src/providers/__tests__/grant-store.test.ts
+++ b/src/providers/__tests__/grant-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryGrantStore, type Grant } from '../grant-store.js';
+
+/**
+ * GrantStore is the provider seam for an approved authorization grant — the
+ * post-approval, durable counterpart to the pending ResumeTokenStore. A grant
+ * binds to the agent DID (durable authority) and optionally to a session (the
+ * confused-deputy-safe, no-paste retry convenience). The memory implementation
+ * is the dev/reference impl; production injects Redis / a Durable Object /
+ * Postgres behind the same interface.
+ */
+
+function grant(over: Partial<Grant> = {}): Grant {
+  return {
+    id: over.id ?? 'grant-1',
+    agentDid: over.agentDid ?? 'did:key:zAgentA',
+    scopes: over.scopes ?? ['vault:read'],
+    issuedAt: over.issuedAt ?? 1_000,
+    status: over.status ?? 'active',
+    ...over,
+  };
+}
+
+describe('MemoryGrantStore', () => {
+  it('binds a grant and finds it by agent DID', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ agentDid: 'did:key:zAgentA' }));
+    const found = await store.getByAgent('did:key:zAgentA');
+    expect(found).toHaveLength(1);
+    expect(found[0]?.scopes).toContain('vault:read');
+  });
+
+  it('returns no grants for an agent that has none', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ agentDid: 'did:key:zAgentA' }));
+    expect(await store.getByAgent('did:key:zAgentB')).toEqual([]);
+  });
+
+  it('binds to a session and resolves by session — the no-paste retry path', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ sessionId: 'sess-1' }));
+    const found = await store.getBySession('sess-1');
+    expect(found).toHaveLength(1);
+  });
+
+  it('does NOT return one session\'s grant to another session (confused-deputy guard)', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ sessionId: 'sess-A', agentDid: 'did:key:zAgentA' }));
+    expect(await store.getBySession('sess-A')).toHaveLength(1);
+    expect(await store.getBySession('sess-B')).toEqual([]);
+  });
+
+  it('soft-revokes (status + reason) without deleting the record', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ id: 'g1', agentDid: 'did:key:zAgentA' }));
+    await store.revoke('g1', 'user logged out');
+    // A revoked grant is not returned from active lookups.
+    expect(await store.getByAgent('did:key:zAgentA')).toEqual([]);
+    // But the record is retained (soft revoke) and reflects the reason.
+    const record = await store.getById('g1');
+    expect(record?.status).toBe('revoked');
+    expect(record?.revocationReason).toBe('user logged out');
+  });
+
+  it('treats an expired grant as inactive', async () => {
+    const store = new MemoryGrantStore({ now: () => 5_000 });
+    await store.bind(grant({ agentDid: 'did:key:zAgentA', expiresAt: 4_000 }));
+    expect(await store.getByAgent('did:key:zAgentA')).toEqual([]);
+  });
+
+  it('cleanup removes expired records', async () => {
+    let t = 1_000;
+    const store = new MemoryGrantStore({ now: () => t });
+    await store.bind(grant({ id: 'g1', expiresAt: 2_000 }));
+    t = 3_000;
+    await store.cleanup();
+    expect(await store.getById('g1')).toBeUndefined();
+  });
+
+  it('optionally narrows a session lookup by required scopes', async () => {
+    const store = new MemoryGrantStore();
+    await store.bind(grant({ sessionId: 'sess-1', scopes: ['vault:read'] }));
+    expect(await store.getBySession('sess-1', ['vault:read'])).toHaveLength(1);
+    expect(await store.getBySession('sess-1', ['vault:write'])).toEqual([]);
+  });
+});

--- a/src/providers/grant-store.ts
+++ b/src/providers/grant-store.ts
@@ -1,0 +1,147 @@
+/**
+ * GrantStore — the provider seam for an approved authorization grant.
+ *
+ * Where {@link ResumeTokenStore} holds a *pending* authorization challenge
+ * (token → {agentDid, scopes}, awaiting approval), a GrantStore holds the
+ * *approved* result one lifecycle step later: a durable grant bound to the
+ * agent DID, optionally bound to a session for a no-paste retry.
+ *
+ * Layering this seam makes explicit:
+ *   - the durable authority is the grant, anchored to the **agent DID** (and,
+ *     when known, the user DID) — portable across sessions and instances;
+ *   - the **session** binding is a transport convenience for wallet-less
+ *     clients, and is confused-deputy-safe: a grant bound to one session is
+ *     never returned to another;
+ *   - the store is pluggable. The in-memory implementation here is the
+ *     dev/reference impl; production injects Redis, a Durable Object, or a
+ *     database behind the same interface (mirroring {@link NonceCacheProvider}).
+ *
+ * A grant is the convenience cache of authority, not the authority's proof:
+ * possession is still proven per request by the agent's detached-JWS signature
+ * over the request (holder-of-key). Storing a grant never substitutes for that.
+ */
+
+export interface Grant {
+  /** Stable id for this grant (used for revocation). */
+  id: string;
+  /** The agent the grant authorizes — the durable binding key. */
+  agentDid: string;
+  /** The user on whose behalf the agent acts, when known. */
+  userDid?: string;
+  /** The scopes granted. */
+  scopes: string[];
+  /**
+   * The session that approved this grant, when known. Enables the no-paste
+   * retry: a later call from the same session resolves the grant with no token.
+   * A grant bound to one session is never returned to another.
+   */
+  sessionId?: string;
+  /** The authorization method that produced the grant. */
+  authorization?: { type: string; provider?: string };
+  /** The delegation credential (VC-JWT), when one was minted. */
+  credentialJwt?: string;
+  /** When the grant was issued (ms epoch). */
+  issuedAt: number;
+  /** When the grant expires (ms epoch); omitted means no expiry. */
+  expiresAt?: number;
+  /** Lifecycle status. Revocation is soft — the record is retained. */
+  status: 'active' | 'expired' | 'revoked';
+  /** Why the grant was revoked, when applicable. */
+  revocationReason?: string;
+}
+
+/**
+ * Store for approved authorization grants. Implementations bind a grant,
+ * resolve active grants by agent DID or by session, and soft-revoke.
+ */
+export abstract class GrantStore {
+  /** Persist (or replace) a grant. */
+  abstract bind(grant: Grant): Promise<void>;
+  /** Active grants for an agent DID, optionally narrowed to required scopes. */
+  abstract getByAgent(agentDid: string, requiredScopes?: string[]): Promise<Grant[]>;
+  /** Active grants bound to a session, optionally narrowed to required scopes. */
+  abstract getBySession(sessionId: string, requiredScopes?: string[]): Promise<Grant[]>;
+  /** A grant by id regardless of status (returns revoked/expired records too). */
+  abstract getById(id: string): Promise<Grant | undefined>;
+  /** Soft-revoke a grant: mark revoked with a reason; do not delete. */
+  abstract revoke(id: string, reason?: string): Promise<void>;
+  /** Drop expired records. */
+  abstract cleanup(): Promise<void>;
+}
+
+export interface MemoryGrantStoreOptions {
+  /** Clock injection for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * In-memory {@link GrantStore} — the dev/reference implementation.
+ *
+ * NOT for production: grants are lost on restart and do not scale past a single
+ * process. Inject a Redis / Durable Object / database-backed store instead. A
+ * runtime warning is emitted when this is used as a session manager's store
+ * (see SessionManager), matching the NonceCacheProvider precedent.
+ */
+export class MemoryGrantStore extends GrantStore {
+  private readonly grants = new Map<string, Grant>();
+  private readonly now: () => number;
+
+  constructor(options: MemoryGrantStoreOptions = {}) {
+    super();
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  async bind(grant: Grant): Promise<void> {
+    this.grants.set(grant.id, { ...grant });
+  }
+
+  async getByAgent(agentDid: string, requiredScopes?: string[]): Promise<Grant[]> {
+    return this.activeGrants().filter(
+      (g) => g.agentDid === agentDid && this.coversScopes(g, requiredScopes),
+    );
+  }
+
+  async getBySession(sessionId: string, requiredScopes?: string[]): Promise<Grant[]> {
+    return this.activeGrants().filter(
+      (g) => g.sessionId === sessionId && this.coversScopes(g, requiredScopes),
+    );
+  }
+
+  async getById(id: string): Promise<Grant | undefined> {
+    const grant = this.grants.get(id);
+    return grant ? { ...grant } : undefined;
+  }
+
+  async revoke(id: string, reason?: string): Promise<void> {
+    const grant = this.grants.get(id);
+    if (!grant) return;
+    grant.status = 'revoked';
+    if (reason !== undefined) grant.revocationReason = reason;
+  }
+
+  async cleanup(): Promise<void> {
+    const now = this.now();
+    for (const [id, grant] of this.grants) {
+      if (grant.expiresAt !== undefined && grant.expiresAt <= now) {
+        this.grants.delete(id);
+      }
+    }
+  }
+
+  /** Active = not revoked and not past expiry. */
+  private activeGrants(): Grant[] {
+    const now = this.now();
+    const out: Grant[] = [];
+    for (const grant of this.grants.values()) {
+      if (grant.status === 'revoked') continue;
+      if (grant.expiresAt !== undefined && grant.expiresAt <= now) continue;
+      out.push({ ...grant });
+    }
+    return out;
+  }
+
+  private coversScopes(grant: Grant, requiredScopes?: string[]): boolean {
+    if (!requiredScopes || requiredScopes.length === 0) return true;
+    return requiredScopes.every((s) => grant.scopes.includes(s));
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -24,3 +24,5 @@ export {
   NoopAuditLogProvider,
   buildAuditRecord,
 } from './audit-log.js';
+
+export { GrantStore, MemoryGrantStore, type Grant, type MemoryGrantStoreOptions } from './grant-store.js';


### PR DESCRIPTION
## Summary

Adds the provider seam for an **approved authorization grant** — the post-approval counterpart to `ResumeTokenStore` (which holds the *pending* challenge). 

This is the storage seam the authz examples currently hand-roll, and it makes the layering explicit.

## Why

A grant should bind to the **agent DID** (durable authority — portable across
sessions and instances), with an optional **session** binding for a no-paste
retry. The session binding is confused-deputy-safe: **a grant bound to one
session is never returned to another** unlike a tool-name-only lookup, which
would let one caller pick up another's approval.

The memory implementation is the dev/reference store; in a production environment, one could inject Redis, a
Durable Object, or a database behind the same interface exactly as `NonceCacheProvider` is injected. 
A grant is a *convenience cache of authority*, **not** a substitute for per-request holder-of-key proof.

## Interface

```ts
abstract class GrantStore {
  bind(grant: Grant): Promise<void>;
  getByAgent(agentDid, requiredScopes?): Promise<Grant[]>;   // durable binding
  getBySession(sessionId, requiredScopes?): Promise<Grant[]>; // no-paste retry, session-safe
  getById(id): Promise<Grant | undefined>;                    // incl. revoked/expired
  revoke(id, reason?): Promise<void>;                         // SOFT — status+reason, never delete
  cleanup(): Promise<void>;                                   // TTL sweep
}
```

`Grant` carries `agentDid` (+ optional `userDid`) first-class, `scopes`,
optional `sessionId`, optional `credentialJwt` (the VC when minted), `expiresAt`,
and a `status` of `active | expired | revoked`. No tenancy/project field — that
stays implementation-specific so downstream stores (Postgres, Durable Object) can
add their own partitioning.

## Tests / verification

- 8 tests: bind/get-by-agent, get-by-session, **cross-session isolation**, soft
  revoke (record retained), expiry, TTL cleanup, scope narrowing.
- Full suite: 1077 passing; `tsc` + lint clean; builds to `dist/providers/`.

## Notes

- Sibling of `NonceCacheProvider` / `ResumeTokenStore`; does not extend the
  string-KV `StorageProvider` (which couldn't express by-agent indexing or soft
  revoke).
- A loud production warning on the memory impl (matching the `NonceCacheProvider`
  precedent in `SessionManager`) is the intended follow-up when a host wires it
  into the session layer.

## Checklist
- [x] Commit signed off (DCO).
- [x] Tests pass; `tsc` + lint clean.
- [x] No new runtime dependency.
- [x] CHANGELOG updated under `[Unreleased]`.

## When is GrantStore the right tool?

Use a GrantStore when a **server governs access with KYA-OS on behalf of agents that do not carry their own identity** — i.e. the server holds/manages the authorization and re-attaches it to a returning caller. This is the right seam for:

- Wallet-less clients (MCP Inspector, plain MCP clients with no signing key) that cannot hold or present a credential themselves.
- A gateway/host that performs the OAuth/consent exchange server-side and needs to cache the approved grant for the next call.

**This is distinct from full Level 3 (Full Delegation) operation.** At L3, the *agent itself has an identity* (a DID + key) and **presents and proves it on every request** — the agent carries the delegation credential and signs each call (holder-of-key), so the server verifies possession per request rather than re-attaching authority from a server-side store. In that model the durable authority travels with the agent, and a GrantStore is **not** required on the path.

In short:
- **Agent has no identity, server governs →** GrantStore caches the server-held grant (binds to the session for the no-paste retry, to the agent DID when one exists). The grant is a *convenience cache*, soft-revocable, with TTL.
- **Agent presents an identity (L3) →** the agent presents + proves its DID-bound credential each request; the 
GrantStore is optional plumbing and a interoperable fallback, never the source of authority.

Either way, a stored grant is never a substitute for per-request holder-of-key proof where the agent can provide it.