### PR TITLE
fix(spec): align Appendix A error codes with updated schema / hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed
+
+- **Appendix A error codes corrected** to match `src/errors.ts`, the single
+  source of truth. The table listed prefixed codes (`KYA_OS_EHANDSHAKE`,
+  `KYA_OS_EPROOF`, ...) that no part of the codebase emits; the runtime,
+  middleware, and session manager all return bare snake_case codes
+  (`handshake_failed`, `invalid_proof`, ...). Documentation only — no behaviour
+  change.
+
 ## [1.6.1] - 2026-06-10
 
 Releases the schema-host migration already merged on `main` (it was unshipped:

--- a/SPEC.md
+++ b/SPEC.md
@@ -1264,13 +1264,13 @@ and a trust signal (§11.0), never a substitute for chain verification.
 
 | Code | Description |
 |------|-------------|
-| `KYA_OS_EHANDSHAKE` | Handshake validation failed (timestamp, nonce, or audience) |
-| `KYA_OS_ESESSION` | Session not found or expired |
-| `KYA_OS_EDELEGATION` | Delegation verification failed |
-| `KYA_OS_ESCOPE` | Requested operation outside delegated scope |
-| `KYA_OS_EREVOKED` | Delegation has been revoked |
-| `KYA_OS_EPROOF` | Proof verification failed |
-| `KYA_OS_EDID` | DID resolution failed |
+| `handshake_failed` | Handshake validation failed (timestamp, nonce, or audience) |
+| `session_expired` | Session not found or expired |
+| `delegation_invalid` | Delegation verification failed |
+| `insufficient_scope` | Requested operation outside delegated scope |
+| `delegation_revoked` | Delegation has been revoked |
+| `invalid_proof` | Proof verification failed |
+| `did_not_found` | DID resolution failed |
 
 ---
 


### PR DESCRIPTION
## Description

Appendix A documented a set of prefixed error codes — `KYA_OS_EHANDSHAKE`, `KYA_OS_EPROOF`, and so on — that nothing in the codebase emits. `src/errors.ts` is the declared single source of truth and uses bare snake_case codes (OAuth 2.0 / Stripe style); `with-kya-os.ts`, the session manager, and the runtime all return those on the wire.

This renames the seven appendix rows to their snake_case equivalents so the spec matches what implementations actually emit:

| Was | Now |
|-----|-----|
| `KYA_OS_EHANDSHAKE` | `handshake_failed` |
| `KYA_OS_ESESSION` | `session_expired` |
| `KYA_OS_EDELEGATION` | `delegation_invalid` |
| `KYA_OS_ESCOPE` | `insufficient_scope` |
| `KYA_OS_EREVOKED` | `delegation_revoked` |
| `KYA_OS_EPROOF` | `invalid_proof` |
| `KYA_OS_EDID` | `did_not_found` |

Descriptions are unchanged. The appendix is still a non-exhaustive subset — the full set (26 codes) lives in `src/errors.ts`.

## Spec Impact

Appendix A (Error Codes) only. No normative behaviour change; this corrects documentation to match shipped behaviour.

## Checklist

- [x] Tests pass (`npm test`)
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable