### PR TITLE
feat(providers): add isomorphic WebCryptoProvider (Ed25519 via WebCrypto)

### DIFF
--- a/src/providers/__tests__/web-crypto.test.ts
+++ b/src/providers/__tests__/web-crypto.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { WebCryptoProvider } from "../web-crypto.js";
+import { NodeCryptoProvider } from "../node-crypto.js";
+import { bytesToBase64 } from "../../utils/base64.js";
+
+const web = new WebCryptoProvider();
+const node = new NodeCryptoProvider();
+const enc = (s: string) => new TextEncoder().encode(s);
+
+describe("WebCryptoProvider", () => {
+  it("round-trips sign → verify with its own key", async () => {
+    const { privateKey, publicKey } = await web.generateKeyPair();
+    const msg = enc("hello kya-os");
+    const sig = await web.sign(msg, privateKey);
+    expect(await web.verify(msg, sig, publicKey)).toBe(true);
+  });
+
+  it("verify() returns false (never throws) for a tampered message", async () => {
+    const { privateKey, publicKey } = await web.generateKeyPair();
+    const sig = await web.sign(enc("original"), privateKey);
+    expect(await web.verify(enc("tampered"), sig, publicKey)).toBe(false);
+  });
+
+  it("verify() returns false for a wrong/garbage key instead of throwing", async () => {
+    const { privateKey } = await web.generateKeyPair();
+    const sig = await web.sign(enc("x"), privateKey);
+    expect(await web.verify(enc("x"), sig, "not-a-real-key")).toBe(false);
+  });
+
+  it("hash matches NodeCryptoProvider (sha256:<hex>)", async () => {
+    const data = enc("canonical payload bytes");
+    expect(await web.hash(data)).toBe(await node.hash(data));
+    expect(await web.hash(data)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("randomBytes returns the requested length and varies", async () => {
+    const a = await web.randomBytes(32);
+    const b = await web.randomBytes(32);
+    expect(a).toHaveLength(32);
+    expect(bytesToBase64(a)).not.toBe(bytesToBase64(b));
+  });
+
+  describe("cross-provider parity with NodeCryptoProvider (drop-in interchangeable)", () => {
+    it("a Node-signed proof verifies under WebCrypto (the Worker path)", async () => {
+      const { privateKey, publicKey } = await node.generateKeyPair();
+      const msg = enc("proof canonical bytes");
+      const sigNode = await node.sign(msg, privateKey);
+      expect(await web.verify(msg, sigNode, publicKey)).toBe(true);
+    });
+
+    it("a WebCrypto-signed proof verifies under Node", async () => {
+      const { privateKey, publicKey } = await web.generateKeyPair();
+      const msg = enc("proof canonical bytes");
+      const sigWeb = await web.sign(msg, privateKey);
+      expect(await node.verify(msg, sigWeb, publicKey)).toBe(true);
+    });
+
+    it("Ed25519 is deterministic → both providers produce byte-identical signatures", async () => {
+      const { privateKey } = await node.generateKeyPair();
+      const msg = enc("deterministic");
+      const sigNode = await node.sign(msg, privateKey);
+      const sigWeb = await web.sign(msg, privateKey);
+      expect(bytesToBase64(sigWeb)).toBe(bytesToBase64(sigNode));
+    });
+  });
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -15,6 +15,7 @@ export {
 } from './memory.js';
 
 export { NodeCryptoProvider } from './node-crypto.js';
+export { WebCryptoProvider } from './web-crypto.js';
 export { SystemClockProvider } from './system-clock.js';
 export { RuntimeFetchProvider } from './runtime-fetch.js';
 

--- a/src/providers/web-crypto.ts
+++ b/src/providers/web-crypto.ts
@@ -1,0 +1,104 @@
+/**
+ * WebCrypto CryptoProvider
+ *
+ * Ed25519 crypto backed by the WebCrypto API (`globalThis.crypto.subtle`).
+ * Isomorphic — runs in Cloudflare Workers, Deno, modern browsers, and Node 20+
+ * — so an edge runtime (or the isomorphic `@kya-os/verifier`) can use the
+ * shared `ProofVerifier` without pulling in `node:crypto`.
+ *
+ * Mirrors {@link NodeCryptoProvider}'s key formats EXACTLY — raw 32-byte
+ * Ed25519 keys, base64-encoded; `sha256:<hex>` digests — so the two are
+ * drop-in interchangeable: a proof signed under one verifies under the other.
+ * (Cross-provider parity is asserted in the tests.)
+ *
+ * Requires a runtime whose WebCrypto implements the Ed25519 curve (Workers,
+ * Deno, Node 20+, recent browsers). Throws a clear error if `crypto.subtle`
+ * is unavailable rather than failing obscurely deep in a verify call.
+ *
+ * @example
+ * ```typescript
+ * import { WebCryptoProvider } from '@kya-os/mcp/providers';
+ * const verifier = new ProofVerifier({ cryptoProvider: new WebCryptoProvider(), ... });
+ * ```
+ */
+
+import { CryptoProvider } from "./base.js";
+import { base64ToBytes, bytesToBase64 } from "../utils/base64.js";
+
+const ALG = "Ed25519" as const;
+
+/** PKCS8 DER header for Ed25519 private keys (16 bytes) — matches NodeCryptoProvider. */
+const ED25519_PKCS8_PREFIX = Uint8Array.from([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+function getCrypto(): typeof crypto {
+  // `crypto` is the WebCrypto global (Node 20+, Cloudflare Workers, Deno,
+  // browsers). Typed via the runtime's lib/@types — referenced bare (like
+  // authz/oidc/pkce.ts) so this file needs no DOM lib in tsconfig.
+  if (typeof crypto === "undefined" || !crypto.subtle) {
+    throw new Error(
+      "WebCryptoProvider: WebCrypto (crypto.subtle) is unavailable in this runtime",
+    );
+  }
+  return crypto;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+export class WebCryptoProvider extends CryptoProvider {
+  async sign(data: Uint8Array, privateKeyBase64: string): Promise<Uint8Array> {
+    const raw = base64ToBytes(privateKeyBase64);
+    // Accept both raw 32-byte and full 64-byte Ed25519 keys (use the seed).
+    const seed = raw.length === 64 ? raw.subarray(0, 32) : raw;
+    const pkcs8 = new Uint8Array(ED25519_PKCS8_PREFIX.length + seed.length);
+    pkcs8.set(ED25519_PKCS8_PREFIX, 0);
+    pkcs8.set(seed, ED25519_PKCS8_PREFIX.length);
+    const key = await getCrypto().subtle.importKey("pkcs8", pkcs8, { name: ALG }, false, ["sign"]);
+    const sig = await getCrypto().subtle.sign({ name: ALG }, key, data);
+    return new Uint8Array(sig);
+  }
+
+  async verify(
+    data: Uint8Array,
+    signature: Uint8Array,
+    publicKeyBase64: string,
+  ): Promise<boolean> {
+    try {
+      const raw = base64ToBytes(publicKeyBase64);
+      const key = await getCrypto().subtle.importKey("raw", raw, { name: ALG }, false, ["verify"]);
+      return await getCrypto().subtle.verify({ name: ALG }, key, signature, data);
+    } catch {
+      // Never throw on a bad key/signature — verification simply fails.
+      return false;
+    }
+  }
+
+  async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> {
+    const kp = await getCrypto().subtle.generateKey({ name: ALG }, true, ["sign", "verify"]);
+    // generateKey returns CryptoKey | CryptoKeyPair; narrow to the pair without
+    // naming the DOM type (this file compiles without a DOM lib — see getCrypto).
+    if (!("publicKey" in kp)) {
+      throw new Error("WebCryptoProvider: expected an Ed25519 key pair from generateKey");
+    }
+    const rawPub = new Uint8Array(await getCrypto().subtle.exportKey("raw", kp.publicKey));
+    const pkcs8 = new Uint8Array(await getCrypto().subtle.exportKey("pkcs8", kp.privateKey));
+    // Strip the 16-byte PKCS8 prefix to recover the raw 32-byte seed (mirrors
+    // NodeCryptoProvider, which slices [16,48) of the DER).
+    const seed = pkcs8.subarray(ED25519_PKCS8_PREFIX.length, ED25519_PKCS8_PREFIX.length + 32);
+    return { privateKey: bytesToBase64(seed), publicKey: bytesToBase64(rawPub) };
+  }
+
+  async hash(data: Uint8Array): Promise<string> {
+    const digest = new Uint8Array(await getCrypto().subtle.digest("SHA-256", data));
+    return `sha256:${toHex(digest)}`;
+  }
+
+  async randomBytes(length: number): Promise<Uint8Array> {
+    return getCrypto().getRandomValues(new Uint8Array(length));
+  }
+}


### PR DESCRIPTION
## What

Adds `WebCryptoProvider` a `CryptoProvider` implementation backed by the WebCrypto API (`globalThis.crypto.subtle`, Ed25519). Isomorphic: runs in Cloudflare Workers, Deno, modern browsers, and Node 20+, so an edge runtime can drive the canonical `ProofVerifier` **without pulling in `node:crypto`**.

Exported from `@kya-os/mcp/providers` next to `NodeCryptoProvider`.

## Why

`@kya-os/mcp` currently ships only `NodeCryptoProvider` (node:crypto), which won't load in a Worker. The isomorphic `@kya-os/verifier` (its `./worker` build runs in Cloudflare Workers) cannot wrap the shared `ProofVerifier` until an isomorphic provider exists here. This PR is the **non-breaking prerequisite for E3.2** (verifier consolidation, checkpoint #2889): inject `WebCryptoProvider` on the Worker path, `NodeCryptoProvider` on Node.

## Drop-in parity

Mirrors `NodeCryptoProvider`'s key formats **exactly** raw 32-byte Ed25519 keys, base64-encoded; `sha256:<hex>` digests so the two are interchangeable. The tests assert it:

- a **Node-signed** proof verifies under WebCrypto (the Worker path), and a WebCrypto-signed proof verifies under Node;
- Ed25519 is deterministic, so both providers produce **byte-identical signatures**;
- `hash()` output matches `NodeCryptoProvider` byte-for-byte;
- `verify()` returns `false` (never throws) on a tampered message or garbage key.

## Notes

- Additive and non-breaking a new optional provider; no change to existing behaviour. No version bump (releases are cut as separate `chore(release)` commits; this lands in the next minor).
- `getCrypto()` throws a clear error if `crypto.subtle` is unavailable, rather than failing obscurely deep in a verify call. Requires a runtime whose WebCrypto implements the Ed25519 curve (Workers, Deno, Node 20+, recent browsers).
- No DOM `lib` added to tsconfig: the global `crypto` is referenced bare (as in `authz/oidc/pkce.ts`) and typed via the runtime's lib/@types.

## Verification

- `npm run typecheck` clean
- `npx eslint src/providers/web-crypto.ts src/providers/index.ts` clean
- `npx vitest run src/providers/__tests__/web-crypto.test.ts` **8/8 pass** (incl. cross-provider parity)