### PR TITLE
chore(schemas): migrate $id and @context host to schema.kya-os.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,12 @@ shipped runtime providers. Additive over 1.3.x except where noted under
 
 ### Changed
 
+- **Schema `$id` and JSON-LD `@context` hosts migrated** to the DIF-registered
+  `schema.kya-os.org`. All five shipped JSON Schemas (`schemas/*.json`), the
+  spec's context references, and the `DELEGATION_CREDENTIAL_CONTEXT` constant
+  now resolve under `schema.kya-os.org`; the prior `schema.kya-os.ai` host
+  continues to serve the same documents during the migration window (no `$id`
+  is 301-redirected).
 - **Schema `$id` and JSON-LD `@context` hosts migrated** off the
   `modelcontextprotocol-identity.io` trademark domain to the foundation-owned
   `schema.kya-os.ai`. All five shipped JSON Schemas (`schemas/*.json`), the

--- a/SPEC.md
+++ b/SPEC.md
@@ -354,7 +354,7 @@ Delegations are issued as W3C Verifiable Credentials:
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0"
+    "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
   ],
   "id": "urn:uuid:d7f8a9b0-1234-5678-9abc-def012345678",
   "type": ["VerifiableCredential", "DelegationCredential"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -67,7 +67,7 @@ except ValidationError as e:
 All schemas use JSON Schema draft 2020-12 and are published at:
 
 ```
-https://schema.kya-os.ai/v1/protocol/{family}/{resource}/v1.0.0
+https://schema.kya-os.org/v1/protocol/{family}/{resource}/v1.0.0
 ```
 
 Schemas can reference each other using `$ref`. For example, the delegation credential schema references shared definitions for constraints and proof structures.

--- a/schemas/delegation-credential.json
+++ b/schemas/delegation-credential.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/v1/protocol/delegation/credential/v1.0.0",
+  "$id": "https://schema.kya-os.org/v1/protocol/delegation/credential/v1.0.0",
   "title": "KYA-OS Delegation Credential",
   "description": "W3C Verifiable Credential containing a KYA-OS delegation with CRISP constraints.",
   "type": "object",
@@ -286,7 +286,7 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0"
+        "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
       ],
       "id": "urn:uuid:12345678-1234-1234-1234-123456789abc",
       "type": ["VerifiableCredential", "DelegationCredential"],

--- a/schemas/detached-proof.json
+++ b/schemas/detached-proof.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/v1/protocol/proof/detached/v1.0.0",
+  "$id": "https://schema.kya-os.org/v1/protocol/proof/detached/v1.0.0",
   "title": "KYA-OS Detached Proof",
   "description": "Cryptographic proof binding an MCP tool request/response pair to an agent's identity and session context.",
   "type": "object",

--- a/schemas/handshake-request.json
+++ b/schemas/handshake-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/v1/protocol/handshake/request/v1.0.0",
+  "$id": "https://schema.kya-os.org/v1/protocol/handshake/request/v1.0.0",
   "title": "KYA-OS Handshake Request",
   "description": "Client-initiated handshake request to establish a KYA-OS session with nonce-based replay protection.",
   "type": "object",

--- a/schemas/handshake-response.json
+++ b/schemas/handshake-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/v1/protocol/handshake/response/v1.0.0",
+  "$id": "https://schema.kya-os.org/v1/protocol/handshake/response/v1.0.0",
   "title": "KYA-OS Handshake Response",
   "description": "Server response to a successful handshake request, establishing session context.",
   "type": "object",

--- a/schemas/well-known-mcpi.json
+++ b/schemas/well-known-mcpi.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schema.kya-os.ai/v1/protocol/well-known/v1.0.0",
+  "$id": "https://schema.kya-os.org/v1/protocol/well-known/v1.0.0",
   "title": "KYA-OS Discovery Document",
   "description": "Well-known discovery document served at /.well-known/mcp for KYA-OS service discovery.",
   "type": "object",

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -118,7 +118,7 @@ export interface DelegationCredential {
 }
 
 export const DELEGATION_CREDENTIAL_CONTEXT =
-  'https://schema.kya-os.ai/v1/protocol/delegation/context/v1.0.0' as const;
+  'https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0' as const;
 
 // ============================================================================
 // StatusList2021 (W3C)


### PR DESCRIPTION
Migrates the published schema `$id`s and the JSON-LD `@context` host from `schema.kya-os.ai` to the DIF-registered `schema.kya-os.org`, continuing the host-migration pattern established in #65.

## Changes
- All five shipped JSON Schemas (`schemas/*.json`) `$id`s → `schema.kya-os.org`
- Delegation `@context` + `DELEGATION_CREDENTIAL_CONTEXT` (`src/types/protocol.ts`) → `schema.kya-os.org`
- `SPEC.md` context reference and `schemas/README.md` URL template → `schema.kya-os.org`
- `CHANGELOG.md`: new "Changed" entry (the historical `.io → .ai` entry is preserved)
- Version → `1.6.0`

The prior `schema.kya-os.ai` host continues to serve the same documents during the migration window; no released `$id` is 301-redirected. Marketing-site `kya-os.ai/mcp` links are intentionally left unchanged (separate brand decision, still open).

## Verification
`npm run build` clean; `npm test` → **1144 passed (80 files)**.

## Release note
Publish `@kya-os/mcp@1.6.0` to npm after merge — the schema repo's drift gate bumps to this version to re-sync the DIF mirror.