### PR TITLE
feat(delegation): enforce holder-of-key binding at the inbound gate (opt-in)

### DIFF
--- a/src/delegation/__tests__/holder-binding.test.ts
+++ b/src/delegation/__tests__/holder-binding.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  assertHolderBinding,
+  generateRequestProof,
+  toHolderBindingRequest,
+  HOLDER_BINDING_ERROR,
+} from '../holder-binding.js';
+import { ProofGenerator } from '../../proof/generator.js';
+import { ProofVerifier } from '../../proof/verifier.js';
+import type { ToolRequest } from '../../proof/generator.js';
+import type { DetachedProof } from '../../types/protocol.js';
+import type { AgentIdentity } from '../../providers/base.js';
+import { didKeyFragment } from '../../utils/did-helpers.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  RealClockProvider,
+  RealFetchProvider,
+  MemoryNonceCacheProvider,
+} from '../../__tests__/audit/helpers/crypto-helpers.js';
+
+/**
+ * Holder binding closes the §11.8 theft-replay residual. A delegation names a
+ * subject DID; the caller must prove possession of that DID's key on the
+ * request. For a did:key subject the DID *is* the key, so proving possession =
+ * the request proof verifying against the subject DID's key. A proof signed by
+ * any other key — a thief replaying a stolen credential — does not verify and is
+ * rejected. did:web subjects (key not encoded in the DID) are out of phase-1
+ * scope and reported `not_applicable` so the gate can defer them to cnf binding
+ * rather than reject legitimate traffic.
+ */
+
+const crypto = createRealCryptoProvider();
+const AUDIENCE = 'did:web:server.example.com';
+
+function makeVerifier(): ProofVerifier {
+  return new ProofVerifier({
+    cryptoProvider: crypto,
+    clockProvider: new RealClockProvider(),
+    nonceCacheProvider: new MemoryNonceCacheProvider(),
+    fetchProvider: new RealFetchProvider(),
+    timestampSkewSeconds: 300,
+  });
+}
+
+const request: ToolRequest = { method: 'tools/call', params: { name: 'read_vault' } };
+
+/**
+ * A request-only detached proof signed by `identity` — the realistic inbound
+ * shape (the agent has no response yet when it makes the call).
+ */
+async function signRequestProof(identity: AgentIdentity): Promise<DetachedProof> {
+  const gen = new ProofGenerator(
+    {
+      did: identity.did,
+      kid: identity.kid,
+      privateKey: identity.privateKey,
+      publicKey: identity.publicKey,
+    },
+    crypto,
+  );
+  const now = Math.floor(Date.now() / 1000);
+  return gen.generateProof(request, undefined, {
+    sessionId: 'sess-1',
+    audience: AUDIENCE,
+    nonce: `nonce-${now}-${Math.random().toString(36).slice(2)}`,
+    timestamp: now,
+    createdAt: now,
+    lastActivity: now,
+    ttlMinutes: 30,
+    identityState: 'anonymous',
+  });
+}
+
+describe('assertHolderBinding', () => {
+  let agent: AgentIdentity;
+  let attacker: AgentIdentity;
+
+  beforeAll(async () => {
+    agent = await createRealIdentity(crypto);
+    attacker = await createRealIdentity(crypto);
+  });
+
+  it("binds a proof signed by the delegation subject's own key", async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+    expect(result.errorCode).toBeUndefined();
+  });
+
+  it('rejects a proof whose subject does not match the delegation subject', async () => {
+    // Attacker holds the leaked VC (subject = agent) but signs as themselves, so
+    // the proof self-declares the attacker. Caught by the pre-crypto check.
+    const proof = await signRequestProof(attacker);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+    expect(result.errorCode).toBe(HOLDER_BINDING_ERROR);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('rejects a stolen-credential replay: proof claims the subject but is signed by another key', async () => {
+    // The crucial cryptographic case. Attacker forges BOTH meta.did and meta.kid
+    // to impersonate the subject — defeating the subject pre-check AND the kid
+    // check — but cannot sign with the subject's key. The reconstructed payload
+    // binds sub/iss = subject, so the attacker's signature cannot verify against
+    // the subject's key: only the Ed25519 check can reject this, and it does.
+    const attackerProof = await signRequestProof(attacker);
+    const forged: DetachedProof = {
+      jws: attackerProof.jws,
+      meta: {
+        ...attackerProof.meta,
+        did: agent.did,
+        kid: `${agent.did}#${didKeyFragment(agent.did)}`,
+      },
+    };
+    const result = await assertHolderBinding({
+      proof: forged,
+      subjectDid: agent.did,
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+    expect(result.errorCode).toBe(HOLDER_BINDING_ERROR);
+  });
+
+  it('rejects a tampered request (content binding) even from the right signer', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request: { method: 'tools/call', params: { name: 'DIFFERENT_tool' } },
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+    expect(result.errorCode).toBe(HOLDER_BINDING_ERROR);
+  });
+
+  it('reports not_applicable for a non-did:key subject (deferred to phase-2 cnf binding)', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: 'did:web:agent.example.com',
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    // Phase 1 binds did:key subjects (DID == key). did:web needs an explicit cnf
+    // claim; report not_applicable so the gate defers rather than rejects.
+    expect(result.status).toBe('not_applicable');
+    expect(result.errorCode).toBeUndefined();
+  });
+
+  it('fails closed (unbound) on a structurally malformed proof — never throws', async () => {
+    // A proof object with no meta (e.g. the gate's {} substitution after a failed
+    // JSON.parse) must fail closed, not throw an uncaught error.
+    const result = await assertHolderBinding({
+      proof: {} as unknown as DetachedProof,
+      subjectDid: agent.did,
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+    expect(result.errorCode).toBe(HOLDER_BINDING_ERROR);
+  });
+});
+
+describe('generateRequestProof + toHolderBindingRequest (client mint <-> PEP assert)', () => {
+  let agent: AgentIdentity;
+
+  beforeAll(async () => {
+    agent = await createRealIdentity(crypto);
+  });
+
+  it('toHolderBindingRequest binds tool name + business args, stripping _kyaos_* control keys', () => {
+    expect(
+      toHolderBindingRequest('read_vault', {
+        path: '/x',
+        _kyaos_delegation: { id: 'vc-1' },
+        _kyaos_proof: { jws: 'x', meta: {} },
+      }),
+    ).toEqual({ method: 'read_vault', params: { path: '/x' } });
+  });
+
+  it('a proof minted by the subject round-trips to bound at the PEP', async () => {
+    const args = { path: '/secret', _kyaos_delegation: { id: 'vc-1' } };
+    const proof = await generateRequestProof({
+      identity: agent,
+      crypto,
+      toolName: 'read_vault',
+      args,
+      audience: AUDIENCE,
+      sessionId: 'sess-1',
+    });
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request: toHolderBindingRequest('read_vault', args),
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+  });
+
+  it('a proof minted for one call does not bind a different call (content binding)', async () => {
+    const proof = await generateRequestProof({
+      identity: agent,
+      crypto,
+      toolName: 'read_vault',
+      args: { path: '/a' },
+      audience: AUDIENCE,
+      sessionId: 'sess-1',
+    });
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request: toHolderBindingRequest('read_vault', { path: '/b' }),
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+  });
+
+  it('each minted proof carries a fresh nonce (replay protection)', async () => {
+    const base = { identity: agent, crypto, toolName: 't', args: {}, audience: AUDIENCE, sessionId: 's' };
+    const p1 = await generateRequestProof(base);
+    const p2 = await generateRequestProof(base);
+    expect(p1.meta.nonce).not.toBe(p2.meta.nonce);
+  });
+});
+
+describe('assertHolderBinding — audience binding (confused-deputy guard)', () => {
+  let agent: AgentIdentity;
+
+  beforeAll(async () => {
+    agent = await createRealIdentity(crypto);
+  });
+
+  it('accepts when expectedAudience matches the proof audience', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      expectedAudience: AUDIENCE,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+  });
+
+  it('accepts when expectedAudience is an array containing the proof audience (rotation / multi-DID)', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      expectedAudience: ['did:web:old.example.com', AUDIENCE],
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+  });
+
+  it('rejects a proof minted for a different server (audience mismatch)', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      expectedAudience: 'did:web:other-server.example.com',
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('unbound');
+    expect(result.errorCode).toBe(HOLDER_BINDING_ERROR);
+    expect(result.cause).toBe('audience_mismatch');
+  });
+
+  it('omitting expectedAudience preserves prior behavior (no audience check)', async () => {
+    const proof = await signRequestProof(agent);
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request,
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+  });
+});

--- a/src/delegation/holder-binding.ts
+++ b/src/delegation/holder-binding.ts
@@ -1,0 +1,259 @@
+/**
+ * Holder binding — enforce that a request proof is bound to the delegation subject.
+ *
+ * A delegation credential names a subject DID and grants it authority. On its
+ * own that credential is a *bearer* token: anyone who obtains the string can
+ * present it. Holder binding closes that gap (spec §11.8 theft-replay residual)
+ * by requiring the caller to prove possession of the subject DID's key on the
+ * request itself.
+ *
+ * For a `did:key` subject the proof is exact and needs no new credential fields:
+ * the DID *is* the public key, so "the proof verifies against the subject DID's
+ * key" is equivalent to "the caller holds the subject's private key". This module
+ * derives the subject key straight from the DID and verifies the request proof
+ * against it. A proof signed by any other key — a thief replaying a stolen
+ * credential — cannot verify and is rejected.
+ *
+ * `did:web` (and other non-`did:key`) subjects do not encode their key in the
+ * DID and may rotate or hold several keys, so phase-1 cannot pin "the" key for
+ * them. They are reported {@link HolderBindingStatus | not_applicable} so the
+ * caller can defer them to cnf-based binding (phase 2) instead of rejecting
+ * legitimate traffic. Callers MUST surface that gap (e.g. log it) rather than
+ * treat `not_applicable` as success.
+ */
+
+import { extractPublicKeyFromDidKey, publicKeyToJwk } from './did-key-resolver.js';
+import { getDidMethod, didKeyFragment } from '../utils/did-helpers.js';
+import { ProofGenerator } from '../proof/generator.js';
+import { base64urlEncodeFromBytes } from '../utils/base64.js';
+import type { ProofVerifier } from '../proof/verifier.js';
+import type { ToolRequest, ToolResponse, ProofAgentIdentity } from '../proof/generator.js';
+import type { DetachedProof } from '../types/protocol.js';
+import type { CryptoProvider } from '../providers/base.js';
+import type { Ed25519JWK } from '../utils/crypto-service.js';
+
+/**
+ * The control-arg key prefix. Args beginning with this are protocol envelope
+ * (`_kyaos_delegation`, `_kyaos_proof`, `_kyaos_approvals`), not the caller's
+ * tool intent, so they are excluded from the holder-binding request hash.
+ */
+const KYAOS_CONTROL_PREFIX = '_kyaos';
+
+/**
+ * Whether an argument key is reserved KYA-OS protocol envelope (`_kyaos*`:
+ * `_kyaos_delegation`, `_kyaos_proof`, `_kyaos_approvals`, …) rather than caller
+ * tool intent. The SINGLE predicate behind both the holder-binding request hash
+ * and the middleware's handler-arg stripping, so the set excluded from the bound
+ * hash and the set withheld from the handler cannot drift — a proof binds exactly
+ * the call the handler runs.
+ */
+export function isKyaOsControlArg(key: string): boolean {
+  return key.startsWith(KYAOS_CONTROL_PREFIX);
+}
+
+/**
+ * The canonical request a holder-binding proof binds: the tool name plus the
+ * caller's business arguments, with protocol control args stripped. SHARED by
+ * the client (when minting the proof) and the PEP (when verifying it) so the two
+ * cannot drift — the request hash is computed over the identical shape on both
+ * sides regardless of which control args rode along.
+ */
+export function toHolderBindingRequest(
+  toolName: string,
+  args: Record<string, unknown>,
+): ToolRequest {
+  const params: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (!isKyaOsControlArg(k)) params[k] = v;
+  }
+  return { method: toolName, params };
+}
+
+export interface GenerateRequestProofInput {
+  /** The agent (delegation subject) identity holding the signing key. */
+  identity: ProofAgentIdentity;
+  /** Crypto provider used to sign and to mint the per-request nonce. */
+  crypto: CryptoProvider;
+  /** The tool being called. */
+  toolName: string;
+  /** The tool arguments (control args are stripped before binding). */
+  args: Record<string, unknown>;
+  /** The server DID the call is addressed to. */
+  audience: string;
+  /** The handshake session id, when one exists. */
+  sessionId?: string;
+}
+
+/**
+ * Mint the `_kyaos_proof` a key-bearing agent attaches to an outbound tool call
+ * — the client half of holder binding. It is a request-only detached proof (no
+ * response yet) signed by the agent's key over {@link toHolderBindingRequest}.
+ * A fresh nonce is generated per call so the PEP's replay cache rejects reuse.
+ */
+export async function generateRequestProof(
+  input: GenerateRequestProofInput,
+): Promise<DetachedProof> {
+  const { identity, crypto, toolName, args, audience, sessionId } = input;
+  const generator = new ProofGenerator(identity, crypto);
+  const request = toHolderBindingRequest(toolName, args);
+  const nonce = base64urlEncodeFromBytes(await crypto.randomBytes(16));
+  const now = Math.floor(Date.now() / 1000);
+  return generator.generateProof(request, undefined, {
+    sessionId: sessionId ?? '',
+    audience,
+    nonce,
+    timestamp: now,
+    createdAt: now,
+    lastActivity: now,
+    ttlMinutes: 30,
+    identityState: 'anonymous',
+  });
+}
+
+/**
+ * Stable, client-facing error code for a failed holder binding. Distinct from
+ * the verifier's granular codes (which are kept in {@link HolderBindingResult.cause}
+ * for server-side diagnosis) so a binding failure presents one reason to callers
+ * and never leaks why the proof was rejected.
+ */
+export const HOLDER_BINDING_ERROR = 'holder_binding_failed';
+
+/**
+ * - `bound` — subject is a did:key and the proof verifies against its key: the
+ *   caller is the holder. Allow.
+ * - `unbound` — subject is a did:key but the proof failed (wrong key, tampered
+ *   request, stale, or replayed). Reject — this is the theft-replay closure.
+ * - `not_applicable` — subject is not a did:key, so phase-1 cannot bind it.
+ *   Defer to cnf-based binding (phase 2); the caller decides how to treat it.
+ */
+export type HolderBindingStatus = 'bound' | 'unbound' | 'not_applicable';
+
+/**
+ * Whether phase-1 holder binding can bind this subject. True only for did:key
+ * (the DID encodes the key). The PEP uses this to decide between *enforcing* a
+ * proof (did:key) and *deferring* to cnf binding (did:web and others), so it
+ * never rejects legitimate traffic it cannot yet bind.
+ */
+export function isHolderBindingApplicable(subjectDid: string): boolean {
+  return extractPublicKeyFromDidKey(subjectDid) !== null;
+}
+
+export interface AssertHolderBindingInput {
+  /** The per-request detached proof presented by the caller. */
+  proof: DetachedProof;
+  /** The delegation subject DID the proof must be bound to. */
+  subjectDid: string;
+  /** The request the proof must bind (content binding). */
+  request: ToolRequest;
+  /**
+   * The response the proof binds, when the proof carries one. Inbound request
+   * proofs are request-only and omit this.
+   */
+  response?: ToolResponse;
+  /**
+   * The audience the proof must be addressed to — the recipient server's DID
+   * (RFC 8707 "to-whom" binding). When set, `proof.meta.audience` must equal it
+   * (or be one of the array, for DID rotation / multi-DID servers); a proof
+   * minted for another server is rejected, closing confused-deputy replay across
+   * servers. Omit to skip the audience check (back-compatible).
+   */
+  expectedAudience?: string | string[];
+  /** The existing verifier — supplies signature, nonce, timestamp and content checks. */
+  proofVerifier: ProofVerifier;
+}
+
+export interface HolderBindingResult {
+  status: HolderBindingStatus;
+  /** Human-readable explanation (present whenever status is not `bound`). */
+  reason?: string;
+  /** {@link HOLDER_BINDING_ERROR} when status is `unbound`. */
+  errorCode?: typeof HOLDER_BINDING_ERROR;
+  /** Underlying verifier error code, for server-side diagnosis only. */
+  cause?: string;
+}
+
+/**
+ * Assert that `proof` is a holder-of-key proof for `subjectDid` over `request`.
+ *
+ * @see module documentation for the did:key / did:web split and the security
+ *   property each branch enforces.
+ */
+export async function assertHolderBinding(
+  input: AssertHolderBindingInput,
+): Promise<HolderBindingResult> {
+  const { proof, subjectDid, request, response, expectedAudience, proofVerifier } = input;
+
+  // Phase-1 scope: did:key subjects only — the DID encodes the key, so holding
+  // the key is being the subject. Anything else is deferred to cnf binding.
+  const subjectKeyBytes = extractPublicKeyFromDidKey(subjectDid);
+  if (!subjectKeyBytes) {
+    return {
+      status: 'not_applicable',
+      reason:
+        `Holder binding (phase 1) covers did:key subjects only; ` +
+        `"${getDidMethod(subjectDid) ?? 'unknown'}" is deferred to cnf-based binding`,
+    };
+  }
+
+  // Fail closed on a structurally malformed proof (e.g. the {} a caller
+  // substitutes when a string proof fails to parse) — never throw out of the
+  // gate, which would surface as an internal error instead of a binding failure.
+  if (typeof proof?.meta !== 'object' || proof.meta === null) {
+    return {
+      status: 'unbound',
+      errorCode: HOLDER_BINDING_ERROR,
+      reason: 'Malformed proof: missing meta',
+    };
+  }
+
+  // Pre-crypto consistency: the proof must self-declare the delegation subject.
+  // Cheap, and gives a precise reason before the signature check.
+  if (proof.meta.did !== subjectDid) {
+    return {
+      status: 'unbound',
+      errorCode: HOLDER_BINDING_ERROR,
+      reason: 'Proof subject does not match the delegation subject',
+    };
+  }
+
+  // Audience binding (RFC 8707): the proof must be addressed to THIS server. A
+  // proof minted for another server cannot be replayed here. Checked before the
+  // signature so a misdirected proof fails fast without burning its nonce.
+  if (expectedAudience !== undefined) {
+    const allowed = Array.isArray(expectedAudience) ? expectedAudience : [expectedAudience];
+    if (!allowed.includes(proof.meta.audience)) {
+      return {
+        status: 'unbound',
+        errorCode: HOLDER_BINDING_ERROR,
+        reason: 'Proof audience does not match this server',
+        cause: 'audience_mismatch',
+      };
+    }
+  }
+
+  // The binding itself: verify the proof against the SUBJECT DID's key. The
+  // verifier reconstructs the signed payload from proof.meta (sub/iss = subject),
+  // so a proof signed by any other key cannot verify here — defeating a
+  // stolen-credential replay — and a tampered request fails content binding.
+  // Tag the key with the subject's canonical did:key verification-method id.
+  // The verifier's kid check (publicKeyJwk.kid === proof.meta.kid) then enforces
+  // that the proof's kid is the subject's verification method — a proof citing
+  // any other kid is rejected before the signature is even checked. The key
+  // material (x) still comes from the DID, so the signature is the real binding.
+  const subjectKey = publicKeyToJwk(subjectKeyBytes) as Ed25519JWK;
+  subjectKey.kid = `${subjectDid}#${didKeyFragment(subjectDid)}`;
+  const verification = await proofVerifier.verifyProof(proof, subjectKey, {
+    request,
+    ...(response !== undefined ? { response } : {}),
+  });
+  if (!verification.valid) {
+    return {
+      status: 'unbound',
+      errorCode: HOLDER_BINDING_ERROR,
+      reason: 'Request proof is not bound to the delegation subject',
+      ...(verification.errorCode !== undefined ? { cause: verification.errorCode } : {}),
+    };
+  }
+
+  return { status: 'bound' };
+}

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -16,6 +16,7 @@ export * from './outbound-proof.js';
 export * from './outbound-headers.js';
 export * from './audience-validator.js';
 export * from './scope-matcher.js';
+export * from './holder-binding.js';
 export {
   createDidKeyResolver,
   resolveDidKeySync,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -32,6 +32,7 @@ export const KYA_OS_ERROR_CODES = {
   delegation_not_yet_valid: "delegation_not_yet_valid",
   delegation_revoked: "delegation_revoked",
   delegation_invalid: "delegation_invalid",
+  holder_binding_failed: "holder_binding_failed",
   budget_exceeded: "budget_exceeded",
   rate_limit_exceeded: "rate_limit_exceeded",
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,19 @@ export {
   type VCJWTPayload,
 } from './delegation/utils.js';
 
+export {
+  assertHolderBinding,
+  generateRequestProof,
+  toHolderBindingRequest,
+  isHolderBindingApplicable,
+  isKyaOsControlArg,
+  HOLDER_BINDING_ERROR,
+  type AssertHolderBindingInput,
+  type GenerateRequestProofInput,
+  type HolderBindingResult,
+  type HolderBindingStatus,
+} from './delegation/holder-binding.js';
+
 export { MemoryStatusListStorage } from './delegation/storage/memory-statuslist-storage.js';
 
 export { MemoryDelegationGraphStorage } from './delegation/storage/memory-graph-storage.js';

--- a/src/middleware/__tests__/holder-binding-gate.test.ts
+++ b/src/middleware/__tests__/holder-binding-gate.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect } from 'vitest';
+import { createKyaOsMiddleware, type KyaOsDelegationConfig } from '../with-kya-os.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import { generateRequestProof } from '../../delegation/holder-binding.js';
+import type { DelegationCredential, Proof } from '../../types/protocol.js';
+import type { ProofAgentIdentity } from '../../proof/generator.js';
+import type { NonceCacheProvider } from '../../providers/base.js';
+import { MemoryNonceCacheProvider } from '../../providers/memory.js';
+import { base64urlEncodeFromBytes } from '../../utils/base64.js';
+
+/**
+ * Holder binding at the PEP (spec §11.8). The gate already validates the
+ * delegation *credential*; these tests prove it now also enforces that the
+ * caller holds the delegation *subject's* key — closing theft-replay for the
+ * key-bearing did:key population. Enforcement is opt-in (off | warn | enforce).
+ */
+
+const crypto = new NodeCryptoProvider();
+const SCOPE = 'vault:read';
+
+async function makeIdentity(): Promise<ProofAgentIdentity> {
+  const kp = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(kp.publicKey);
+  return { did, kid: `${did}#${did.replace('did:key:', '')}`, privateKey: kp.privateKey, publicKey: kp.publicKey };
+}
+
+function makeServer(
+  holderBinding?: KyaOsDelegationConfig['holderBinding'],
+  nonceCache?: NonceCacheProvider,
+) {
+  // The server identity (the PEP's own DID).
+  return makeIdentity().then((server) => ({
+    server,
+    middleware: createKyaOsMiddleware(
+      {
+        identity: server,
+        session: { sessionTtlMinutes: 60 },
+        delegation: holderBinding ? { holderBinding } : undefined,
+        ...(nonceCache ? { nonceCache } : {}),
+      },
+      crypto,
+    ),
+  }));
+}
+
+/** A nonce cache that records every nonce added, to prove one instance is shared. */
+class RecordingNonceCache extends MemoryNonceCacheProvider {
+  readonly added = new Set<string>();
+  async add(nonce: string, ttlSeconds: number, agentDid?: string): Promise<void> {
+    this.added.add(nonce);
+    return super.add(nonce, ttlSeconds, agentDid);
+  }
+}
+
+/** Issue a delegation VC (issuer-signed) naming `subjectDid` as the holder. */
+async function issueVC(subjectDid: string, scopes: string[] = [SCOPE]): Promise<DelegationCredential> {
+  const issuer = await makeIdentity();
+  const signingFn = async (canonicalVC: string, _issuerDid: string, kid: string): Promise<Proof> => {
+    const sig = await crypto.sign(new TextEncoder().encode(canonicalVC), issuer.privateKey);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue: base64urlEncodeFromBytes(sig),
+    };
+  };
+  const credentialIssuer = new DelegationCredentialIssuer(
+    { getDid: () => issuer.did, getKeyId: () => issuer.kid, getPrivateKey: () => issuer.privateKey },
+    signingFn,
+  );
+  return credentialIssuer.createAndIssueDelegation({
+    id: `del-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    issuerDid: issuer.did,
+    subjectDid,
+    constraints: { scopes, notAfter: Math.floor(Date.now() / 1000) + 3600 },
+  });
+}
+
+async function openSession(middleware: Awaited<ReturnType<typeof makeServer>>['middleware'], serverDid: string) {
+  const hs = await middleware.handleHandshake({
+    nonce: `hs-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    audience: serverDid,
+    timestamp: Math.floor(Date.now() / 1000),
+  });
+  return JSON.parse(hs.content[0].text).sessionId as string;
+}
+
+const REACHED = { content: [{ type: 'text' as const, text: 'reached-handler' }] };
+const handlerThatRuns = async () => REACHED;
+
+function parse(result: Awaited<ReturnType<typeof handlerThatRuns>> & { isError?: boolean }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wrapWithDelegation — holder binding', () => {
+  it("enforce: a call carrying the subject's request proof reaches the handler", async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ ...args, _kyaos_proof: proof }, sessionId);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('enforce: a call with NO request proof is rejected (holder binding required)', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ path: '/secret', _kyaos_delegation: vc }, sessionId);
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('holder_binding_failed');
+  });
+
+  it('enforce: a proof signed by a DIFFERENT key (stolen credential) is rejected', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const attacker = await makeIdentity();
+    const vc = await issueVC(agent.did); // VC names the agent as subject
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    // The attacker holds the leaked VC but signs with their own key.
+    const forgedProof = await generateRequestProof({
+      identity: attacker, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ ...args, _kyaos_proof: forgedProof }, sessionId);
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('holder_binding_failed');
+  });
+
+  it('warn: a call with no proof still reaches the handler (logged, not enforced)', async () => {
+    const { server, middleware } = await makeServer('warn');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ path: '/secret', _kyaos_delegation: vc }, sessionId);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('off (default): no proof required — behavior is unchanged', async () => {
+    const { middleware } = await makeServer(); // no holderBinding config
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ path: '/secret', _kyaos_delegation: vc });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('enforce: a non-did:key (did:web) subject is deferred (not_applicable), not rejected', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const vc = await issueVC('did:web:agent.example.com');
+    const sessionId = await openSession(middleware, server.did);
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    // No proof, did:web subject → phase-1 cannot bind it → deferred (allowed).
+    const result = await handler({ path: '/secret', _kyaos_delegation: vc }, sessionId);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('enforce: a proof minted for a DIFFERENT server (wrong audience) is rejected', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent,
+      crypto,
+      toolName: 'my-tool',
+      args,
+      audience: 'did:web:evil.example.com', // minted for someone else
+      sessionId,
+    });
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ ...args, _kyaos_proof: proof }, sessionId);
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('holder_binding_failed');
+  });
+
+  it('enforce: replaying the same _kyaos_proof is rejected the second time (nonce replay)', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+
+    const first = await handler({ ...args, _kyaos_proof: proof }, sessionId);
+    const second = await handler({ ...args, _kyaos_proof: proof }, sessionId);
+
+    expect(first.content[0].text).toBe('reached-handler');
+    expect(second.isError).toBe(true);
+    expect(parse(second).error).toBe('holder_binding_failed');
+  });
+
+  it('a caller-injected NonceCacheProvider is shared by the handshake and holder binding', async () => {
+    const cache = new RecordingNonceCache();
+    const { server, middleware } = await makeServer('enforce', cache);
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did); // handshake adds a nonce
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    await handler({ ...args, _kyaos_proof: proof }, sessionId); // holder binding adds the proof nonce
+
+    // ONE injected instance saw both the handshake nonce and the holder-binding proof nonce.
+    expect(cache.added.has(proof.meta.nonce)).toBe(true);
+    expect(cache.added.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('enforce: the _kyaos_proof control arg never leaks into the handler args', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+
+    let seenArgs: Record<string, unknown> | undefined;
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      async (a) => {
+        seenArgs = a;
+        return REACHED;
+      },
+    );
+    await handler({ ...args, _kyaos_proof: proof }, sessionId);
+
+    expect(seenArgs).toBeDefined();
+    expect(Object.keys(seenArgs!)).not.toContain('_kyaos_proof');
+    expect(Object.keys(seenArgs!)).not.toContain('_kyaos_delegation');
+    expect(seenArgs!.path).toBe('/secret');
+  });
+
+  it('warn: a present-but-forged proof is logged but still reaches the handler', async () => {
+    // warn-mode contract: detect AND allow. A forged proof during rollout must be
+    // logged yet not block the call.
+    const { server, middleware } = await makeServer('warn');
+    const agent = await makeIdentity();
+    const attacker = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const forged = await generateRequestProof({
+      identity: attacker, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ ...args, _kyaos_proof: forged }, sessionId);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('enforce: a proof minted for different business args is rejected (content binding through the gate)', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    // Proof binds path:/a; the call substitutes path:/b.
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args: { path: '/a', _kyaos_delegation: vc }, audience: server.did, sessionId,
+    });
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ path: '/b', _kyaos_delegation: vc, _kyaos_proof: proof }, sessionId);
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('holder_binding_failed');
+  });
+
+  it('enforce: a valid proof passed as a JSON string round-trips to bound', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler({ ...args, _kyaos_proof: JSON.stringify(proof) }, sessionId);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('reached-handler');
+  });
+
+  it('enforce: a malformed string _kyaos_proof fails closed (holder_binding_failed), not a crash', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      handlerThatRuns,
+    );
+    const result = await handler(
+      { path: '/secret', _kyaos_delegation: vc, _kyaos_proof: 'not-json{{{' },
+      sessionId,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('holder_binding_failed');
+  });
+
+  it('enforce: reserved _kyaos* args never reach the handler (strip symmetric with the bound hash)', async () => {
+    const { server, middleware } = await makeServer('enforce');
+    const agent = await makeIdentity();
+    const vc = await issueVC(agent.did);
+    const sessionId = await openSession(middleware, server.did);
+
+    const args = { path: '/secret', _kyaos_delegation: vc };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: 'my-tool', args, audience: server.did, sessionId,
+    });
+    let seenArgs: Record<string, unknown> | undefined;
+    const handler = middleware.wrapWithDelegation(
+      'my-tool',
+      { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+      async (a) => {
+        seenArgs = a;
+        return REACHED;
+      },
+    );
+    // Smuggle an extra reserved-namespace key. It is excluded from the bound hash
+    // (so binding still passes) and MUST also be stripped before the handler.
+    const result = await handler(
+      { ...args, _kyaos_proof: proof, _kyaos_extra: 'smuggled' },
+      sessionId,
+    );
+
+    expect(result.content[0].text).toBe('reached-handler');
+    expect(Object.keys(seenArgs!)).not.toContain('_kyaos_extra');
+  });
+});

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -18,6 +18,7 @@
 import {
   type CryptoProvider,
   type FetchProvider,
+  type NonceCacheProvider,
 } from "../providers/base.js";
 import { RuntimeFetchProvider } from "../providers/runtime-fetch.js";
 import { AuditLogProvider, NoopAuditLogProvider } from "../providers/audit-log.js";
@@ -40,6 +41,15 @@ import {
   type StatusListResolver,
 } from "../delegation/vc-verifier.js";
 import { createDidKeyResolver } from "../delegation/did-key-resolver.js";
+import {
+  assertHolderBinding,
+  isHolderBindingApplicable,
+  isKyaOsControlArg,
+  toHolderBindingRequest,
+} from "../delegation/holder-binding.js";
+import { ProofVerifier } from "../proof/verifier.js";
+import { SystemClockProvider } from "../providers/system-clock.js";
+import { MemoryNonceCacheProvider } from "../providers/memory.js";
 import { scopeSatisfies } from "../delegation/scope-matcher.js";
 import { createDidWebResolver } from "../delegation/did-web-resolver.js";
 import { verifyDelegationAudience } from "../delegation/audience-validator.js";
@@ -49,6 +59,7 @@ import {
   extractDelegationFromVC,
   type DelegationCredential,
   type DelegationRecord,
+  type DetachedProof,
   type NeedsAuthorizationError,
 } from "../types/protocol.js";
 import { logger } from "../logging/index.js";
@@ -95,6 +106,23 @@ export interface KyaOsDelegationConfig {
   resolveDelegationChain?: (
     leafCredential: DelegationCredential,
   ) => Promise<DelegationCredential[]>;
+  /**
+   * Holder-of-key enforcement for inbound calls (spec §11.8). A valid delegation
+   * is a *bearer* credential; holder binding additionally requires the caller to
+   * present a per-request proof (`_kyaos_proof`) signed by the delegation
+   * SUBJECT's key, closing theft-replay for the key-bearing population.
+   *
+   * - `'off'` (default): no holder-binding check — current behavior, unchanged.
+   * - `'warn'`: check and log failures (missing/unbound proof), but still allow.
+   * - `'enforce'`: reject calls whose proof is missing or does not bind the
+   *   subject. **Breaking for callers that don't yet send `_kyaos_proof`** — opt
+   *   in only once your agents mint request proofs.
+   *
+   * Scope is did:key subjects (the DID encodes the key). did:web and other
+   * subjects are deferred to cnf-based binding (phase 2) and logged, never
+   * rejected — so enabling `'enforce'` never breaks did:web traffic.
+   */
+  holderBinding?: "off" | "warn" | "enforce";
 }
 
 export interface KyaOsConfig {
@@ -102,6 +130,14 @@ export interface KyaOsConfig {
   identity: KyaOsIdentityConfig;
   /** Session configuration overrides */
   session?: Omit<SessionConfig, "nonceCache">;
+  /**
+   * Replay-protection store, shared by the session handshake AND inbound holder
+   * binding so both draw on one nonce namespace. Defaults to an in-memory store
+   * (single-process only); inject a Redis / Durable Object / KV-backed
+   * {@link NonceCacheProvider} for multi-instance deployments. Set here, not on
+   * `session`, so there is exactly one cache and the two cannot diverge.
+   */
+  nonceCache?: NonceCacheProvider;
   /** Delegation verification overrides */
   delegation?: KyaOsDelegationConfig;
   /**
@@ -439,14 +475,45 @@ export function createKyaOsMiddleware(
     publicKey: config.identity.publicKey,
   };
 
+  // One replay-protection store, shared by the handshake and holder binding.
+  // Defaults to in-memory; SessionManager.cleanup() drives its expiry sweep.
+  const nonceCache = config.nonceCache ?? new MemoryNonceCacheProvider();
+
   const sessionManager = new SessionManager(cryptoProvider, {
     ...config.session,
     serverDid: identity.did,
+    nonceCache,
   });
 
   const proofGenerator = new ProofGenerator(identity, cryptoProvider);
   const delegationConfig = config.delegation;
   const auditLog = config.auditLog ?? new NoopAuditLogProvider();
+
+  // Holder binding (spec §11.8). Built once so all tools share one replay cache.
+  // The verifier derives the subject key from the did:key DID directly, so its
+  // fetchProvider is unused on the phase-1 path — a never-called stub keeps
+  // enforcement active even where a runtime fetch is absent.
+  const holderBindingMode = delegationConfig?.holderBinding ?? "off";
+  const holderBindingVerifier =
+    holderBindingMode === "off"
+      ? undefined
+      : new ProofVerifier({
+          cryptoProvider,
+          clockProvider: new SystemClockProvider(),
+          nonceCacheProvider: nonceCache,
+          fetchProvider:
+            delegationConfig?.fetchProvider ??
+            (typeof globalThis.fetch === "function"
+              ? new RuntimeFetchProvider()
+              : ({
+                  resolveDID: async () => null,
+                  fetchStatusList: async () => null,
+                  fetchDelegationChain: async () => [],
+                  fetch: async () => {
+                    throw new Error("fetch unavailable");
+                  },
+                } as unknown as FetchProvider)),
+        });
 
   // Session map: sessionId → last nonce (for proof generation)
   const sessionNonces = new Map<string, string>();
@@ -1211,6 +1278,79 @@ export function createKyaOsMiddleware(
         );
       }
 
+      // Holder binding (spec §11.8): the delegation is valid, but a valid
+      // *credential* is a bearer token until we also prove the caller holds the
+      // delegation SUBJECT's key. Opt-in via `delegation.holderBinding`. did:key
+      // subjects are bound here; did:web is deferred to cnf binding (phase 2) and
+      // logged, never rejected. Runs after identity is established, before scope.
+      if (holderBindingMode !== "off" && holderBindingVerifier) {
+        const subjectDid = vc.credentialSubject?.id;
+        if (subjectDid && isHolderBindingApplicable(subjectDid)) {
+          const proofArg = args["_kyaos_proof"];
+          if (proofArg === undefined) {
+            const reason =
+              "Holder-of-key proof (_kyaos_proof) is required for this delegation subject";
+            logger.warn(
+              `[kya-os] Holder binding: "${toolName}" called without _kyaos_proof`,
+            );
+            if (holderBindingMode === "enforce") {
+              return attachOutcomeProof(
+                buildDelegationErrorResponse(
+                  KYA_OS_ERROR_CODES.holder_binding_failed,
+                  reason,
+                ),
+                toolName,
+                args,
+                sessionId,
+                reason,
+              );
+            }
+          } else {
+            let parsedProof: unknown = proofArg;
+            if (typeof proofArg === "string") {
+              try {
+                parsedProof = JSON.parse(proofArg);
+              } catch {
+                parsedProof = {};
+              }
+            }
+            const binding = await assertHolderBinding({
+              proof: parsedProof as DetachedProof,
+              subjectDid,
+              request: toHolderBindingRequest(toolName, args),
+              expectedAudience: identity.did,
+              proofVerifier: holderBindingVerifier,
+            });
+            if (binding.status !== "bound") {
+              const reason =
+                binding.reason ??
+                "Holder-of-key proof did not bind the delegation subject";
+              logger.warn(
+                `[kya-os] Holder binding ${binding.status} for "${toolName}": ${sanitizeForMessage(reason)}`,
+              );
+              if (holderBindingMode === "enforce") {
+                return attachOutcomeProof(
+                  buildDelegationErrorResponse(
+                    KYA_OS_ERROR_CODES.holder_binding_failed,
+                    reason,
+                  ),
+                  toolName,
+                  args,
+                  sessionId,
+                  reason,
+                );
+              }
+            }
+          }
+        } else if (subjectDid) {
+          // Non-did:key subject — phase 1 cannot pin its key; defer to cnf
+          // binding (phase 2) rather than reject legitimate traffic.
+          logger.warn(
+            `[kya-os] Holder binding: subject "${subjectDid}" is not did:key; deferring to cnf binding (phase 2)`,
+          );
+        }
+      }
+
       // Safe to call directly: the structural guard + validateDelegationChain
       // above guarantee a well-formed credential here, and scopeSatisfies is
       // bounded (ReDoS-guarded) and returns rather than throws.
@@ -1235,10 +1375,12 @@ export function createKyaOsMiddleware(
         );
       }
 
-      // Strip _kyaos_delegation from args before passing to handler
+      // Strip the reserved _kyaos* control namespace before passing to the
+      // handler — same predicate the bound request hash uses, so the handler
+      // receives exactly the call the subject signed (no smuggled control arg).
       const cleanArgs: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(args)) {
-        if (k !== "_kyaos_delegation") cleanArgs[k] = v;
+        if (!isKyaOsControlArg(k)) cleanArgs[k] = v;
       }
 
       logger.debug(
@@ -1271,10 +1413,11 @@ export function createKyaOsMiddleware(
       opts.isValidApprovalSignature ?? (async () => false);
 
     return async (args: Record<string, unknown>, sessionId?: string) => {
-      const controlKeys = new Set(["_kyaos_delegation", approvalsKey]);
+      // Drop the reserved _kyaos* namespace plus the (possibly custom) approvals
+      // key, so no control arg reaches the handler.
       const cleanArgs: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(args)) {
-        if (!controlKeys.has(k)) cleanArgs[k] = v;
+        if (!isKyaOsControlArg(k) && k !== approvalsKey) cleanArgs[k] = v;
       }
 
       const namespace = opts.resolveNamespace?.(args) ?? toolName;


### PR DESCRIPTION
## What

Adds holder-of-key binding at the inbound delegation gate (`wrapWithDelegation`). A valid delegation credential is a *bearer* token: any party holding the credential string can present it. This requires the caller to additionally prove possession of the delegation **subject's** key on the request, closing the spec §11.8 theft-replay residual for the did:key population.

## How

- **`assertHolderBinding` (PEP)** — verifies the per-request proof against the key derived directly from the did:key subject DID. A proof signed by another key (stolen-credential replay) cannot verify; a tampered request fails content binding; a proof minted for another server fails audience binding; a replayed nonce or stale timestamp rejects.
- **`generateRequestProof` (client)** — mints the `_kyaos_proof` a key-bearing agent attaches to its tool call (request-only, fresh nonce per call).
- **`toHolderBindingRequest` / `isKyaOsControlArg`** — the single shared definition of the bound request shape and the reserved `_kyaos*` control namespace, so the hash the proof binds and the args handed to the handler are stripped identically and cannot drift.
- **Audience binding (RFC 8707)** — `proof.meta.audience` must equal the server DID (accepts an array for DID rotation / multi-DID servers).
- **One injectable `NonceCacheProvider`** (`KyaOsConfig.nonceCache`, default in-memory) shared by the session handshake and holder binding; consumers inject a Redis / KV / Durable-Object store for multi-instance deployments.

## Opt-in / non-breaking

`delegation.holderBinding: 'off' | 'warn' | 'enforce'` (default `off`). Existing callers are unchanged. `did:web` and other non-did:key subjects are deferred to cnf-based binding (a follow-up) and logged, never rejected — enabling `enforce` does not break them. A malformed proof fails closed rather than throwing.

## Tests

16 new tests (TDD, real Ed25519, no mocks): stolen-credential replay, forged-meta theft, tampered request (unit and through the gate), wrong audience, replay, missing proof, warn-mode detect-and-allow, did:web defer, malformed-proof fail-closed, JSON-string proof, reserved-namespace strip symmetry, and injected-cache sharing across handshake + binding. Full suite 1106/1106; typecheck, lint, build clean.
