### PR TITLE
refactor(providers): extract NoopFetchProvider to cover the offline fetch fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,7 @@ export {
 
 export { NodeCryptoProvider } from './providers/node-crypto.js';
 export { SystemClockProvider } from './providers/system-clock.js';
-export { RuntimeFetchProvider } from './providers/runtime-fetch.js';
+export { RuntimeFetchProvider, NoopFetchProvider } from './providers/runtime-fetch.js';
 
 export {
   AuditLogProvider,

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -20,7 +20,7 @@ import {
   type FetchProvider,
   type NonceCacheProvider,
 } from "../providers/base.js";
-import { RuntimeFetchProvider } from "../providers/runtime-fetch.js";
+import { RuntimeFetchProvider, NoopFetchProvider } from "../providers/runtime-fetch.js";
 import { AuditLogProvider, NoopAuditLogProvider } from "../providers/audit-log.js";
 import {
   SessionManager,
@@ -505,14 +505,7 @@ export function createKyaOsMiddleware(
             delegationConfig?.fetchProvider ??
             (typeof globalThis.fetch === "function"
               ? new RuntimeFetchProvider()
-              : ({
-                  resolveDID: async () => null,
-                  fetchStatusList: async () => null,
-                  fetchDelegationChain: async () => [],
-                  fetch: async () => {
-                    throw new Error("fetch unavailable");
-                  },
-                } as unknown as FetchProvider)),
+              : new NoopFetchProvider()),
         });
 
   // Session map: sessionId → last nonce (for proof generation)

--- a/src/providers/__tests__/noop-fetch.test.ts
+++ b/src/providers/__tests__/noop-fetch.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { NoopFetchProvider } from '../runtime-fetch.js';
+
+describe('NoopFetchProvider (offline fallback)', () => {
+  const provider = new NoopFetchProvider();
+
+  it('resolveDID returns null — nothing is resolvable without network', async () => {
+    expect(await provider.resolveDID('did:web:example.com')).toBeNull();
+  });
+
+  it('fetchStatusList returns null — revocation checks fail closed', async () => {
+    expect(await provider.fetchStatusList('https://example.com/status/1')).toBeNull();
+  });
+
+  it('fetchDelegationChain returns an empty chain', async () => {
+    expect(await provider.fetchDelegationChain('urn:delegation:1')).toEqual([]);
+  });
+
+  it('fetch throws rather than pretending to succeed', async () => {
+    await expect(provider.fetch('https://example.com')).rejects.toThrow('fetch unavailable');
+  });
+});

--- a/src/providers/runtime-fetch.ts
+++ b/src/providers/runtime-fetch.ts
@@ -141,6 +141,29 @@ export class RuntimeFetchProvider extends FetchProvider {
   }
 }
 
+/**
+ * No-op {@link FetchProvider} for runtimes without a global `fetch`, and the
+ * offline fallback when a verifier is constructed without one. Every network
+ * lookup resolves empty so verification fails closed on anything that would
+ * need the network, and the raw `fetch` escape hatch throws rather than
+ * pretending to succeed. A single named definition (vs. an inline literal) so
+ * it is covered once and reused everywhere the offline fallback is needed.
+ */
+export class NoopFetchProvider extends FetchProvider {
+  async resolveDID(_did: string): Promise<DIDDocument | null> {
+    return null;
+  }
+  async fetchStatusList(_url: string): Promise<StatusList2021Credential | null> {
+    return null;
+  }
+  async fetchDelegationChain(_id: string): Promise<DelegationRecord[]> {
+    return [];
+  }
+  async fetch(_url: string, _options?: unknown): Promise<Response> {
+    throw new Error("fetch unavailable");
+  }
+}
+
 /** Structural guard: a JSON payload is a StatusList2021 credential. */
 function isStatusList2021Credential(
   value: unknown,


### PR DESCRIPTION
## What

The holder-binding gate's verifier built its offline `FetchProvider` (the one used when the runtime has no global `fetch`) as an inline object literal. Its four arrow methods are never constructed under Node 18+/CI, so they counted as uncovered functions and pulled **Functions coverage down ~1%** (the drop noticed on #86).

## How

- Extract the fallback into a named **`NoopFetchProvider`** in `providers/runtime-fetch.ts`, exported alongside `RuntimeFetchProvider`.
- Reuse it at the holder-binding gate in `with-kya-os.ts` — replacing the inline literal (also removes a small duplication).
- Add a unit test exercising its four methods.

## Result

Functions coverage restored (95.61% → 96.71% locally); full suite green, `tsc` clean. No behaviour change — the fallback's semantics are identical (DID / status-list / delegation-chain lookups resolve empty; the raw `fetch` escape hatch throws).

## Checklist
- [x] Commit signed off (DCO)
- [x] Tests pass; typecheck clean
- [x] No new dependencies
