### PR TITLE
chore(release): v1.6.1 — ship schema host → schema.kya-os.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-10
+
+Releases the schema-host migration already merged on `main` (it was unshipped:
+`1.6.0` still carried the prior host). Schema-only; no code or API changes.
+
+### Changed
+
+- **Schema `$id` and JSON-LD `@context` hosts migrated** to the DIF-registered
+  `schema.kya-os.org` — now live. All five shipped JSON Schemas
+  (`schemas/*.json`), the spec's context references, and the
+  `DELEGATION_CREDENTIAL_CONTEXT` constant resolve under `schema.kya-os.org`.
+  The prior `schema.kya-os.ai` host served the same documents during the
+  migration window; no `$id` is 301-redirected. Consumers that pinned a
+  `schema.kya-os.ai` `$id` should update to `schema.kya-os.org`.
+
 ## [1.6.0] - 2026-06-03
 
 Advances the E3 verifier-consolidation groundwork and hardens the delegation
@@ -311,12 +326,6 @@ shipped runtime providers. Additive over 1.3.x except where noted under
 
 ### Changed
 
-- **Schema `$id` and JSON-LD `@context` hosts migrated** to the DIF-registered
-  `schema.kya-os.org`. All five shipped JSON Schemas (`schemas/*.json`), the
-  spec's context references, and the `DELEGATION_CREDENTIAL_CONTEXT` constant
-  now resolve under `schema.kya-os.org`; the prior `schema.kya-os.ai` host
-  continues to serve the same documents during the migration window (no `$id`
-  is 301-redirected).
 - **Schema `$id` and JSON-LD `@context` hosts migrated** off the
   `modelcontextprotocol-identity.io` trademark domain to the foundation-owned
   `schema.kya-os.ai`. All five shipped JSON Schemas (`schemas/*.json`), the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What

Releases the **schema-host migration to `schema.kya-os.org`** that merged on `main` via #90 but was **never shipped** — published `1.6.0` still carries the prior `schema.kya-os.ai` host. `schema.kya-os.org` is now **live and serving**, so the `$id`s should point there.

**Schema-only — no code or API changes.** The `v1.6.0…main` diff is exclusively the host string (`.ai → .org`) in the shipped schemas, the delegation `@context`, the `DELEGATION_CREDENTIAL_CONTEXT` constant, and docs.

## Why this is needed

`@kya-os/mcp` is the reference source of truth for the published schemas in `kya-os/schema` (a drift gate enforces byte-identity). That repo can't flip its published `$id`s to `.org` until it can install an `@kya-os/mcp` release that ships `.org`, which no published version does yet. This release unblocks that.

## Changes
- `package.json` `1.6.0 → 1.6.1`
- `CHANGELOG.md` — proper `[1.6.1]` entry; also moved the migration note out of a misplaced older-version section (#90 had appended it under an old heading).

## After merge
1. Tag `v1.6.1` + `npm publish`.
2. Then `kya-os/schema` bumps its `@kya-os/mcp` devDep to `^1.6.1`, re-syncs the schemas to `.org`, updates test host strings → drift passes → auto-deploys.