### PR TITLE
feat(middleware): durable consent persistence + _meta namespacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- **Durable consent persistence (optional, in-memory defaults — no breaking
+  change).** New pluggable seams so consent / grant / PKCE state survives
+  restarts and resolves across load-balanced instances: `grantStore` (the
+  no-paste retry — holder-of-key `getByAgent` first, then session-bearer
+  `getBySession`), `PendingFlowStore` (durable OAuth/OIDC PKCE state with an
+  atomic `consume()`), and an optional `SessionStore`. The detached proof is now
+  namespaced under `_meta["org.kya-os/proof"]`; the legacy bare `proof` key is
+  still accepted on verify and (by default) still emitted — toggle with
+  `emitLegacyProofKey`. The legacy mirror stays **ON by default for the entire
+  1.x line** (a pre-1.1 reader of bare `_meta.proof` would otherwise silently get
+  no proof; the cost is ~1.5 KB of `_meta`, which is outside the response hash)
+  and will be **dropped at 2.0**.
+
+### Changed
+
+- **BEHAVIORAL — `strict` `metaPolicy` now IGNORES foreign `_meta` keys instead
+  of rejecting them.** Previously a `strict` verifier rejected any `_meta` key
+  other than the proof. Under MCP 2026-07-28 (SEP-414) `_meta` legitimately
+  carries reserved `io.modelcontextprotocol/*` and W3C trace-context keys
+  (`traceparent`/`tracestate`/`baggage`), so `strict` now ignores every
+  non-KYA-OS key (never hashed, trusted, or rejected) and `allow-extensions`
+  additionally surfaces them. The zero-trust boundary is unchanged — only the
+  KYA-OS proof key is ever hashed or trusted. **Migration:** anyone relying on
+  `strict` to REJECT foreign `_meta` keys must now enforce that themselves; the
+  verifier no longer fails on them.
+
 ### Fixed
 
 - **Appendix A error codes corrected** to match `src/errors.ts`, the single

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Also available: [outbound-delegation](./examples/outbound-delegation/) (gateway 
 | **Replay prevention** | Nonce-based handshake with timestamp skew validation |
 | **Extensible** | Bring your own KMS, HSM, nonce cache (Redis, DynamoDB, KV), or DID method |
 
+### Multi-instance deployments
+
+The in-memory defaults are **single-process only**. For a load-balanced /
+multi-instance deployment, inject a durable Redis / Durable Object / DB-backed
+implementation for **every** runtime-state seam — the nonce cache
+(`NonceCacheProvider`) together with the consent stores (`GrantStore`,
+`PendingFlowStore`, `SessionStore`) — so replay protection, grants, pending OAuth
+flows, and sessions are shared across instances and survive restarts.
+
 ---
 
 ## Links

--- a/examples/_shared/consent-page.ts
+++ b/examples/_shared/consent-page.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared consent page (the canonical example consent UI).
+ *
+ * Extracted from examples/consent-basic so every example's consent screen has a
+ * consistent look. It is a single self-contained styled HTML document — no
+ * external bundle, no dependencies — so it works for examples that have their own
+ * npm package (consent-basic, consent-persistence) AND for ones that run off the
+ * repo root (node-server). consent-full intentionally keeps the richer
+ * @kya-os/consent production component as its showcase.
+ *
+ * The Approve button POSTs `{ tool, scopes, agentDid, resumeToken }` to
+ * `approvePath` and adapts to whichever backend answers:
+ *   - `{ delegationToken }` → shows the credential to copy/paste (VC flow:
+ *      consent-basic, node-server).
+ *   - `{ approved: true }` / `{ success: true }` → shows a "retry, no re-paste"
+ *      message (holder-of-key flow: consent-persistence).
+ */
+
+export interface ConsentPageOptions {
+  /** Tool the agent wants to call (display only). */
+  tool: string;
+  /** Comma-separated requested scopes (display only). */
+  scopes: string;
+  /** Agent DID requesting authorization (display only). */
+  agentDid: string;
+  /** Endpoint the Approve button POSTs to. Default '/approve'. */
+  approvePath?: string;
+}
+
+/** Escape a user-controlled string for safe interpolation into HTML (text + attributes). */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Render the canonical consent page HTML. All reflected values are escaped.
+ */
+export function renderConsentPage(opts: ConsentPageOptions): string {
+  const tool = escapeHtml(opts.tool);
+  const scopes = escapeHtml(opts.scopes);
+  const agentDid = escapeHtml(opts.agentDid);
+  const approvePath = escapeHtml(opts.approvePath ?? '/approve');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KYA-OS Consent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117; color: #e1e4e8; min-height: 100vh;
+      display: flex; align-items: center; justify-content: center; padding: 1rem;
+    }
+    .card {
+      background: #1c1f26; border: 1px solid #30363d; border-radius: 12px;
+      padding: 2rem; max-width: 480px; width: 100%;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 1.5rem; color: #f0f6fc; }
+    .field { margin-bottom: 1rem; }
+    .field .label {
+      display: block; font-size: 0.75rem; font-weight: 500; text-transform: uppercase;
+      letter-spacing: 0.05em; color: #8b949e; margin-bottom: 0.25rem;
+    }
+    .field .value {
+      font-size: 0.95rem; color: #c9d1d9; word-break: break-all;
+      padding: 0.5rem 0.75rem; background: #161b22; border: 1px solid #21262d; border-radius: 6px;
+    }
+    .actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+    button {
+      flex: 1; padding: 0.625rem 1rem; border: none; border-radius: 6px;
+      font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: opacity 0.15s;
+    }
+    button:hover { opacity: 0.9; }
+    button:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-approve { background: #238636; color: #fff; }
+    .btn-deny { background: #da3633; color: #fff; }
+    #status { margin-top: 1rem; padding: 0.75rem; border-radius: 6px; font-size: 0.85rem; display: none; }
+    #status.success { display: block; background: #0d1117; border: 1px solid #238636; color: #3fb950; }
+    #status.error { display: block; background: #0d1117; border: 1px solid #da3633; color: #f85149; }
+    #status.denied { display: block; background: #0d1117; border: 1px solid #d29922; color: #e3b341; }
+    #delegation-output { display: none; margin-top: 1rem; }
+    #delegation-output textarea {
+      width: 100%; min-height: 120px; background: #161b22; color: #c9d1d9;
+      border: 1px solid #21262d; border-radius: 6px; padding: 0.5rem;
+      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem; resize: vertical;
+    }
+    .btn-copy { background: #388bfd; color: #fff; margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+  <main class="card" role="dialog" aria-labelledby="consent-title">
+    <h1 id="consent-title">Agent Consent Request</h1>
+
+    <div class="field">
+      <span class="label" id="label-tool">Tool</span>
+      <div class="value" id="field-tool" aria-labelledby="label-tool">${tool}</div>
+    </div>
+
+    <div class="field">
+      <span class="label" id="label-scopes">Requested Scopes</span>
+      <div class="value" id="field-scopes" aria-labelledby="label-scopes">${scopes}</div>
+    </div>
+
+    <div class="field">
+      <span class="label" id="label-agent">Agent DID</span>
+      <div class="value" id="field-agent" aria-labelledby="label-agent">${agentDid}</div>
+    </div>
+
+    <div class="actions">
+      <button class="btn-approve" id="btn-approve" type="button" aria-label="Approve delegation for this tool">Approve</button>
+      <button class="btn-deny" id="btn-deny" type="button" aria-label="Deny delegation request">Deny</button>
+    </div>
+
+    <div id="status" role="alert" aria-live="polite"></div>
+
+    <div id="delegation-output">
+      <span class="label">Delegation Token</span>
+      <textarea id="delegation-json" readonly aria-label="Delegation token JSON"></textarea>
+      <button class="btn-copy" id="btn-copy" type="button">Copy to Clipboard</button>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      var APPROVE_PATH = ${JSON.stringify(approvePath)};
+      var tool = document.getElementById('field-tool').textContent;
+      var scopes = document.getElementById('field-scopes').textContent;
+      var agentDid = document.getElementById('field-agent').textContent;
+      var resumeToken = new URLSearchParams(window.location.search).get('resume_token') || '';
+      var statusEl = document.getElementById('status');
+      var approveBtn = document.getElementById('btn-approve');
+      var denyBtn = document.getElementById('btn-deny');
+
+      function setStatus(msg, cls) { statusEl.textContent = msg; statusEl.className = cls; }
+
+      approveBtn.addEventListener('click', function () {
+        approveBtn.disabled = true; denyBtn.disabled = true;
+        setStatus('Authorizing...', '');
+
+        fetch(APPROVE_PATH, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tool: tool, scopes: scopes, agentDid: agentDid, resumeToken: resumeToken }),
+        })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            if (data.delegationToken) {
+              // VC flow: show the credential to copy and re-paste into the tool call.
+              setStatus('Delegation approved. Copy the credential below and retry the tool with "_kyaos_delegation".', 'success');
+              var outputEl = document.getElementById('delegation-output');
+              var jsonEl = document.getElementById('delegation-json');
+              jsonEl.value = typeof data.delegationToken === 'string'
+                ? data.delegationToken
+                : JSON.stringify(data.delegationToken, null, 2);
+              outputEl.style.display = 'block';
+              document.getElementById('btn-copy').addEventListener('click', function () {
+                jsonEl.select();
+                navigator.clipboard.writeText(jsonEl.value).then(function () {
+                  setStatus('Copied to clipboard!', 'success');
+                });
+              });
+            } else if (data.approved || data.success) {
+              // Holder-of-key flow: nothing to paste — the agent re-proves possession.
+              setStatus('Approved. Retry the tool — no re-paste needed; your holder-of-key proof resolves the grant.', 'success');
+            } else {
+              setStatus('Error: ' + (data.message || data.error || 'Unknown error'), 'error');
+              approveBtn.disabled = false; denyBtn.disabled = false;
+            }
+          })
+          .catch(function (err) {
+            setStatus('Network error: ' + err.message, 'error');
+            approveBtn.disabled = false; denyBtn.disabled = false;
+          });
+      });
+
+      denyBtn.addEventListener('click', function () {
+        approveBtn.disabled = true; denyBtn.disabled = true;
+        setStatus('Request denied. No authorization was issued.', 'denied');
+      });
+
+      approveBtn.focus();
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/examples/brave-search-mcp-server/src/server.ts
+++ b/examples/brave-search-mcp-server/src/server.ts
@@ -42,7 +42,9 @@ export default async function createMcpServer(
   );
 
   // KYA-OS: auto-register handshake + auto-proof all tools (reuses shared identity)
-  await withKyaOs(mcpServer, { crypto, identity: sharedIdentity });
+  // emitLegacyProofKey: false → single-key Inspector view (library default mirrors
+  // the proof under legacy bare `proof` for pre-1.1 back-compat).
+  await withKyaOs(mcpServer, { crypto, identity: sharedIdentity, emitLegacyProofKey: false });
 
   for (const tool of Object.values(tools)) {
     // The user may have enabled/disabled this tool at runtime

--- a/examples/consent-basic/__tests__/e2e.test.ts
+++ b/examples/consent-basic/__tests__/e2e.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, KYA_OS_PROOF_META_KEY, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 
@@ -18,7 +18,7 @@ const crypto = new NodeCryptoProvider();
 interface ToolResult {
   content: Array<{ type: string; text: string; [key: string]: unknown }>;
   isError?: boolean;
-  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  _meta?: Record<string, { jws: string; meta: Record<string, unknown> } | undefined>;
   [key: string]: unknown;
 }
 
@@ -111,8 +111,8 @@ describe('E2E: consent -> delegation -> execution', () => {
 
     // 9. Response includes proof
     expect(retryResult._meta).toBeDefined();
-    expect(retryResult._meta!.proof).toBeDefined();
-    expect(retryResult._meta!.proof!.jws).toBeDefined();
+    expect(retryResult._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
+    expect(retryResult._meta![KYA_OS_PROOF_META_KEY]!.jws).toBeDefined();
   });
 
   // Full cycle with VC-JWT format: §6.1 → §4.1 → §6.2 → §5.1
@@ -153,7 +153,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     expect(retryResult.content[0]!.text).toContain('headphones');
 
     // 9. Response includes proof
-    expect(retryResult._meta?.proof).toBeDefined();
+    expect(retryResult._meta?.[KYA_OS_PROOF_META_KEY]).toBeDefined();
   });
 
   // §4.3 — scope mismatch across tools
@@ -195,6 +195,6 @@ describe('E2E: consent -> delegation -> execution', () => {
     const result = await browseHandler({ category: 'electronics' });
     expect(result.isError).toBeUndefined();
     expect(result.content[0]!.text).toContain('electronics');
-    expect(result._meta?.proof).toBeDefined();
+    expect(result._meta?.[KYA_OS_PROOF_META_KEY]).toBeDefined();
   });
 });

--- a/examples/consent-basic/__tests__/server.test.ts
+++ b/examples/consent-basic/__tests__/server.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, KYA_OS_PROOF_META_KEY, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 
 const crypto = new NodeCryptoProvider();
@@ -19,7 +19,7 @@ const CONSENT_URL = 'http://localhost:9999/consent';
 interface ToolResult {
   content: Array<{ type: string; text: string; [key: string]: unknown }>;
   isError?: boolean;
-  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  _meta?: Record<string, { jws: string; meta: Record<string, unknown> } | undefined>;
   [key: string]: unknown;
 }
 
@@ -171,9 +171,9 @@ describe('MCP Server with consent-basic', () => {
     const result = await browseHandler({ category: 'books' });
 
     expect(result._meta).toBeDefined();
-    expect(result._meta!.proof).toBeDefined();
+    expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
 
-    const proof = result._meta!.proof!;
+    const proof = result._meta![KYA_OS_PROOF_META_KEY]!;
     // JWS: 3 dot-separated base64url parts
     expect(proof.jws).toBeDefined();
     expect(proof.jws.split('.').length).toBe(3);
@@ -189,8 +189,8 @@ describe('MCP Server with consent-basic', () => {
     const result1 = await browseHandler({ category: 'books' });
     const result2 = await browseHandler({ category: 'books' });
 
-    expect(result1._meta!.proof!.meta.requestHash).toBe(
-      result2._meta!.proof!.meta.requestHash,
+    expect(result1._meta![KYA_OS_PROOF_META_KEY]!.meta.requestHash).toBe(
+      result2._meta![KYA_OS_PROOF_META_KEY]!.meta.requestHash,
     );
   });
 

--- a/examples/consent-basic/src/server.ts
+++ b/examples/consent-basic/src/server.ts
@@ -54,7 +54,7 @@ export interface ServerConfig {
 export class DelegationStore {
   private store = new Map<string, { vc: unknown; expiresAt: number }>();
 
-  set(resumeToken: string, vc: unknown, ttlSeconds = 300): void {
+  set(resumeToken: string, vc: unknown, ttlSeconds = 3600): void {
     this.store.set(resumeToken, { vc, expiresAt: Date.now() + ttlSeconds * 1000 });
   }
 
@@ -79,7 +79,9 @@ export class DelegationStore {
       const metadata = (vc?.credentialSubject as Record<string, unknown>)
         ?.delegation as Record<string, unknown> | undefined;
       if (metadata?.metadata && (metadata.metadata as Record<string, unknown>).tool === toolName) {
-        this.store.delete(token); // consume it
+        // PEEK — do NOT consume. Re-present the approved delegation on EVERY
+        // retry so a generic client (e.g. mcp-inspector) keeps succeeding after a
+        // single approval, until the entry's TTL lapses.
         return { resumeToken: token, vc: entry.vc };
       }
     }
@@ -201,19 +203,21 @@ export function createConsentMcpServer(
     ],
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args = {} } = request.params;
+    // Thread the transport's sessionId (when present) instead of dropping it.
+    const sessionId = extra?.sessionId;
 
     if (name === '_kyaos') {
       return kyaos.handleKyaOs(args as Record<string, unknown>);
     }
 
     if (name === 'browse') {
-      return browseHandler(args as Record<string, unknown>);
+      return browseHandler(args as Record<string, unknown>, sessionId);
     }
 
     if (name === 'checkout') {
-      return checkoutHandler(args as Record<string, unknown>);
+      return checkoutHandler(args as Record<string, unknown>, sessionId);
     }
 
     return {
@@ -259,6 +263,9 @@ export async function loadKyaOsMiddleware() {
       identity: { did, kid, privateKey, publicKey },
       session: { sessionTtlMinutes: 60 },
       autoSession: true,
+      // Single-key Inspector view for the demo; the library default also mirrors
+      // the proof under legacy bare `proof` for pre-1.1 back-compat.
+      emitLegacyProofKey: false,
     },
     crypto,
   );

--- a/examples/consent-full/__tests__/e2e.test.ts
+++ b/examples/consent-full/__tests__/e2e.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, KYA_OS_PROOF_META_KEY, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 import type { ToolResult } from '../src/server.js';
@@ -112,8 +112,8 @@ describe('E2E: consent -> delegation -> execution', () => {
 
     // 9. Response includes proof
     expect(retryResult._meta).toBeDefined();
-    expect(retryResult._meta!.proof).toBeDefined();
-    expect(retryResult._meta!.proof!.jws).toBeDefined();
+    expect(retryResult._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
+    expect(retryResult._meta![KYA_OS_PROOF_META_KEY]!.jws).toBeDefined();
   });
 
   // §4.3 — scope mismatch across tools
@@ -153,7 +153,7 @@ describe('E2E: consent -> delegation -> execution', () => {
     const result = await browseHandler({ category: 'electronics' });
     expect(result.isError).toBeUndefined();
     expect(result.content[0]!.text).toContain('electronics');
-    expect(result._meta?.proof).toBeDefined();
+    expect(result._meta?.[KYA_OS_PROOF_META_KEY]).toBeDefined();
   });
 
   // Consent page rendered by @kya-os/consent

--- a/examples/consent-full/__tests__/inspector-retry.test.ts
+++ b/examples/consent-full/__tests__/inspector-retry.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Interactive retry regression test (mcp-inspector style).
+ *
+ * Unlike e2e.test.ts (which wires checkoutHandler directly and re-passes the VC
+ * on retry), this drives the REAL server handler chain —
+ * createConsentFullMcpServer → formatAsConsentLink → DelegationStore — over a
+ * live MCP client + a real consent server, exactly as a generic client
+ * (mcp-inspector) would: it NEVER re-passes the delegation on retry.
+ *
+ * Guards the bug the user hit: a peek→consume regression (or dropping the
+ * auto-apply) would make the 3rd call fail, so the suite would catch it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  createKyaOsMiddleware,
+  NodeCryptoProvider,
+  generateDidKeyFromBase64,
+  type KyaOsMiddleware,
+} from '@kya-os/mcp';
+import { createConsentFullMcpServer, DelegationStore } from '../src/server.js';
+import { startConsentServer, type ConsentServer } from '../src/consent-server.js';
+import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
+
+const crypto = new NodeCryptoProvider();
+
+interface ToolCallResult {
+  content?: Array<{ text?: string }>;
+  isError?: boolean;
+}
+const textOf = (r: ToolCallResult): string => r.content?.[0]?.text ?? '';
+
+describe('consent-full interactive retry (mcp-inspector style, no re-paste)', () => {
+  let consentServer: ConsentServer;
+  let client: Client;
+  let store: DelegationStore;
+  let kyaos: KyaOsMiddleware;
+
+  beforeAll(async () => {
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const kid = `${did}#${did.replace('did:key:', '')}`;
+    const identity = { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey };
+
+    kyaos = createKyaOsMiddleware(
+      { identity, session: { sessionTtlMinutes: 60 }, autoSession: true, emitLegacyProofKey: false },
+      crypto,
+    );
+
+    const factory = createDelegationIssuerFromIdentity(crypto, identity);
+    store = new DelegationStore();
+    // Shared store: the consent server writes the approved VC, the MCP server reads it.
+    consentServer = await startConsentServer({ port: 0, factory, delegationStore: store });
+
+    // The ACTUAL server handler chain (wraps checkout with formatAsConsentLink).
+    const server = createConsentFullMcpServer(kyaos, {
+      consentUrl: `${consentServer.url}/consent`,
+      delegationStore: store,
+    });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverT);
+    client = new Client({ name: 'inspector-mimic', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(clientT);
+  });
+
+  afterAll(async () => {
+    await consentServer.close();
+  });
+
+  it('approve once, then retry twice with NO re-paste — both succeed (peek, not consume)', async () => {
+    // 1. checkout WITHOUT a delegation → needs_authorization (consent link).
+    const r1 = (await client.callTool({ name: 'checkout', arguments: { item: 'laptop' } })) as ToolCallResult;
+    const t1 = textOf(r1);
+    expect(t1).toMatch(/Authorization required|needs_authorization/);
+    const resumeToken = (t1.match(/resume_token=([^)\s&]+)/) ?? [])[1] ?? '';
+    expect(resumeToken).toBeTruthy();
+
+    // 2. Approve via the consent server (stores the delegation, keyed by resume token).
+    const approveRes = await fetch(`${consentServer.url}/consent/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'checkout',
+        scopes: JSON.stringify(['cart:write']),
+        agent_did: kyaos.identity.did,
+        session_id: resumeToken,
+        auth_mode: 'consent-only',
+        termsAccepted: true,
+      }),
+    });
+    expect(((await approveRes.json()) as { success?: boolean }).success).toBe(true);
+
+    // 3. Retry WITHOUT re-passing the VC → SUCCESS (re-presented from the store).
+    const r2 = (await client.callTool({ name: 'checkout', arguments: { item: 'laptop' } })) as ToolCallResult;
+    expect(r2.isError ?? false).toBe(false);
+    expect(textOf(r2)).toContain('Order confirmed');
+
+    // 4. Retry AGAIN WITHOUT the VC → still SUCCESS (proves PEEK, not consume).
+    const r3 = (await client.callTool({ name: 'checkout', arguments: { item: 'laptop' } })) as ToolCallResult;
+    expect(r3.isError ?? false).toBe(false);
+    expect(textOf(r3)).toContain('Order confirmed');
+  });
+});

--- a/examples/consent-full/__tests__/server.test.ts
+++ b/examples/consent-full/__tests__/server.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
+import { createKyaOsMiddleware, NodeCryptoProvider, generateDidKeyFromBase64, KYA_OS_PROOF_META_KEY, type KyaOsMiddleware, type DelegationCredential, type NeedsAuthorizationError } from '@kya-os/mcp';
 import { createDelegationIssuerFromIdentity } from '../src/delegation-issuer.js';
 import { createConsentFullMcpServer, type ToolResult } from '../src/server.js';
 
@@ -194,12 +194,21 @@ describe('MCP Server with consent-full', () => {
 
   // §5.1 — Detached proof on browse
   it('should attach a detached proof to browse tool response', async () => {
-    const result = await browseHandler({ category: 'books' });
+    // Thread the session explicitly: the shared middleware has multiple sessions
+    // by now, so the auto-proof path won't borrow activeSessionId (proof
+    // mis-attribution guard). A KYA-OS-aware caller threads its sessionId.
+    const hs = await kyaos.handleHandshake({
+      nonce: `bp-${Math.random().toString(16).slice(2)}`,
+      audience: serverDid,
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    const sessionId = JSON.parse(hs.content[0]!.text).sessionId as string;
+    const result = await browseHandler({ category: 'books' }, sessionId);
 
     expect(result._meta).toBeDefined();
-    expect(result._meta!.proof).toBeDefined();
+    expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
 
-    const proof = result._meta!.proof!;
+    const proof = result._meta![KYA_OS_PROOF_META_KEY]!;
     // JWS: 3 dot-separated base64url parts
     expect(proof.jws).toBeDefined();
     expect(proof.jws.split('.').length).toBe(3);
@@ -212,11 +221,17 @@ describe('MCP Server with consent-full', () => {
 
   // §5.2 — Deterministic hashing
   it('should produce deterministic hashes for identical requests', async () => {
-    const result1 = await browseHandler({ category: 'books' });
-    const result2 = await browseHandler({ category: 'books' });
+    const hs = await kyaos.handleHandshake({
+      nonce: `dh-${Math.random().toString(16).slice(2)}`,
+      audience: serverDid,
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    const sessionId = JSON.parse(hs.content[0]!.text).sessionId as string;
+    const result1 = await browseHandler({ category: 'books' }, sessionId);
+    const result2 = await browseHandler({ category: 'books' }, sessionId);
 
-    expect(result1._meta!.proof!.meta.requestHash).toBe(
-      result2._meta!.proof!.meta.requestHash,
+    expect(result1._meta![KYA_OS_PROOF_META_KEY]!.meta.requestHash).toBe(
+      result2._meta![KYA_OS_PROOF_META_KEY]!.meta.requestHash,
     );
   });
 

--- a/examples/consent-full/src/server.ts
+++ b/examples/consent-full/src/server.ts
@@ -67,7 +67,7 @@ export interface ServerConfig {
 export class DelegationStore {
   private store = new Map<string, { vc: unknown; expiresAt: number }>();
 
-  set(resumeToken: string, vc: unknown, ttlSeconds = 300): void {
+  set(resumeToken: string, vc: unknown, ttlSeconds = 3600): void {
     this.store.set(resumeToken, { vc, expiresAt: Date.now() + ttlSeconds * 1000 });
   }
 
@@ -92,7 +92,10 @@ export class DelegationStore {
       const metadata = (vc?.credentialSubject as Record<string, unknown>)
         ?.delegation as Record<string, unknown> | undefined;
       if (metadata?.metadata && (metadata.metadata as Record<string, unknown>).tool === toolName) {
-        this.store.delete(token); // consume it
+        // PEEK — do NOT consume. Re-present the approved delegation on EVERY
+        // retry so a generic client (e.g. mcp-inspector) that can't thread a
+        // session or mint a holder-of-key proof keeps succeeding after a single
+        // approval, until the entry's TTL lapses.
         return { resumeToken: token, vc: entry.vc };
       }
     }
@@ -132,7 +135,7 @@ function formatAsConsentLink(
 export interface ToolResult {
   content: Array<{ type: string; text: string; [key: string]: unknown }>;
   isError?: boolean;
-  _meta?: { proof?: { jws: string; meta: Record<string, unknown> } };
+  _meta?: Record<string, { jws: string; meta: Record<string, unknown> } | undefined>;
   [key: string]: unknown;
 }
 
@@ -220,19 +223,23 @@ export function createConsentFullMcpServer(
     ],
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args = {} } = request.params;
+    // Thread the transport's sessionId (when it has one) into the handlers
+    // instead of dropping it — previously it was lost, so proofs/grants couldn't
+    // be attributed to the call's session.
+    const sessionId = extra?.sessionId;
 
     if (name === '_kyaos') {
       return kyaos.handleKyaOs(args as Record<string, unknown>);
     }
 
     if (name === 'browse') {
-      return browseHandler(args as Record<string, unknown>);
+      return browseHandler(args as Record<string, unknown>, sessionId);
     }
 
     if (name === 'checkout') {
-      return checkoutHandler(args as Record<string, unknown>);
+      return checkoutHandler(args as Record<string, unknown>, sessionId);
     }
 
     return {
@@ -263,7 +270,9 @@ export async function loadKyaOsMiddleware() {
   }
 
   return createKyaOsMiddleware(
-    { identity, session: { sessionTtlMinutes: 60 }, autoSession: true },
+    // emitLegacyProofKey: false → single-key Inspector view for the demo (the
+    // library default mirrors the proof under legacy bare `proof` for back-compat).
+    { identity, session: { sessionTtlMinutes: 60 }, autoSession: true, emitLegacyProofKey: false },
     crypto,
   );
 }

--- a/examples/consent-persistence/.gitignore
+++ b/examples/consent-persistence/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.kya-os/
+.data/

--- a/examples/consent-persistence/README.md
+++ b/examples/consent-persistence/README.md
@@ -1,0 +1,103 @@
+# Durable Consent Persistence
+
+Proves that KYA-OS consent **survives restarts and resolves across load-balanced
+instances** — the agent never has to re-paste its delegation after the user has
+approved once.
+
+This is the fix for the *"consent doesn't persist after the user grants the
+consent URL"* bug, demonstrated end-to-end. Unlike
+[`consent-basic`](../consent-basic), there is **no per-example `DelegationStore`
+Map** — the no-paste retry comes from the package's own grant resolution over a
+durable, process-external store.
+
+It uses **holder-of-key** (`holderBinding: 'enforce'`) as the cross-instance
+mechanism: the agent presents a per-request `_kyaos_proof` proving possession of
+its key, and the retry resolves an **agent-anchored** grant via `getByAgent` with
+**no shared server session**. That is what lets the no-paste promise hold over a
+stateless HTTP transport — a session-based approach (`getBySession`) would need
+the client to thread a sessionId, which the stateless transport does not.
+
+## What's Inside
+
+| File | Shows | How it proves the fix |
+|------|-------|-----------------------|
+| `src/file-grant-store.ts` | A `GrantStore` persisting approved grants to a JSON file. | The same process-external store both instances read. |
+| `src/file-pending-flow-store.ts` | A `PendingFlowStore` persisting OAuth/OIDC PKCE state to a JSON file. | Lets the OAuth callback complete on the *other* instance. |
+| `src/instance.ts` | The shared identity + stores, the per-instance KYA-OS middleware factory (`holderBinding: 'enforce'`, `grantStore` injected), and `mintCheckoutProof()` (the agent's per-request holder-of-key proof). | Demonstrates the package's own holder-of-key retry resolution, not an example hack. |
+| `src/approve.ts` | Issues the delegation VC and **binds an agent-anchored grant** into the shared store. | Approval is written to durable storage. |
+| `src/consent-server.ts` | Consent page → `POST /approve` calls `approve()`. | The HTTP approval write path. |
+| `src/server.ts` | Two MCP instances (ports A/B) + the consent server, sharing one identity and one file-backed `grantStore` + `pendingFlowStore`. | A running two-instance deployment. |
+| `scripts/scenario-cross-instance.ts` | Approve, retry on a separate instance with a holder-of-key proof → succeeds, no re-paste (+ a PKCE pending flow consumed cross-instance). | Direct proof of cross-instance consent persistence. |
+| `scripts/scenario-restart.ts` | Approve, then a brand-new instance with empty memory retries with a fresh proof → succeeds from the file store. | Direct proof of restart survival. |
+
+## How it works
+
+1. The agent calls the protected `checkout` tool with a per-request
+   `_kyaos_proof` but no delegation. The middleware returns `needs_authorization`
+   with a consent link.
+2. The user approves at the consent page. `approve()` mints the delegation VC and
+   **binds a durable, agent-anchored grant** (`agentDid` + scopes, no sessionId)
+   into the shared file-backed `GrantStore`.
+3. The agent retries `checkout` — **on any instance, or after a restart** — with a
+   fresh `_kyaos_proof` and no delegation. The middleware re-proves possession of
+   the agent's key (holder-of-key) and resolves the grant from the shared store
+   via `getByAgent`, then runs the tool. **No re-paste, no shared session.**
+
+A call that omits the proof cannot resolve the agent grant (confused-deputy
+guard), so it is re-challenged.
+
+Swapping the file stores for Redis / a Durable Object / Postgres behind the same
+`GrantStore` / `PendingFlowStore` interfaces makes this production-ready — the
+server code does not change. For a real multi-instance deployment, swap the
+**nonce cache** (`NonceCacheProvider`) and the `SessionStore` off their
+in-memory defaults the same way: the in-memory implementations are single-process
+only, so replay protection and sessions must also use a durable, shared backing.
+
+> This example sets `emitLegacyProofKey: false` so the Inspector shows a single
+> clean `org.kya-os/proof` key. The library default is `true` (it also mirrors
+> the proof under legacy bare `proof`) for back-compat with pre-1.1 clients.
+
+> **Consent UI:** this example uses the basic shared consent page, not the
+> `@kya-os/consent` component (which consent-full and node-server use). That
+> component's approval response must carry a delegation token, but this
+> holder-of-key flow issues none — approval binds an agent-anchored grant and
+> the agent re-proves possession per request. The basic page renders that
+> token-less `{ approved: true }` outcome cleanly; it's the honest holder-of-key
+> exception.
+
+> The grant is the durable *authority*, anchored to the agent DID and re-proven
+> per request by the holder-of-key proof. The session-bearer path (`getBySession`)
+> is the alternative when an agent has no key, but it resolves on sessionId
+> possession alone (so the sessionId is load-bearing) and needs the client to
+> thread that id — which a stateless HTTP transport does not. Holder-of-key is
+> the robust cross-instance choice and what this example uses.
+
+## Testing
+
+```bash
+# 0. (optional) persist a shared identity so the DID survives restarts
+npm run generate-identity
+
+# 1. Cross-instance: approve on A, retry on B with no re-paste
+npm run scenario:cross-instance
+
+# 2. Restart survival: approve, restart, retry from the file store
+npm run scenario:restart
+```
+
+Both scripts are headless and deterministic, printing `PASS`/`FAIL` per check and
+exiting non-zero on failure.
+
+### Interactive (two live instances)
+
+```bash
+npm start
+# → consent page + instance A (/mcp on PORT_A) + instance B (/mcp on PORT_B)
+```
+
+Drive it with the MCP Inspector (`pnpm demo` from the repo root includes this
+example): call `checkout` on instance A (with a `_kyaos_proof` in the args),
+approve at the consent page, then call `checkout` on instance B with a fresh
+`_kyaos_proof` — it succeeds without re-pasting the delegation. Minting that
+proof is what a KYA-OS-aware client does automatically; the scenario scripts
+above are the deterministic, runnable demonstration.

--- a/examples/consent-persistence/package.json
+++ b/examples/consent-persistence/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@kya-os/example-consent-persistence",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "KYA-OS durable consent example — file-backed GrantStore + PendingFlowStore proving no-paste consent reuse across instances and restarts",
+  "scripts": {
+    "start": "npx tsx src/server.ts",
+    "generate-identity": "npx tsx scripts/generate-identity.ts",
+    "scenario:cross-instance": "npx tsx scripts/scenario-cross-instance.ts",
+    "scenario:restart": "npx tsx scripts/scenario-restart.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@kya-os/mcp": "file:../..",
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/examples/consent-persistence/scripts/generate-identity.ts
+++ b/examples/consent-persistence/scripts/generate-identity.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env npx tsx
+/**
+ * Generate the shared Ed25519 identity used by BOTH server instances and read
+ * back after a restart. Saves to .kya-os/identity.json.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-identity.ts
+ *   npx tsx scripts/generate-identity.ts --force   # overwrite existing
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_DIR = path.resolve(__dirname, '..', '.kya-os');
+const IDENTITY_PATH = path.join(IDENTITY_DIR, 'identity.json');
+
+async function main() {
+  const force = process.argv.includes('--force');
+
+  if (fs.existsSync(IDENTITY_PATH) && !force) {
+    const existing = JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as { did: string };
+    process.stderr.write(`Identity already exists (use --force to regenerate)\n`);
+    process.stderr.write(`  DID: ${existing.did}\n`);
+    process.stderr.write(`  Path: ${IDENTITY_PATH}\n`);
+    return;
+  }
+
+  const crypto = new NodeCryptoProvider();
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  const kid = `${did}#${did.replace('did:key:', '')}`;
+
+  fs.mkdirSync(IDENTITY_DIR, { recursive: true });
+  fs.writeFileSync(
+    IDENTITY_PATH,
+    JSON.stringify(
+      { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey, createdAt: new Date().toISOString() },
+      null,
+      2,
+    ) + '\n',
+  );
+
+  process.stderr.write(`Identity generated\n  DID: ${did}\n  Path: ${IDENTITY_PATH}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-persistence/scripts/scenario-cross-instance.ts
+++ b/examples/consent-persistence/scripts/scenario-cross-instance.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env npx tsx
+/**
+ * Scenario: cross-instance consent persistence via holder-of-key (no re-paste,
+ * no shared session).
+ *
+ * The agent presents a per-request `_kyaos_proof` in the checkout args. Call
+ * protected `checkout` on instance A → needs_authorization. Approve (binds an
+ * agent-anchored grant to the shared, file-backed store). Retry on a SEPARATE
+ * instance B with a fresh proof → it succeeds with NO re-paste and NO shared
+ * session, because B re-proves possession of the agent's key and resolves the
+ * grant via getByAgent. Also proves the OAuth half: a PKCE pending flow
+ * initiated on A is atomically consumed on B via the shared PendingFlowStore.
+ *
+ * Headless and deterministic. Exits 0 on success, 1 on failure.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GenericOidcAdapter } from '@kya-os/mcp/authz';
+import { createInstance, loadIdentity, mintCheckoutProof, SCOPE } from '../src/instance.js';
+import { FileGrantStore } from '../src/file-grant-store.js';
+import { FilePendingFlowStore } from '../src/file-pending-flow-store.js';
+import { approve } from '../src/approve.js';
+
+type Result = { content: Array<{ text: string }>; isError?: boolean };
+const text = (r: Result): string => r.content[0]?.text ?? '';
+const isChallenge = (r: Result): boolean => text(r).includes('Authorization required');
+const isConfirmed = (r: Result): boolean => !r.isError && text(r).includes('Order confirmed');
+
+let failed = false;
+function check(label: string, ok: boolean): void {
+  process.stdout.write(`${ok ? 'PASS' : 'FAIL'}  ${label}\n`);
+  if (!ok) failed = true;
+}
+
+async function main(): Promise<void> {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kya-consent-xinst-'));
+  const identity = await loadIdentity();
+  const consentUrl = 'http://consent.local/consent';
+
+  // Two INDEPENDENT store objects over the SAME files: two instances, one durable backing.
+  const grantA = new FileGrantStore(path.join(dataDir, 'grants.json'));
+  const grantB = new FileGrantStore(path.join(dataDir, 'grants.json'));
+  const instanceA = createInstance({ label: 'A', identity, grantStore: grantA, consentUrl });
+  const instanceB = createInstance({ label: 'B', identity, grantStore: grantB, consentUrl });
+
+  // 1. Call protected checkout on A with a holder-of-key proof but NO grant → challenge.
+  const proof1 = await mintCheckoutProof(identity, { item: 'laptop' });
+  const first = await instanceA.checkout({ item: 'laptop', _kyaos_proof: proof1 });
+  check('instance A: first call (proof, no grant) returns needs_authorization', isChallenge(first));
+
+  // 2. Approve → agent-anchored grant written to the shared durable store.
+  await approve({ identity, grantStore: grantA, agentDid: identity.did, scopes: [SCOPE] });
+
+  // 3. Retry on instance B (separate memory) with a FRESH proof, no session → success.
+  const proof2 = await mintCheckoutProof(identity, { item: 'laptop' });
+  const retry = await instanceB.checkout({ item: 'laptop', _kyaos_proof: proof2 });
+  check('instance B: retry resolves the grant via holder-of-key (NO re-paste, NO session)', isConfirmed(retry));
+
+  // 4. Confused-deputy guard: a call with NO proof can't resolve the agent grant.
+  const noProof = await instanceB.checkout({ item: 'laptop' });
+  check('instance B: a call without a holder-of-key proof is NOT auto-authorized', isChallenge(noProof));
+
+  // 5. OAuth half: a PKCE pending flow initiated on A is consumed on B via the shared store.
+  const oidcConfig = {
+    type: 'oauth' as const,
+    issuer: 'https://idp.local',
+    authorizationEndpoint: 'https://idp.local/authorize',
+    tokenEndpoint: 'https://idp.local/token',
+    clientId: 'agent-client',
+    scopes: ['openid', 'vault:read'],
+  };
+  const protection = {
+    toolName: 'vault.read',
+    requirement: { type: 'oauth' as const, provider: 'generic-oidc', requiredScopes: ['vault:read'] },
+  };
+  const oidcA = new GenericOidcAdapter({
+    ...oidcConfig,
+    pendingFlowStore: new FilePendingFlowStore(path.join(dataDir, 'pending-flows.json')),
+  });
+  const challenge = await oidcA.initiateFlow({
+    protection,
+    agentDid: identity.did,
+    redirectUri: 'https://app.local/cb',
+    state: 'state-xyz',
+  });
+  const fakeToken = async (): Promise<Response> =>
+    new Response(JSON.stringify({ access_token: 'at', token_type: 'Bearer', scope: 'vault:read' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  const oidcB = new GenericOidcAdapter({
+    ...oidcConfig,
+    fetchImpl: fakeToken,
+    pendingFlowStore: new FilePendingFlowStore(path.join(dataDir, 'pending-flows.json')),
+  });
+  const verified = await oidcB.verifyAuthorization(challenge.resumeToken, { code: 'code-1', state: 'state-xyz' });
+  check('OAuth: PKCE pending flow initiated on A is consumed + completes on B', verified.valid === true);
+
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  process.stdout.write(
+    failed
+      ? '\nSCENARIO FAILED\n'
+      : '\nSCENARIO PASSED — consent survives cross-instance (holder-of-key) with no re-paste\n',
+  );
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-persistence/scripts/scenario-restart.ts
+++ b/examples/consent-persistence/scripts/scenario-restart.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env npx tsx
+/**
+ * Scenario: restart survival via holder-of-key (no re-paste after a restart).
+ *
+ * Approve a checkout on an instance (binds an agent-anchored grant to the file
+ * store), then simulate a restart by building a brand-new instance with EMPTY
+ * in-process memory that reads the same file store. The agent presents a fresh
+ * `_kyaos_proof` and the retry succeeds from the file store — proving consent
+ * survives a restart, with no re-paste and no shared session.
+ *
+ * Headless and deterministic. Exits 0 on success, 1 on failure.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createInstance, loadIdentity, mintCheckoutProof, SCOPE } from '../src/instance.js';
+import { FileGrantStore } from '../src/file-grant-store.js';
+import { approve } from '../src/approve.js';
+
+type Result = { content: Array<{ text: string }>; isError?: boolean };
+const text = (r: Result): string => r.content[0]?.text ?? '';
+const isChallenge = (r: Result): boolean => text(r).includes('Authorization required');
+const isConfirmed = (r: Result): boolean => !r.isError && text(r).includes('Order confirmed');
+
+let failed = false;
+function check(label: string, ok: boolean): void {
+  process.stdout.write(`${ok ? 'PASS' : 'FAIL'}  ${label}\n`);
+  if (!ok) failed = true;
+}
+
+async function main(): Promise<void> {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kya-consent-restart-'));
+  const identity = await loadIdentity();
+  const consentUrl = 'http://consent.local/consent';
+  const grantsFile = path.join(dataDir, 'grants.json');
+
+  // ── Process 1 ───────────────────────────────────────────────────────────
+  const instance1 = createInstance({
+    label: '1',
+    identity,
+    grantStore: new FileGrantStore(grantsFile),
+    consentUrl,
+  });
+
+  const proof1 = await mintCheckoutProof(identity, { item: 'laptop' });
+  const first = await instance1.checkout({ item: 'laptop', _kyaos_proof: proof1 });
+  check('process 1: first call (proof, no grant) returns needs_authorization', isChallenge(first));
+
+  await approve({ identity, grantStore: new FileGrantStore(grantsFile), agentDid: identity.did, scopes: [SCOPE] });
+
+  // ── Restart: a brand-new instance with EMPTY memory, same file store ──────
+  const instance2 = createInstance({
+    label: '2 (restarted)',
+    identity,
+    grantStore: new FileGrantStore(grantsFile),
+    consentUrl,
+  });
+
+  const proof2 = await mintCheckoutProof(identity, { item: 'laptop' });
+  const retry = await instance2.checkout({ item: 'laptop', _kyaos_proof: proof2 });
+  check('process 2 (restarted): retry resolves the grant from the file store (NO re-paste)', isConfirmed(retry));
+
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  process.stdout.write(
+    failed ? '\nSCENARIO FAILED\n' : '\nSCENARIO PASSED — consent survives a restart (holder-of-key) with no re-paste\n',
+  );
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-persistence/src/approve.ts
+++ b/examples/consent-persistence/src/approve.ts
@@ -1,0 +1,67 @@
+/**
+ * Approval: mint the delegation VC and BIND a durable, agent-anchored grant into
+ * the shared store. This is the durable-storage write that makes consent
+ * survive: after `approve()`, a retry of the protected tool on ANY instance (or
+ * after a restart) resolves the grant via `getByAgent` — behind the agent's
+ * per-request holder-of-key proof — with no re-paste and no shared session.
+ *
+ * Shared by the HTTP consent server (`consent-server.ts`) and the headless
+ * scenario scripts, so both exercise the identical write path.
+ */
+
+import { NodeCryptoProvider, type Grant } from '@kya-os/mcp';
+import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
+import { FileGrantStore } from './file-grant-store.js';
+import type { AgentIdentity } from './instance.js';
+
+export interface ApproveInput {
+  /** Issuer identity (single trust domain: the server's own DID issues + verifies). */
+  identity: AgentIdentity;
+  /** The shared, durable grant store both instances read. */
+  grantStore: FileGrantStore;
+  /** The agent the grant authorizes (the durable, portable anchor). */
+  agentDid: string;
+  /** Granted scopes. */
+  scopes: string[];
+  /** Grant lifetime in seconds (default 1 hour). */
+  ttlSeconds?: number;
+}
+
+export interface ApproveResult {
+  grantId: string;
+}
+
+export async function approve(input: ApproveInput): Promise<ApproveResult> {
+  const crypto = new NodeCryptoProvider();
+  const { issuer } = createDelegationIssuerFromIdentity(crypto, input.identity);
+  const ttlSeconds = input.ttlSeconds ?? 3600;
+  const notAfter = Math.floor(Date.now() / 1000) + ttlSeconds;
+
+  // Mint the delegation VC — the durable proof of authority the grant caches.
+  await issuer.createAndIssueDelegation({
+    id: `del-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    issuerDid: input.identity.did,
+    subjectDid: input.agentDid,
+    constraints: { scopes: input.scopes, notAfter },
+  });
+
+  const idBytes = await crypto.randomBytes(16);
+  const grantId = `grant_${Array.from(idBytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')}`;
+
+  // Agent-anchored grant — NO sessionId — so it is portable: a retry resolves it
+  // via getByAgent (behind the agent's holder-of-key proof) on any instance.
+  const grant: Grant = {
+    id: grantId,
+    agentDid: input.agentDid,
+    scopes: input.scopes,
+    authorization: { type: 'delegation', provider: 'consent-persistence' },
+    issuedAt: Date.now(),
+    expiresAt: notAfter * 1000,
+    status: 'active',
+  };
+  await input.grantStore.bind(grant);
+
+  return { grantId };
+}

--- a/examples/consent-persistence/src/consent-server.ts
+++ b/examples/consent-persistence/src/consent-server.ts
@@ -1,0 +1,107 @@
+/**
+ * Consent server — renders the consent page and, on POST /approve, mints the
+ * delegation VC and binds a durable grant into the SHARED grant store (see
+ * approve.ts). It is the durable-storage write half of the flow; the MCP server
+ * instances read that store on a retry.
+ *
+ * UI note: this example deliberately uses the basic shared consent page
+ * (examples/_shared/consent-page.ts), NOT @kya-os/consent (which consent-full /
+ * node-server use). @kya-os/consent's approval response schema REQUIRES a
+ * `delegation_id` + `delegation_token` on success, but this flow is
+ * holder-of-key: approval binds an agent-anchored grant and returns no token
+ * (the agent re-proves possession per request). The basic page handles that
+ * `{ approved: true }` response cleanly; @kya-os/consent would reject it. This
+ * is the honest holder-of-key exception, not an oversight.
+ */
+
+import http from 'node:http';
+import { approve } from './approve.js';
+import { FileGrantStore } from './file-grant-store.js';
+import { SCOPE, TOOL, type AgentIdentity } from './instance.js';
+import { renderConsentPage } from '../../_shared/consent-page.js';
+
+export interface ConsentServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => (data += chunk));
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function parseBody(req: http.IncomingMessage, raw: string): Record<string, string> {
+  const contentType = req.headers['content-type'] ?? '';
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(raw) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(raw)) out[k] = v;
+  return out;
+}
+
+export async function startConsentServer(opts: {
+  port: number;
+  identity: AgentIdentity;
+  grantStore: FileGrantStore;
+}): Promise<ConsentServer> {
+  const server = http.createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', 'http://localhost');
+
+    if (url.pathname === '/consent' && req.method === 'GET') {
+      const tool = url.searchParams.get('tool') ?? TOOL;
+      const agentDid = url.searchParams.get('agent_did') ?? opts.identity.did;
+      const scopes = url.searchParams.get('scopes') ?? SCOPE;
+      // Canonical shared consent page (escapes all reflected values). On approve
+      // its script POSTs JSON and, since this backend returns `{ approved: true }`
+      // (no token), shows the holder-of-key "retry, no re-paste" message.
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(renderConsentPage({ tool, scopes, agentDid, approvePath: '/approve' }));
+      return;
+    }
+
+    if (url.pathname === '/approve' && req.method === 'POST') {
+      const params = parseBody(req, await readBody(req));
+      const agentDid = params['agentDid'] ?? params['agent_did'] ?? opts.identity.did;
+      const scopes = (params['scopes'] ?? SCOPE).split(',').filter(Boolean);
+      const result = await approve({
+        identity: opts.identity,
+        grantStore: opts.grantStore,
+        agentDid,
+        scopes,
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ approved: true, grantId: result.grantId, agentDid }));
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(opts.port, resolve));
+  const addr = server.address();
+  const actualPort = typeof addr === 'object' && addr ? addr.port : opts.port;
+
+  return {
+    url: `http://localhost:${actualPort}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}

--- a/examples/consent-persistence/src/delegation-issuer.ts
+++ b/examples/consent-persistence/src/delegation-issuer.ts
@@ -1,0 +1,60 @@
+/**
+ * Delegation Issuer Factory (shared with examples/consent-basic).
+ *
+ * Creates a DelegationCredentialIssuer from an identity config. The consent
+ * server uses it to mint the delegation VC that backs an approved grant.
+ *
+ * Related Spec: KYA-OS §3.1 (VC structure), §4.1 (DelegationRecord)
+ */
+
+import {
+  DelegationCredentialIssuer,
+  base64urlEncodeFromBytes,
+  type VCSigningFunction,
+  type Proof,
+  type CryptoProvider,
+} from '@kya-os/mcp';
+
+export interface AgentIdentityConfig {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+export interface DelegationIssuerFactory {
+  issuer: DelegationCredentialIssuer;
+  identity: AgentIdentityConfig;
+}
+
+export function createDelegationIssuerFromIdentity(
+  crypto: CryptoProvider,
+  identity: AgentIdentityConfig,
+): DelegationIssuerFactory {
+  const signingFunction: VCSigningFunction = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kid: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, identity.privateKey);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue: base64urlEncodeFromBytes(sigBytes),
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => identity.did,
+      getKeyId: () => identity.kid,
+      getPrivateKey: () => identity.privateKey,
+    },
+    signingFunction,
+  );
+
+  return { issuer, identity };
+}

--- a/examples/consent-persistence/src/file-grant-store.ts
+++ b/examples/consent-persistence/src/file-grant-store.ts
@@ -1,0 +1,92 @@
+/**
+ * FileGrantStore — a durable {@link GrantStore} backed by a single JSON file.
+ *
+ * The simplest swappable process-external backing (no Redis dependency in CI):
+ * every operation reads the JSON file fresh and writes it back, so two server
+ * instances — or the same instance after a restart — see each other's grants.
+ * This is what makes the no-paste retry work across instances: the grant is in a
+ * store both instances read, not in a per-process Map.
+ *
+ * The confused-deputy guard is preserved exactly as in MemoryGrantStore:
+ * `getBySession` only returns grants bound to the asked session, and a grant
+ * bound to one session is never returned to another.
+ *
+ * Production would swap this for Redis / a Durable Object / Postgres behind the
+ * same `GrantStore` interface — the server code does not change.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { GrantStore, type Grant } from '@kya-os/mcp';
+
+export class FileGrantStore extends GrantStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    super();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  }
+
+  private read(): Grant[] {
+    try {
+      if (!fs.existsSync(this.filePath)) return [];
+      return JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as Grant[];
+    } catch {
+      return [];
+    }
+  }
+
+  private write(grants: Grant[]): void {
+    fs.writeFileSync(this.filePath, JSON.stringify(grants, null, 2) + '\n');
+  }
+
+  private active(grants: Grant[]): Grant[] {
+    const now = this.now();
+    return grants.filter(
+      (g) => g.status !== 'revoked' && (g.expiresAt === undefined || g.expiresAt > now),
+    );
+  }
+
+  private covers(grant: Grant, required?: string[]): boolean {
+    if (!required || required.length === 0) return true;
+    return required.every((s) => grant.scopes.includes(s));
+  }
+
+  async bind(grant: Grant): Promise<void> {
+    const grants = this.read().filter((g) => g.id !== grant.id);
+    grants.push({ ...grant });
+    this.write(grants);
+  }
+
+  async getByAgent(agentDid: string, requiredScopes?: string[]): Promise<Grant[]> {
+    return this.active(this.read()).filter(
+      (g) => g.agentDid === agentDid && this.covers(g, requiredScopes),
+    );
+  }
+
+  async getBySession(sessionId: string, requiredScopes?: string[]): Promise<Grant[]> {
+    return this.active(this.read()).filter(
+      (g) => g.sessionId === sessionId && this.covers(g, requiredScopes),
+    );
+  }
+
+  async getById(id: string): Promise<Grant | undefined> {
+    return this.read().find((g) => g.id === id);
+  }
+
+  async revoke(id: string, reason?: string): Promise<void> {
+    const grants = this.read();
+    const grant = grants.find((g) => g.id === id);
+    if (!grant) return;
+    grant.status = 'revoked';
+    if (reason !== undefined) grant.revocationReason = reason;
+    this.write(grants);
+  }
+
+  async cleanup(): Promise<void> {
+    const now = this.now();
+    this.write(this.read().filter((g) => g.expiresAt === undefined || g.expiresAt > now));
+  }
+}

--- a/examples/consent-persistence/src/file-pending-flow-store.ts
+++ b/examples/consent-persistence/src/file-pending-flow-store.ts
@@ -1,0 +1,99 @@
+/**
+ * FilePendingFlowStore — a durable {@link PendingFlowStore} backed by a JSON
+ * file, the OAuth/OIDC counterpart to {@link FileGrantStore}.
+ *
+ * It persists the PKCE `codeVerifier` (keyed by the resume token) to the same
+ * kind of process-external backing, so an authorization callback that lands on a
+ * DIFFERENT instance — or after a restart — can still complete the token
+ * exchange. Holding that state in a per-process Map is exactly what breaks the
+ * OAuth half of consent persistence.
+ *
+ * `get` is non-consuming; `delete` consumes after a successful exchange. A
+ * production Redis/Durable-Object backing should make delete-after-exchange
+ * atomic (GETDEL / CAS) to close the one-time-use replay window.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { PendingFlowStore, type PendingFlow } from '@kya-os/mcp';
+
+interface Entry {
+  flow: PendingFlow;
+  expiresAt: number;
+}
+
+export class FilePendingFlowStore extends PendingFlowStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    super();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  }
+
+  private read(): Record<string, Entry> {
+    try {
+      if (!fs.existsSync(this.filePath)) return {};
+      return JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as Record<string, Entry>;
+    } catch {
+      return {};
+    }
+  }
+
+  private write(data: Record<string, Entry>): void {
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2) + '\n');
+  }
+
+  async put(token: string, flow: PendingFlow, ttlMs: number): Promise<void> {
+    const data = this.read();
+    data[token] = { flow, expiresAt: this.now() + ttlMs };
+    this.write(data);
+  }
+
+  async get(token: string): Promise<PendingFlow | undefined> {
+    const data = this.read();
+    const entry = data[token];
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      delete data[token];
+      this.write(data);
+      return undefined;
+    }
+    return entry.flow;
+  }
+
+  async consume(token: string): Promise<PendingFlow | undefined> {
+    // Atomic read+remove within a process (fs read/write are synchronous). A
+    // production backing should use a real atomic op (Redis GETDEL / CAS) so the
+    // one-time-use guard holds across processes too.
+    const data = this.read();
+    const entry = data[token];
+    if (!entry) return undefined;
+    delete data[token];
+    this.write(data);
+    if (entry.expiresAt <= this.now()) return undefined;
+    return entry.flow;
+  }
+
+  async delete(token: string): Promise<void> {
+    const data = this.read();
+    if (token in data) {
+      delete data[token];
+      this.write(data);
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    const data = this.read();
+    const now = this.now();
+    let changed = false;
+    for (const [token, entry] of Object.entries(data)) {
+      if (entry.expiresAt <= now) {
+        delete data[token];
+        changed = true;
+      }
+    }
+    if (changed) this.write(data);
+  }
+}

--- a/examples/consent-persistence/src/instance.ts
+++ b/examples/consent-persistence/src/instance.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared identity, durable stores, and the per-instance middleware factory.
+ *
+ * The whole point of this example: TWO server instances (and the same instance
+ * after a restart) share ONE file-backed GrantStore + PendingFlowStore and ONE
+ * identity. Each instance builds its own KYA-OS middleware over those shared
+ * stores, with NO per-example delegation Map (contrast examples/consent-basic).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createKyaOsMiddleware,
+  NodeCryptoProvider,
+  generateDidKeyFromBase64,
+  generateRequestProof,
+  type KyaOsMiddleware,
+  type KyaOsToolHandler,
+  type DetachedProof,
+} from '@kya-os/mcp';
+import { FileGrantStore } from './file-grant-store.js';
+import { FilePendingFlowStore } from './file-pending-flow-store.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const IDENTITY_PATH = path.resolve(__dirname, '..', '.kya-os', 'identity.json');
+
+export interface AgentIdentity {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+export const SCOPE = 'cart:write';
+export const TOOL = 'checkout';
+
+/** Load the persisted identity, or generate an ephemeral one (both instances must share it). */
+export async function loadIdentity(): Promise<AgentIdentity> {
+  const crypto = new NodeCryptoProvider();
+  if (fs.existsSync(IDENTITY_PATH)) {
+    return JSON.parse(fs.readFileSync(IDENTITY_PATH, 'utf-8')) as AgentIdentity;
+  }
+  const keyPair = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(keyPair.publicKey);
+  return {
+    did,
+    kid: `${did}#${did.replace('did:key:', '')}`,
+    privateKey: keyPair.privateKey,
+    publicKey: keyPair.publicKey,
+  };
+}
+
+export interface SharedStores {
+  grantStore: FileGrantStore;
+  pendingFlowStore: FilePendingFlowStore;
+  dataDir: string;
+}
+
+/** Create the file-backed stores under `dataDir` (shared by every instance). */
+export function createStores(dataDir: string): SharedStores {
+  return {
+    grantStore: new FileGrantStore(path.join(dataDir, 'grants.json')),
+    pendingFlowStore: new FilePendingFlowStore(path.join(dataDir, 'pending-flows.json')),
+    dataDir,
+  };
+}
+
+export interface Instance {
+  label: string;
+  middleware: KyaOsMiddleware;
+  /** Protected `checkout` handler (requires a cart:write grant). */
+  checkout: KyaOsToolHandler;
+}
+
+/**
+ * Build one server instance over the shared identity + grant store. The
+ * `checkout` tool is protected by the package's own wrapWithDelegation — the
+ * no-paste retry comes from the injected grantStore (§A.2), not example code.
+ */
+export function createInstance(opts: {
+  label: string;
+  identity: AgentIdentity;
+  grantStore: FileGrantStore;
+  consentUrl: string;
+}): Instance {
+  const crypto = new NodeCryptoProvider();
+  const middleware = createKyaOsMiddleware(
+    {
+      identity: opts.identity,
+      session: { sessionTtlMinutes: 60 },
+      grantStore: opts.grantStore,
+      // Holder-of-key is the GENUINE cross-instance mechanism: the agent proves
+      // possession of its key per request (_kyaos_proof), so a retry resolves an
+      // agent-anchored grant via getByAgent with NO shared server session. (This
+      // is what makes the "retry on either instance / after a restart, no
+      // re-paste" promise actually hold over a stateless HTTP transport.)
+      delegation: { holderBinding: 'enforce' },
+      // Dev clarity: emit the proof under only the namespaced `org.kya-os/proof`
+      // key. The library default mirrors it under legacy bare `proof` for
+      // pre-1.1 back-compat; examples keep the Inspector view single-key.
+      emitLegacyProofKey: false,
+    },
+    crypto,
+  );
+
+  const checkout = middleware.wrapWithDelegation(
+    TOOL,
+    {
+      scopeId: SCOPE,
+      consentUrl: opts.consentUrl,
+      formatChallenge: (challenge) => {
+        const url = new URL(opts.consentUrl);
+        url.searchParams.set('tool', TOOL);
+        url.searchParams.set('scopes', challenge.scopes.join(','));
+        url.searchParams.set('agent_did', opts.identity.did);
+        url.searchParams.set('resume_token', challenge.resumeToken);
+        return [
+          {
+            type: 'text' as const,
+            text: `Authorization required.\n\n[Authorize checkout](${url.toString()})\n\nRetry after authorizing — no re-paste needed.`,
+          },
+        ];
+      },
+    },
+    middleware.wrapWithProof(TOOL, async (args) => ({
+      content: [
+        {
+          type: 'text',
+          text: `Order confirmed for item: ${args['item'] ?? 'unknown'}. Thank you! (served by instance ${opts.label})`,
+        },
+      ],
+    })),
+  );
+
+  return { label: opts.label, middleware, checkout };
+}
+
+/**
+ * Mint the per-request holder-of-key proof a KYA-OS agent attaches to a checkout
+ * call. The agent signs `toHolderBindingRequest(checkout, args)` with its key;
+ * the server re-proves possession per request, so an agent-anchored grant
+ * resolves on ANY instance with no shared server session. (Single trust domain
+ * here: the server DID and the agent DID are the same shared identity.)
+ */
+export async function mintCheckoutProof(
+  identity: AgentIdentity,
+  args: Record<string, unknown>,
+): Promise<DetachedProof> {
+  return generateRequestProof({
+    identity,
+    crypto: new NodeCryptoProvider(),
+    toolName: TOOL,
+    args,
+    audience: identity.did,
+    sessionId: 'kyaos_agent_local', // structural only — holder-of-key needs no server session
+  });
+}

--- a/examples/consent-persistence/src/server.ts
+++ b/examples/consent-persistence/src/server.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env npx tsx
+/**
+ * Durable Consent — two MCP server instances sharing one file-backed GrantStore
+ * + PendingFlowStore and one identity.
+ *
+ * Boots a consent server plus TWO MCP instances (ports A and B), both with
+ * holder-of-key enforcement. The agent presents a per-request `_kyaos_proof` in
+ * the `checkout` arguments; the first call returns needs_authorization, the user
+ * approves (binding an agent-anchored grant to the shared store), and a retry on
+ * EITHER instance — or after a restart — succeeds with no re-paste. It works
+ * over the stateless HTTP transport precisely because authorization rides on the
+ * holder-of-key proof, not on a shared server session: each instance re-proves
+ * possession of the agent's key per request and resolves the grant via
+ * getByAgent. No per-process Map, no sticky sessions.
+ *
+ * The deterministic, headless proof lives in scripts/scenario-cross-instance.ts
+ * and scripts/scenario-restart.ts (they mint the `_kyaos_proof` the way a
+ * KYA-OS-aware client would).
+ *
+ * Transports: Streamable HTTP (POST /mcp), per instance.
+ */
+
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { createInstance, createStores, loadIdentity, type Instance } from './instance.js';
+import { startConsentServer } from './consent-server.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function createMcpServer(instance: Instance): Server {
+  const server = new Server(
+    { name: `consent-persistence-${instance.label}`, version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      instance.middleware.kyaOsTool,
+      {
+        name: 'checkout',
+        description: 'Complete a purchase (requires delegation with scope: cart:write)',
+        inputSchema: {
+          type: 'object' as const,
+          properties: { item: { type: 'string', description: 'Item to purchase' } },
+          required: ['item'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+    if (name === '_kyaos') return instance.middleware.handleKyaOs(args as Record<string, unknown>);
+    if (name === 'checkout') return instance.checkout(args as Record<string, unknown>);
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  });
+
+  return server;
+}
+
+function startHttpInstance(instance: Instance, port: number, did: string): http.Server {
+  const httpServer = http.createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, MCP-Session-Id');
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+
+    if (url.pathname === '/mcp' && req.method === 'POST') {
+      const server = createMcpServer(instance);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      res.on('close', () => transport.close());
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    // The mcp-inspector opens an SSE stream with GET /mcp. This example is
+    // holder-of-key and DRIVEN BY THE SCENARIO SCRIPTS, not inspector-interactive
+    // (the inspector can't mint the per-request `_kyaos_proof`, so a retry never
+    // resolves). Return a clear explanation rather than a bare 404.
+    if (url.pathname === '/mcp') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'not_inspector_interactive',
+          message:
+            'consent-persistence is holder-of-key and scenario-script-driven, not ' +
+            'mcp-inspector-interactive (the inspector cannot mint the per-request _kyaos_proof). ' +
+            'Run:  npm run scenario:cross-instance   and   npm run scenario:restart.',
+        }),
+      );
+      return;
+    }
+
+    if (url.pathname === '/' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          instance: instance.label,
+          did,
+          mcp: `http://localhost:${port}/mcp`,
+          note: 'Holder-of-key + scenario-script-driven; NOT mcp-inspector-interactive. See README and npm run scenario:*.',
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  httpServer.listen(port, () => {
+    process.stderr.write(`[consent-persistence] instance ${instance.label}: http://localhost:${port}/mcp\n`);
+  });
+  return httpServer;
+}
+
+async function main() {
+  const identity = await loadIdentity();
+  const dataDir = path.resolve(__dirname, '..', '.data');
+  const stores = createStores(dataDir); // ONE file-backed store, shared by both instances
+
+  const consentPort = parseInt(process.env['CONSENT_PORT'] ?? '3015', 10);
+  const portA = parseInt(process.env['PORT_A'] ?? process.env['PORT'] ?? '3005', 10);
+  const portB = parseInt(process.env['PORT_B'] ?? '3006', 10);
+
+  const consent = await startConsentServer({ port: consentPort, identity, grantStore: stores.grantStore });
+  const consentUrl = `${consent.url}/consent`;
+
+  const instanceA = createInstance({ label: 'A', identity, grantStore: stores.grantStore, consentUrl });
+  const instanceB = createInstance({ label: 'B', identity, grantStore: stores.grantStore, consentUrl });
+
+  startHttpInstance(instanceA, portA, identity.did);
+  startHttpInstance(instanceB, portB, identity.did);
+
+  process.stderr.write(`[consent-persistence] consent page: ${consentUrl}\n`);
+  process.stderr.write(`[consent-persistence] agent DID: ${identity.did}\n`);
+  process.stderr.write(`[consent-persistence] shared store dir: ${dataDir}\n`);
+  process.stderr.write(
+    `[consent-persistence] NOTE: holder-of-key + scenario-script-driven — NOT mcp-inspector-interactive ` +
+      `(the inspector can't mint the per-request _kyaos_proof). Run: npm run scenario:cross-instance / scenario:restart.\n`,
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/examples/consent-persistence/tsconfig.json
+++ b/examples/consent-persistence/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"]
+}

--- a/examples/context7-with-kya-os/src/index.ts
+++ b/examples/context7-with-kya-os/src/index.ts
@@ -148,7 +148,9 @@ async function main() {
   };
 
   // ── KYA-OS: 2 lines to add identity + proofs to all tools ──────
-  const kyaos = await withKyaOs(server, { crypto: new NodeCryptoProvider() });
+  // emitLegacyProofKey: false → single-key Inspector view (the library default
+  // also mirrors the proof under legacy bare `proof` for pre-1.1 back-compat).
+  const kyaos = await withKyaOs(server, { crypto: new NodeCryptoProvider(), emitLegacyProofKey: false });
   console.error(`[kya-os] Server DID: ${kyaos.identity.did}`);
 
   // ── Register tools normally — proofs attached automatically ────

--- a/examples/node-server/.gitignore
+++ b/examples/node-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.kya-os/

--- a/examples/node-server/consent-server.ts
+++ b/examples/node-server/consent-server.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env npx tsx
+/**
+ * Consent HTTP Server (powered by @kya-os/consent)
+ *
+ * This is the core differentiator from consent-basic. It replaces 200+ lines
+ * of hand-rolled HTML with a single generateConsentShell() call from
+ * @kya-os/consent — multi-mode auth, loading skeleton, branding, and no-JS
+ * fallback included.
+ *
+ * Routes:
+ *   GET  /consent          — Consent page via @kya-os/consent
+ *   GET  /consent.js       — Consent component bundle
+ *   POST /consent/approve  — Issues a delegation VC (accepts FormData or JSON)
+ *
+ * Auth modes (AUTH_MODE env var):
+ *   consent-only  (default) — Approve/deny only. Zero config.
+ *   credentials             — Username/password + approve. Demo credentials: demo / demo123
+ *
+ * Related Spec: KYA-OS §4 (Delegation), §6 (Authorization)
+ */
+
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateConsentShell } from '@kya-os/consent/bundle/shell';
+import { CONSENT_BUNDLE } from '@kya-os/consent/bundle/inline';
+import type { ConsentConfig } from '@kya-os/consent/types';
+import { NodeCryptoProvider, generateDidKeyFromBase64 } from '@kya-os/mcp';
+import {
+  createDelegationIssuerFromIdentity,
+  type AgentIdentityConfig,
+  type DelegationIssuerFactory,
+} from './delegation-issuer.js';
+
+export type AuthMode = 'consent-only' | 'credentials';
+
+/** Delegation VC time-to-live in seconds (1 hour). */
+const DELEGATION_TTL_SECONDS = 3600;
+
+export interface DelegationStoreWriter {
+  set(resumeToken: string, vc: unknown, ttlSeconds?: number): void;
+}
+
+export interface ConsentServerConfig {
+  port: number;
+  factory?: DelegationIssuerFactory;
+  delegationStore?: DelegationStoreWriter;
+  authMode?: AuthMode;
+  branding?: { primaryColor?: string; companyName?: string };
+}
+
+export interface ConsentServer {
+  server: http.Server;
+  port: number;
+  url: string;
+  factory: DelegationIssuerFactory;
+  close: () => Promise<void>;
+}
+
+/**
+ * Create and start a consent HTTP server powered by @kya-os/consent.
+ */
+export async function startConsentServer(
+  config: ConsentServerConfig,
+): Promise<ConsentServer> {
+  const authMode: AuthMode = config.authMode
+    ?? (process.env['AUTH_MODE'] as AuthMode | undefined)
+    ?? 'consent-only';
+
+  let factory: DelegationIssuerFactory;
+  if (config.factory) {
+    factory = config.factory;
+  } else {
+    const crypto = new NodeCryptoProvider();
+    const keyPair = await crypto.generateKeyPair();
+    const did = generateDidKeyFromBase64(keyPair.publicKey);
+    const identity: AgentIdentityConfig = {
+      did,
+      kid: `${did}#${did.replace('did:key:', '')}`,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+    };
+    factory = createDelegationIssuerFromIdentity(crypto, identity);
+  }
+
+  const consentConfig: ConsentConfig = {
+    branding: {
+      primaryColor: config.branding?.primaryColor ?? process.env['BRAND_COLOR'] ?? '#2563EB',
+      companyName: config.branding?.companyName ?? process.env['COMPANY_NAME'] ?? 'KYA-OS Demo',
+    },
+    ui: {
+      title: 'Permission Request',
+      description: '[AI Agent] is requesting access to resources on your behalf.',
+      theme: 'auto',
+    },
+    terms: { required: false },
+    expirationDays: 1,
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    // EXAMPLE ONLY — restrict to your consent page origin in production
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const addr = httpServer.address();
+    const actualPort = typeof addr === 'object' && addr ? addr.port : config.port;
+    const url = new URL(req.url ?? '/', `http://localhost:${actualPort}`);
+
+    // GET /consent — consent page via @kya-os/consent
+    if (url.pathname === '/consent' && req.method === 'GET') {
+      const tool = url.searchParams.get('tool') ?? 'unknown';
+      const scopesRaw = url.searchParams.get('scopes') ?? '';
+      const agentDid = url.searchParams.get('agent_did') ?? 'unknown';
+      const resumeToken = url.searchParams.get('resume_token') ?? '';
+      const scopes = scopesRaw.split(',').map(s => s.trim()).filter(Boolean);
+
+      const html = generateConsentShell({
+        config: consentConfig,
+        tool,
+        scopes,
+        agentDid,
+        // @kya-os/consent uses session_id internally; maps 1:1 with KYA-OS resume_token
+        sessionId: resumeToken,
+        projectId: 'node-server-example',
+        serverUrl: `http://localhost:${actualPort}`,
+        authMode,
+      });
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    // GET /consent.js — serve the @kya-os/consent component bundle
+    if (url.pathname === '/consent.js' && req.method === 'GET') {
+      res.writeHead(200, {
+        'Content-Type': 'application/javascript; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+      });
+      res.end(CONSENT_BUNDLE);
+      return;
+    }
+
+    // POST /consent/approve — issue delegation VC
+    if (url.pathname === '/consent/approve' && req.method === 'POST') {
+      try {
+        const fields = await parseApprovalBody(req);
+        const tool = fields['tool'];
+        const scopesRaw = fields['scopes'];
+        const agentDid = fields['agent_did'];
+        const sessionId = fields['session_id'] ?? ''; // This is the resume_token
+        const requestAuthMode = fields['auth_mode'] ?? 'consent-only';
+
+        if (typeof tool !== 'string' || typeof scopesRaw !== 'string' || typeof agentDid !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'missing_fields',
+            message: 'tool, scopes, and agent_did are required',
+          }));
+          return;
+        }
+
+        // EXAMPLE ONLY — replace with real credential validation in production
+        if (requestAuthMode === 'credentials') {
+          const username = fields['username'] ?? '';
+          const password = fields['password'] ?? '';
+          if (username !== 'demo' || password !== 'demo123') {
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              error: 'invalid_credentials',
+              message: 'Invalid username or password',
+            }));
+            return;
+          }
+        }
+
+        // Parse scopes — FormData sends as JSON string, plain strings also accepted
+        let scopeList: string[];
+        try {
+          scopeList = JSON.parse(scopesRaw) as string[];
+        } catch {
+          scopeList = scopesRaw.split(',').map(s => s.trim()).filter(Boolean);
+        }
+
+        const delegationId = `delegation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const nowSeconds = Math.floor(Date.now() / 1000);
+
+        const vc = await factory.issuer.createAndIssueDelegation({
+          id: delegationId,
+          issuerDid: factory.identity.did,
+          subjectDid: agentDid,
+          constraints: {
+            scopes: scopeList,
+            notAfter: nowSeconds + DELEGATION_TTL_SECONDS,
+          },
+          metadata: { tool, approvedAt: new Date().toISOString() },
+        });
+
+        // Store VC in delegation store for auto-apply on retry
+        if (sessionId && config.delegationStore) {
+          config.delegationStore.set(sessionId, vc);
+          process.stderr.write(`[consent] Stored delegation for resume_token: ${sessionId}\n`);
+        }
+
+        // Response includes delegation_id for the <mcp-consent> component's
+        // success event (ConsentApproveDetail) and delegationToken for API clients.
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          success: true,
+          delegation_id: delegationId,
+          delegationToken: vc,
+        }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          error: 'internal_error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        }));
+      }
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(config.port, () => {
+      const addr = httpServer.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : config.port;
+      const serverUrl = `http://localhost:${actualPort}`;
+
+      process.stderr.write(`[consent] Consent server: ${serverUrl}\n`);
+      process.stderr.write(`[consent] Auth mode: ${authMode}\n`);
+      process.stderr.write(`[consent] Issuer DID: ${factory.identity.did}\n`);
+
+      resolve({
+        server: httpServer,
+        port: actualPort,
+        url: serverUrl,
+        factory,
+        close: () => new Promise<void>((res) => httpServer.close(() => res())),
+      });
+    });
+  });
+}
+
+/**
+ * Parse approval body — supports both FormData (from <mcp-consent>)
+ * and JSON (from API clients/tests).
+ */
+async function parseApprovalBody(req: http.IncomingMessage): Promise<Record<string, string>> {
+  const contentType = req.headers['content-type'] ?? '';
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of req) {
+    totalBytes += (chunk as Buffer).length;
+    if (totalBytes > 1_048_576) throw new Error('Request body too large');
+    chunks.push(chunk as Buffer);
+  }
+
+  const rawBody = Buffer.concat(chunks);
+
+  // JSON bodies (from tests, API clients)
+  if (contentType.includes('application/json')) {
+    return JSON.parse(rawBody.toString('utf-8')) as Record<string, string>;
+  }
+
+  // FormData bodies (from <mcp-consent> web component) — use Web Request API
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === 'string') headers[key] = value;
+  }
+
+  const webReq = new Request(`http://localhost${req.url}`, {
+    method: 'POST',
+    headers,
+    body: rawBody,
+  });
+
+  const formData = await webReq.formData();
+  const result: Record<string, string> = {};
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'string') result[key] = value;
+  }
+  return result;
+}
+
+// Run standalone when executed directly
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const port = parseInt(process.env['CONSENT_PORT'] ?? '3001', 10);
+  startConsentServer({ port }).catch((err) => {
+    process.stderr.write(`Fatal: ${err}\n`);
+    process.exit(1);
+  });
+}

--- a/examples/node-server/delegation-issuer.ts
+++ b/examples/node-server/delegation-issuer.ts
@@ -1,0 +1,78 @@
+/**
+ * Delegation Issuer Factory
+ *
+ * Creates a DelegationCredentialIssuer from an identity config.
+ * Supports two credential formats:
+ *   - Embedded proof (Ed25519Signature2020) — VC as JSON with proof attached
+ *   - VC-JWT — compact JWT string (header.payload.signature)
+ *
+ * Used by both consent-server.ts and tests.
+ *
+ * Related Spec: KYA-OS §3.1 (VC structure), §4.1 (DelegationRecord)
+ */
+
+import { DelegationCredentialIssuer, base64urlEncodeFromBytes, createUnsignedVCJWT, completeVCJWT, type VCSigningFunction, type Proof, type CryptoProvider } from '@kya-os/mcp';
+
+export type DelegationFormat = 'embedded-proof' | 'vc-jwt';
+
+export interface AgentIdentityConfig {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+export interface DelegationIssuerFactory {
+  issuer: DelegationCredentialIssuer;
+  identity: AgentIdentityConfig;
+  /**
+   * Issue a delegation as a VC-JWT string.
+   * Uses createUnsignedVCJWT → Ed25519 sign → completeVCJWT,
+   * matching the pattern used by mcp-i-cloudflare's consent service.
+   */
+  issueAsJWT: (delegation: Parameters<DelegationCredentialIssuer['createAndIssueDelegation']>[0], options?: Parameters<DelegationCredentialIssuer['createAndIssueDelegation']>[1]) => Promise<string>;
+}
+
+export function createDelegationIssuerFromIdentity(
+  crypto: CryptoProvider,
+  identity: AgentIdentityConfig,
+): DelegationIssuerFactory {
+  const signingFunction: VCSigningFunction = async (
+    canonicalVC: string,
+    _issuerDid: string,
+    kid: string,
+  ): Promise<Proof> => {
+    const data = new TextEncoder().encode(canonicalVC);
+    const sigBytes = await crypto.sign(data, identity.privateKey);
+    const proofValue = base64urlEncodeFromBytes(sigBytes);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    };
+  };
+
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => identity.did,
+      getKeyId: () => identity.kid,
+      getPrivateKey: () => identity.privateKey,
+    },
+    signingFunction,
+  );
+
+  const issueAsJWT: DelegationIssuerFactory['issueAsJWT'] = async (params, options) => {
+    const vc = await issuer.createAndIssueDelegation(params, options);
+    const vcWithoutProof = { ...vc } as Record<string, unknown>;
+    delete vcWithoutProof['proof'];
+
+    const { signingInput } = createUnsignedVCJWT(vcWithoutProof, { keyId: identity.kid });
+    const sigBytes = await crypto.sign(new TextEncoder().encode(signingInput), identity.privateKey);
+    const signature = base64urlEncodeFromBytes(sigBytes);
+    return completeVCJWT(signingInput, signature);
+  };
+
+  return { issuer, identity, issueAsJWT };
+}

--- a/examples/node-server/package.json
+++ b/examples/node-server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@kya-os/example-node-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "KYA-OS low-level Server example — proof, delegation (with a @kya-os/consent host + auto-apply), and policy step-up",
+  "scripts": {
+    "start": "npx tsx server.ts",
+    "start:consent": "npx tsx consent-server.ts",
+    "issue-delegation": "npx tsx issue-delegation.ts",
+    "issue-approval": "npx tsx issue-approval.ts"
+  },
+  "dependencies": {
+    "@kya-os/mcp": "file:../..",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@kya-os/consent": "^0.1.37"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/node-server/server.ts
+++ b/examples/node-server/server.ts
@@ -27,6 +27,8 @@
  */
 
 import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -37,8 +39,70 @@ import {
 import { createKyaOsMiddleware, generateDidKeyFromBase64 } from '@kya-os/mcp';
 import { NodeCryptoProvider } from './node-crypto.js';
 import { verifyApprovalGrantSignature } from './approval-demo.js';
+import { startConsentServer } from './consent-server.js';
+import { createDelegationIssuerFromIdentity } from './delegation-issuer.js';
 
-function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
+interface ToolResult {
+  content: Array<{ type: string; text: string; [key: string]: unknown }>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * In-memory resume_token -> approved delegation VC store. The consent host
+ * writes here on approve; the MCP server auto-applies on retry so the user
+ * never pastes the credential by hand. (Same pattern as consent-full.)
+ */
+export class DelegationStore {
+  private store = new Map<string, { vc: unknown; expiresAt: number }>();
+
+  set(resumeToken: string, vc: unknown, ttlSeconds = 300): void {
+    this.store.set(resumeToken, { vc, expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
+
+  /** Find any pending delegation for a given tool (by the VC's metadata.tool). */
+  findByTool(toolName: string): { resumeToken: string; vc: unknown } | undefined {
+    for (const [token, entry] of this.store) {
+      if (Date.now() > entry.expiresAt) {
+        this.store.delete(token);
+        continue;
+      }
+      const vc = entry.vc as Record<string, unknown> | undefined;
+      const delegation = (vc?.credentialSubject as Record<string, unknown>)
+        ?.delegation as Record<string, unknown> | undefined;
+      if (delegation?.metadata && (delegation.metadata as Record<string, unknown>).tool === toolName) {
+        this.store.delete(token); // consume it
+        return { resumeToken: token, vc: entry.vc };
+      }
+    }
+    return undefined;
+  }
+}
+
+/** Auto-inject a previously approved delegation on retry (resume-token flow). */
+function formatAsConsentLink(
+  toolName: string,
+  delegationStore: DelegationStore | undefined,
+  handler: (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
+): (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult> {
+  return async (args, sessionId) => {
+    if (!args['_kyaos_delegation'] && delegationStore) {
+      const pending = delegationStore.findByTool(toolName);
+      if (pending) {
+        console.error(`[kya-os] Auto-applying delegation from consent approval (token: ${pending.resumeToken})`);
+        return handler({ ...args, _kyaos_delegation: pending.vc }, sessionId);
+      }
+    }
+    return handler(args, sessionId);
+  };
+}
+
+function createMcpServer(
+  kyaos: ReturnType<typeof createKyaOsMiddleware>,
+  consentUrl: string,
+  delegationStore: DelegationStore,
+) {
   const server = new Server(
     { name: 'kya-os-example', version: '1.0.0' },
     { capabilities: { tools: {} } }
@@ -50,33 +114,40 @@ function createMcpServer(kyaos: ReturnType<typeof createKyaOsMiddleware>) {
     content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}!` }],
   }));
 
-  // restricted_greet: verify delegation VC, then attach proof on success
-  const restrictedGreetHandler = kyaos.wrapWithDelegation(
+  // restricted_greet: verify delegation VC, then attach proof on success. The
+  // challenge renders a clickable @kya-os/consent link; on approve the consent
+  // host stores the VC and `formatAsConsentLink` auto-applies it on retry — the
+  // user never pastes the credential by hand.
+  const rawRestrictedGreet = kyaos.wrapWithDelegation(
     'restricted_greet',
     {
       scopeId: 'greeting:restricted',
-      // This minimal example does NOT host a consent page. `consentUrl` is a
-      // placeholder; `formatChallenge` (below) renders an actionable instruction
-      // instead — and the challenge proof binds that rendered text. For a hosted
-      // browser consent flow + page, see examples/consent-full.
-      consentUrl: 'https://example.com/consent?scope=greeting:restricted',
-      // Render the needs_authorization challenge as a concrete next step for THIS
-      // (page-less) example, rather than a bare URL the caller can't act on.
-      formatChallenge: (challenge) => [
-        {
-          type: 'text',
-          text:
-            `"restricted_greet" requires a delegation credential (scope: ${challenge.scopes.join(', ')}).\n\n` +
-            `This minimal example does not host a consent page. To authorize:\n` +
-            `  1. Mint a credential:  npx tsx examples/node-server/issue-delegation.ts\n` +
-            `  2. Re-call restricted_greet with "_kyaos_delegation" set to the printed VC.\n\n` +
-            `For a hosted consent page + browser flow, see the consent-full example.`,
-        },
-      ],
+      consentUrl,
+      formatChallenge: (challenge) => {
+        const url = new URL(consentUrl);
+        url.searchParams.set('tool', 'restricted_greet');
+        url.searchParams.set('scopes', challenge.scopes.join(','));
+        url.searchParams.set('agent_did', kyaos.identity.did);
+        url.searchParams.set('resume_token', challenge.resumeToken);
+        return [
+          {
+            type: 'text',
+            text:
+              `Authorization required (scope: ${challenge.scopes.join(', ')}).\n\n` +
+              `[Authorize restricted_greet](${url.toString()})\n\n` +
+              `Approve in the browser, then retry restricted_greet — the delegation is applied automatically.`,
+          },
+        ];
+      },
     },
     kyaos.wrapWithProof('restricted_greet', async (args) => ({
       content: [{ type: 'text', text: `Hello, ${args['name'] ?? 'world'}! (delegation verified)` }],
     })),
+  );
+  const restrictedGreetHandler = formatAsConsentLink(
+    'restricted_greet',
+    delegationStore,
+    rawRestrictedGreet as (args: Record<string, unknown>, sessionId?: string) => Promise<ToolResult>,
   );
 
   // delete_record: a destructive, in-scope action. The policy gate classifies it
@@ -186,17 +257,31 @@ async function main() {
 
   console.error(`[kya-os] Agent DID: ${did}`);
 
+  const identity = { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey };
   const kyaos = createKyaOsMiddleware(
     {
-      identity: { did, kid, privateKey: keyPair.privateKey, publicKey: keyPair.publicKey },
+      identity,
       session: { sessionTtlMinutes: 60 },
       autoSession: true,
+      // Single-key Inspector view for the demo; the library default also mirrors
+      // the proof under legacy bare `proof` for pre-1.1 back-compat.
+      emitLegacyProofKey: false,
     },
     crypto
   );
 
+  // Real consent host powered by @kya-os/consent, issuing the
+  // greeting:restricted VC with this identity. The shared DelegationStore lets
+  // restricted_greet auto-apply the approved VC on retry (no manual paste).
+  const consentPort = parseInt(process.env['CONSENT_PORT'] ?? '3011', 10);
+  const delegationStore = new DelegationStore();
+  const factory = createDelegationIssuerFromIdentity(crypto, identity);
+  const consentHost = await startConsentServer({ port: consentPort, factory, delegationStore });
+  const consentUrl = `${consentHost.url}/consent`;
+  console.error(`[kya-os] Consent page: ${consentUrl}`);
+
   if (useStdio) {
-    const server = createMcpServer(kyaos);
+    const server = createMcpServer(kyaos, consentUrl, delegationStore);
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error('[kya-os] Server running on stdio');
@@ -218,7 +303,7 @@ async function main() {
       const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
 
       if (url.pathname === '/sse' && req.method === 'GET') {
-        const server = createMcpServer(kyaos);
+        const server = createMcpServer(kyaos, consentUrl, delegationStore);
         sseTransport = new SSEServerTransport('/messages', res);
         await server.connect(sseTransport);
         console.error('[kya-os] SSE client connected');
@@ -257,7 +342,12 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('Fatal:', err);
-  process.exit(1);
-});
+// Run only when executed directly (so this module can be imported in tests).
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -40,6 +40,7 @@ usage() {
   echo "  node-server        Low-level KYA-OS server with proof + restricted tools"
   echo "  consent-basic      Human-in-the-loop consent flow (built-in UI)"
   echo "  consent-full       Consent flow with @kya-os/consent (production UI)"
+  echo "  consent-persistence Durable consent: two instances share a file-backed grant store"
   echo "  context7-with-kya-os Context7 MCP server + KYA-OS identity"
   echo ""
   exit 0
@@ -57,7 +58,7 @@ for arg in "$@"; do
   esac
 done
 
-ALL_EXAMPLES=(node-server consent-basic consent-full context7-with-kya-os)
+ALL_EXAMPLES=(node-server consent-basic consent-full consent-persistence context7-with-kya-os)
 
 if [ ${#REQUESTED[@]} -eq 0 ]; then
   EXAMPLES=("${ALL_EXAMPLES[@]}")
@@ -82,7 +83,21 @@ fi
 
 for ex in "${EXAMPLES[@]}"; do
   dir="$ROOT/examples/$ex"
-  if [ -f "$dir/package.json" ] && [ ! -d "$dir/node_modules" ]; then
+  [ -f "$dir/package.json" ] || continue
+
+  # (Re)install when node_modules is missing OR the linked @kya-os/mcp dep is
+  # stale/broken — the latter causes a confusing ERR_MODULE_NOT_FOUND at start
+  # even though deps are unchanged. `-e` follows the file: symlink to its target.
+  needs_install=false
+  if [ ! -d "$dir/node_modules" ]; then
+    needs_install=true
+  elif grep -q '"@kya-os/mcp"' "$dir/package.json" \
+       && [ ! -e "$dir/node_modules/@kya-os/mcp/package.json" ]; then
+    echo -e "${YELLOW}  $ex: @kya-os/mcp link is stale — reinstalling${NC}"
+    needs_install=true
+  fi
+
+  if [ "$needs_install" = true ]; then
     echo -e "${DIM}  $ex${NC}"
     if [ -f "$dir/pnpm-lock.yaml" ]; then
       (cd "$dir" && pnpm install --silent 2>/dev/null) || (cd "$dir" && npm install --silent 2>/dev/null)
@@ -106,7 +121,7 @@ start_example() {
   EX_NAMES+=("$name")
   case "$name" in
     node-server)
-      PORT=3001 npx tsx examples/node-server/server.ts &
+      PORT=3001 CONSENT_PORT=3011 npx tsx examples/node-server/server.ts &
       PIDS+=($!)
       EX_URLS+=("http://localhost:3001/sse")
       EX_TRANSPORTS+=("SSE")
@@ -122,6 +137,12 @@ start_example() {
       PIDS+=($!)
       EX_URLS+=("http://localhost:3003/sse")
       EX_TRANSPORTS+=("SSE")
+      ;;
+    consent-persistence)
+      PORT_A=3005 PORT_B=3006 CONSENT_PORT=3015 npx tsx examples/consent-persistence/src/server.ts &
+      PIDS+=($!)
+      EX_URLS+=("http://localhost:3005/mcp")
+      EX_TRANSPORTS+=("Streamable HTTP")
       ;;
     context7-with-kya-os)
       npx tsx examples/context7-with-kya-os/src/index.ts --transport http --port 3004 &

--- a/src/__tests__/integration/mcp-enhance-server.test.ts
+++ b/src/__tests__/integration/mcp-enhance-server.test.ts
@@ -12,6 +12,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { z } from 'zod';
 import { withKyaOs, generateIdentity } from '../../middleware/with-kya-os-server.js';
 import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
+import { KYA_OS_PROOF_META_KEY } from '../../proof/index.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -137,7 +138,7 @@ describe('withKyaOs()', () => {
 
     // Proof should be present via auto-session + auto-proof
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -159,7 +160,7 @@ describe('withKyaOs()', () => {
     expect(first.text).toBe('Hello, Early Bird!');
 
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
     };
     expect(proof).toBeDefined();
@@ -179,7 +180,7 @@ describe('withKyaOs()', () => {
     expect(greetContent.text).toBe('Hello, No Proof!');
 
     // _meta may be undefined or proof should not be present
-    const greetProof = (greetResult._meta as Record<string, unknown> | undefined)?.proof;
+    const greetProof = (greetResult._meta as Record<string, unknown> | undefined)?.[KYA_OS_PROOF_META_KEY];
     expect(greetProof).toBeUndefined();
 
     // 'add' should still have proof
@@ -189,7 +190,7 @@ describe('withKyaOs()', () => {
     });
 
     expect(addResult._meta).toBeDefined();
-    const addProof = (addResult._meta as Record<string, unknown>).proof as {
+    const addProof = (addResult._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
     };
     expect(addProof).toBeDefined();
@@ -208,7 +209,7 @@ describe('withKyaOs()', () => {
     expect(first.text).toBe('Hello, No Auto-Proof!');
 
     // No proof — auto-proofing is off
-    const proof = (result._meta as Record<string, unknown> | undefined)?.proof;
+    const proof = (result._meta as Record<string, unknown> | undefined)?.[KYA_OS_PROOF_META_KEY];
     expect(proof).toBeUndefined();
   });
 
@@ -253,7 +254,7 @@ describe('withKyaOs()', () => {
     expect(first.text).toBe('Hello, Manual Handshake!');
 
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -274,10 +275,10 @@ describe('withKyaOs()', () => {
       arguments: { a: 1, b: 2 },
     });
 
-    const proof1 = (result1._meta as Record<string, unknown>).proof as {
+    const proof1 = (result1._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       meta: Record<string, unknown>;
     };
-    const proof2 = (result2._meta as Record<string, unknown>).proof as {
+    const proof2 = (result2._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       meta: Record<string, unknown>;
     };
 

--- a/src/__tests__/integration/mcp-transport-context7.test.ts
+++ b/src/__tests__/integration/mcp-transport-context7.test.ts
@@ -18,6 +18,7 @@ import { createKyaOsMiddleware } from '../../middleware/with-kya-os.js';
 import { withKyaOs } from '../../middleware/with-kya-os-server.js';
 import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
 import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { KYA_OS_PROOF_META_KEY } from '../../proof/index.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -196,7 +197,7 @@ describe('McpServer (High-Level API) + KYA-OS Integration', () => {
 
     // Verify proof in _meta
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -222,7 +223,7 @@ describe('McpServer (High-Level API) + KYA-OS Integration', () => {
 
     // Proof should be present via auto-session
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -244,7 +245,7 @@ describe('McpServer (High-Level API) + KYA-OS Integration', () => {
 
     // Verify proof is attached
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -264,10 +265,10 @@ describe('McpServer (High-Level API) + KYA-OS Integration', () => {
       arguments: { libraryId: '/expressjs/express', query: 'middleware' },
     });
 
-    const proof1 = (result1._meta as Record<string, unknown>).proof as {
+    const proof1 = (result1._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       meta: Record<string, unknown>;
     };
-    const proof2 = (result2._meta as Record<string, unknown>).proof as {
+    const proof2 = (result2._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       meta: Record<string, unknown>;
     };
 
@@ -363,7 +364,7 @@ describe('McpServer + withKyaOs() (Dream API)', () => {
     expect(first.text).toBe('Found results for: next.js routing');
 
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -407,7 +408,7 @@ describe('McpServer + withKyaOs() (Dream API)', () => {
 
     for (const result of [searchResult, docsResult]) {
       expect(result._meta).toBeDefined();
-      const proof = (result._meta as Record<string, unknown>).proof as {
+      const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
         jws: string;
       };
       expect(proof).toBeDefined();

--- a/src/__tests__/integration/mcp-transport.test.ts
+++ b/src/__tests__/integration/mcp-transport.test.ts
@@ -20,6 +20,7 @@ import { NodeCryptoProvider } from '../utils/node-crypto-provider.js';
 import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
 import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
 import { ProofVerifier } from '../../proof/verifier.js';
+import { KYA_OS_PROOF_META_KEY } from '../../proof/index.js';
 import { MemoryNonceCacheProvider } from '../../providers/memory.js';
 import { SystemClockProvider } from '../../providers/system-clock.js';
 import { RuntimeFetchProvider } from '../../providers/runtime-fetch.js';
@@ -247,7 +248,7 @@ describe('MCP Transport Integration', () => {
 
     // Verify proof in _meta (top-level on the result)
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -279,7 +280,7 @@ describe('MCP Transport Integration', () => {
       arguments: { name: 'Verifier' },
     });
 
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -318,7 +319,7 @@ describe('MCP Transport Integration', () => {
 
     // Proof should be present via auto-session
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };
@@ -358,7 +359,7 @@ describe('MCP Transport Integration', () => {
 
     // Proof from inner wrapWithProof
     expect(result._meta).toBeDefined();
-    const proof = (result._meta as Record<string, unknown>).proof as {
+    const proof = (result._meta as Record<string, unknown>)[KYA_OS_PROOF_META_KEY] as {
       jws: string;
       meta: Record<string, unknown>;
     };

--- a/src/authz/index.ts
+++ b/src/authz/index.ts
@@ -45,6 +45,13 @@ export {
   type FetchImpl,
 } from './oidc/oidc-adapter.js';
 
+export {
+  PendingFlowStore,
+  MemoryPendingFlowStore,
+  type PendingFlow,
+  type MemoryPendingFlowStoreOptions,
+} from './oidc/pending-flow-store.js';
+
 export { AuthorizationServerRegistry } from './registry.js';
 
 export {

--- a/src/authz/oidc/__tests__/oidc-adapter.test.ts
+++ b/src/authz/oidc/__tests__/oidc-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GenericOidcAdapter } from '../oidc-adapter.js';
+import { MemoryPendingFlowStore } from '../pending-flow-store.js';
 import { isNeedsAuthorizationError } from '../../../types/protocol.js';
 import type { ToolProtection } from '../../requirement.js';
 
@@ -66,7 +67,7 @@ describe('GenericOidcAdapter.initiateFlow', () => {
     const challenge = await adapter.initiateFlow(flowParams);
     // The verifier is retrievable by resumeToken (kept off the wire / not in the URL).
     expect(new URL(challenge.authorizationUrl).searchParams.has('code_verifier')).toBe(false);
-    expect(adapter.pendingVerifierFor(challenge.resumeToken)).toBeTruthy();
+    expect(await adapter.pendingVerifierFor(challenge.resumeToken)).toBeTruthy();
   });
 });
 
@@ -111,6 +112,29 @@ describe('GenericOidcAdapter.verifyAuthorization', () => {
     const adapter = new GenericOidcAdapter(config);
     const result = await adapter.verifyAuthorization('never-issued', { code: 'x', state: 'y' });
     expect(result.valid).toBe(false);
+  });
+
+  it('completes the callback on a SECOND adapter sharing one PendingFlowStore (cross-instance)', async () => {
+    // Instance A initiates; the PKCE verifier lands in the shared store.
+    const store = new MemoryPendingFlowStore();
+    const instanceA = new GenericOidcAdapter({ ...config, pendingFlowStore: store });
+    const challenge = await instanceA.initiateFlow(flowParams);
+
+    // Instance B (fresh, empty memory) shares the store and completes the exchange.
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ access_token: 'at-2', token_type: 'Bearer', scope: 'vault:read' }),
+    );
+    const instanceB = new GenericOidcAdapter({ ...config, fetchImpl, pendingFlowStore: store });
+    const result = await instanceB.verifyAuthorization(challenge.resumeToken, {
+      code: 'auth-code-2',
+      state: 'state-xyz',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.credential?.agent_did).toBe('did:key:zAgent');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    // One-time use: the shared verifier is consumed after the exchange.
+    expect(await instanceB.pendingVerifierFor(challenge.resumeToken)).toBeUndefined();
   });
 });
 

--- a/src/authz/oidc/__tests__/pending-flow-store.test.ts
+++ b/src/authz/oidc/__tests__/pending-flow-store.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryPendingFlowStore, type PendingFlow } from '../pending-flow-store.js';
+
+/**
+ * MemoryPendingFlowStore is the dev/reference impl of the PKCE pending-flow
+ * seam. `get` is non-consuming (pre-exchange validation); `delete` consumes
+ * after a successful exchange — kept separate so a transient IdP error never
+ * burns the resume token. TTL expiry uses an injectable clock (mirrors
+ * MemoryGrantStore's test structure).
+ */
+
+function flow(over: Partial<PendingFlow> = {}): PendingFlow {
+  return {
+    agentDid: over.agentDid ?? 'did:key:zAgent',
+    scopes: over.scopes ?? ['vault:read'],
+    state: over.state ?? 'state-1',
+    codeVerifier: over.codeVerifier ?? 'verifier-1',
+    redirectUri: over.redirectUri ?? 'https://app.example/cb',
+    ...over,
+  };
+}
+
+describe('MemoryPendingFlowStore', () => {
+  it('put then get returns the flow without consuming it', async () => {
+    const store = new MemoryPendingFlowStore();
+    await store.put('tok', flow({ codeVerifier: 'v1' }), 60_000);
+    expect((await store.get('tok'))?.codeVerifier).toBe('v1');
+    // Non-consuming: a second get still returns it.
+    expect(await store.get('tok')).toBeDefined();
+  });
+
+  it('get returns undefined for an unknown token', async () => {
+    const store = new MemoryPendingFlowStore();
+    expect(await store.get('never-issued')).toBeUndefined();
+  });
+
+  it('delete consumes the flow (one-time use after exchange)', async () => {
+    const store = new MemoryPendingFlowStore();
+    await store.put('tok', flow(), 60_000);
+    await store.delete('tok');
+    expect(await store.get('tok')).toBeUndefined();
+  });
+
+  it('consume atomically returns the flow then removes it (one-time use)', async () => {
+    const store = new MemoryPendingFlowStore();
+    await store.put('tok', flow({ codeVerifier: 'v1' }), 60_000);
+    expect((await store.consume('tok'))?.codeVerifier).toBe('v1');
+    // Gone afterward — a second consume (or get) sees nothing.
+    expect(await store.consume('tok')).toBeUndefined();
+    expect(await store.get('tok')).toBeUndefined();
+  });
+
+  it('consume returns undefined for an unknown or expired token', async () => {
+    let t = 1_000;
+    const store = new MemoryPendingFlowStore({ now: () => t });
+    expect(await store.consume('nope')).toBeUndefined();
+    await store.put('tok', flow(), 1_000); // expires at 2_000
+    t = 2_001;
+    expect(await store.consume('tok')).toBeUndefined();
+  });
+
+  it('expires a flow past its TTL (injected clock)', async () => {
+    let t = 1_000;
+    const store = new MemoryPendingFlowStore({ now: () => t });
+    await store.put('tok', flow(), 5_000); // expires at 6_000
+    t = 6_001;
+    expect(await store.get('tok')).toBeUndefined();
+  });
+
+  it('cleanup drops only expired flows', async () => {
+    let t = 1_000;
+    const store = new MemoryPendingFlowStore({ now: () => t });
+    await store.put('a', flow(), 1_000); // expires 2_000
+    await store.put('b', flow(), 10_000); // expires 11_000
+    t = 3_000;
+    await store.cleanup();
+    expect(await store.get('a')).toBeUndefined();
+    expect(await store.get('b')).toBeDefined();
+  });
+
+  it('returns a copy — mutating the result does not corrupt the store', async () => {
+    const store = new MemoryPendingFlowStore();
+    await store.put('tok', flow({ codeVerifier: 'v1' }), 60_000);
+    const got = await store.get('tok');
+    if (got) got.codeVerifier = 'tampered';
+    expect((await store.get('tok'))?.codeVerifier).toBe('v1');
+  });
+});

--- a/src/authz/oidc/oidc-adapter.ts
+++ b/src/authz/oidc/oidc-adapter.ts
@@ -9,6 +9,10 @@ import { requirementMatchesAdapter } from '../adapter.js';
 import { buildAuthorizeUrl } from './authorize.js';
 import { computeS256Challenge } from './pkce.js';
 import type { ToolProtection } from '../requirement.js';
+import {
+  MemoryPendingFlowStore,
+  type PendingFlowStore,
+} from './pending-flow-store.js';
 
 /** A minimal fetch signature — the injectable seam for IdP HTTP calls. */
 export type FetchImpl = (
@@ -30,15 +34,17 @@ export interface GenericOidcAdapterConfig {
   resumeTokenTtlMs?: number;
   /** Injected fetch seam; defaults to the runtime global fetch. */
   fetchImpl?: FetchImpl;
+  /**
+   * Pluggable store for in-flight PKCE state. Defaults to an in-memory store
+   * (single-process only). Inject a durable {@link PendingFlowStore} (Redis /
+   * Durable Object / DB) so an authorization callback that lands on another
+   * instance — or after a restart — can still complete the token exchange.
+   */
+  pendingFlowStore?: PendingFlowStore;
 }
 
-interface PendingFlow {
-  agentDid: string;
-  scopes: string[];
-  state: string;
-  codeVerifier: string;
-  redirectUri: string;
-}
+/** Default resume-token / pending-flow lifetime (10 minutes). */
+const DEFAULT_RESUME_TOKEN_TTL_MS = 600_000;
 
 /**
  * Reference generic-OIDC authorization-server adapter.
@@ -56,11 +62,12 @@ interface PendingFlow {
  */
 export class GenericOidcAdapter implements AuthorizationServerAdapter {
   readonly type = 'oauth' as const;
-  private readonly pending = new Map<string, PendingFlow>();
+  private readonly pendingFlowStore: PendingFlowStore;
   private readonly fetchImpl: FetchImpl;
 
   constructor(private readonly config: GenericOidcAdapterConfig) {
     this.fetchImpl = config.fetchImpl ?? ((url, init) => fetch(url, init));
+    this.pendingFlowStore = config.pendingFlowStore ?? new MemoryPendingFlowStore();
   }
 
   isRequired(protection: ToolProtection): boolean {
@@ -77,14 +84,19 @@ export class GenericOidcAdapter implements AuthorizationServerAdapter {
     const codeVerifier = randomToken(32);
     const codeChallenge = await computeS256Challenge(codeVerifier);
     const resumeToken = randomToken(24);
+    const ttlMs = this.config.resumeTokenTtlMs ?? DEFAULT_RESUME_TOKEN_TTL_MS;
 
-    this.pending.set(resumeToken, {
-      agentDid: params.agentDid,
-      scopes,
-      state: params.state,
-      codeVerifier,
-      redirectUri: params.redirectUri,
-    });
+    await this.pendingFlowStore.put(
+      resumeToken,
+      {
+        agentDid: params.agentDid,
+        scopes,
+        state: params.state,
+        codeVerifier,
+        redirectUri: params.redirectUri,
+      },
+      ttlMs,
+    );
 
     const authorizationUrl = buildAuthorizeUrl({
       authorizationEndpoint: this.config.authorizationEndpoint,
@@ -100,13 +112,18 @@ export class GenericOidcAdapter implements AuthorizationServerAdapter {
       message: `Authorization required for "${params.protection.toolName}".`,
       authorizationUrl,
       resumeToken,
-      expiresAt: nowMs() + (this.config.resumeTokenTtlMs ?? 600_000),
+      expiresAt: nowMs() + ttlMs,
       scopes,
     });
   }
 
   async verifyAuthorization(flowState: string, result: unknown): Promise<VerifyDelegationResult> {
-    const pending = this.pending.get(flowState);
+    // Atomically consume the pending flow up front: one-time use, so two
+    // concurrent callbacks for the same resume token can't both reach the token
+    // exchange (closes the replay window). The trade-off is that a transient IdP
+    // failure burns the token and the user re-initiates — acceptable, and the
+    // authorization code is itself one-time-use at the IdP.
+    const pending = await this.pendingFlowStore.consume(flowState);
     if (!pending) {
       return { valid: false, reason: 'unknown or expired resume token' };
     }
@@ -143,9 +160,7 @@ export class GenericOidcAdapter implements AuthorizationServerAdapter {
       return { valid: false, reason: `token exchange failed: ${(error as Error).message}` };
     }
 
-    // One-time use: a resume token is consumed on verification.
-    this.pending.delete(flowState);
-
+    // The flow was already atomically consumed above (one-time use).
     const grantedScopes = token.scope ? token.scope.split(' ') : pending.scopes;
     return {
       valid: true,
@@ -159,8 +174,8 @@ export class GenericOidcAdapter implements AuthorizationServerAdapter {
   }
 
   /** Test/inspection seam: the pending code verifier for a resume token, if any. */
-  pendingVerifierFor(resumeToken: string): string | undefined {
-    return this.pending.get(resumeToken)?.codeVerifier;
+  async pendingVerifierFor(resumeToken: string): Promise<string | undefined> {
+    return (await this.pendingFlowStore.get(resumeToken))?.codeVerifier;
   }
 }
 

--- a/src/authz/oidc/pending-flow-store.ts
+++ b/src/authz/oidc/pending-flow-store.ts
@@ -1,0 +1,117 @@
+/**
+ * PendingFlowStore — the provider seam for in-flight OAuth/OIDC PKCE state.
+ *
+ * Between {@link GenericOidcAdapter.initiateFlow} (which mints a resume token and
+ * the PKCE `codeVerifier`) and the authorization callback (which exchanges the
+ * code), the verifier must be held server-side keyed by the resume token — it is
+ * never placed on the wire. Holding it in a per-process `Map` breaks the moment a
+ * second instance or a restart enters the picture: if the callback lands on
+ * another instance the verifier is gone, the token exchange fails closed, and no
+ * grant is ever minted.
+ *
+ * This seam mirrors {@link GrantStore} / `NonceCacheProvider`: the in-memory
+ * implementation here is the dev/reference impl; production injects a Redis /
+ * Durable Object / database-backed store behind the same interface so
+ * `initiateFlow` on instance A and the callback on instance B share one verifier.
+ *
+ * `get` (non-consuming read) and `delete` (consume) are kept separate so the
+ * adapter can preserve its one-time-use ordering: it reads the pending flow,
+ * validates `state`, performs the token exchange, and deletes ONLY after the
+ * exchange succeeds — so a transient IdP error does not burn the resume token.
+ *
+ * Production note: a durable backing SHOULD make `delete`-after-exchange atomic
+ * (e.g. Redis `GETDEL`, or a compare-and-set) to close the one-time-use replay
+ * window across instances.
+ */
+
+/** In-flight authorization state held between initiateFlow and the callback. */
+export interface PendingFlow {
+  agentDid: string;
+  scopes: string[];
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+}
+
+/**
+ * Store for pending (awaiting-callback) OAuth/OIDC PKCE flows. Implementations
+ * persist a flow under a resume token with a TTL, read it back (non-consuming),
+ * consume it after a successful exchange, and sweep expired entries.
+ */
+export abstract class PendingFlowStore {
+  /** Persist (or replace) a pending flow under `token`, expiring after `ttlMs`. */
+  abstract put(token: string, flow: PendingFlow, ttlMs: number): Promise<void>;
+  /** Read the pending flow without consuming it (e.g. inspection). */
+  abstract get(token: string): Promise<PendingFlow | undefined>;
+  /**
+   * Atomically read AND remove the pending flow — the one-time-use gate for the
+   * token exchange. Returns the flow if it existed and was not expired, else
+   * undefined; either way the token is gone afterward, so two concurrent
+   * callbacks for the same token can never both proceed (closes the replay
+   * window). Durable backings (Redis / Durable Object / DB) MUST implement this
+   * atomically (e.g. Redis `GETDEL`, or a compare-and-set) — a non-atomic
+   * read-then-delete reopens the window across instances.
+   */
+  abstract consume(token: string): Promise<PendingFlow | undefined>;
+  /** Remove a pending flow without reading it. */
+  abstract delete(token: string): Promise<void>;
+  /** Drop expired entries. */
+  abstract cleanup(): Promise<void>;
+}
+
+export interface MemoryPendingFlowStoreOptions {
+  /** Clock injection for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * In-memory {@link PendingFlowStore} — the dev/reference implementation.
+ *
+ * NOT for production: pending flows are lost on restart and are invisible to a
+ * sibling instance, so a callback that lands elsewhere cannot complete. Inject a
+ * Redis / Durable Object / database-backed store for multi-instance deployments.
+ */
+export class MemoryPendingFlowStore extends PendingFlowStore {
+  private readonly pending = new Map<string, { flow: PendingFlow; expiresAt: number }>();
+  private readonly now: () => number;
+
+  constructor(options: MemoryPendingFlowStoreOptions = {}) {
+    super();
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  async put(token: string, flow: PendingFlow, ttlMs: number): Promise<void> {
+    this.pending.set(token, { flow: { ...flow }, expiresAt: this.now() + ttlMs });
+  }
+
+  async get(token: string): Promise<PendingFlow | undefined> {
+    const entry = this.pending.get(token);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.pending.delete(token);
+      return undefined;
+    }
+    return { ...entry.flow };
+  }
+
+  async consume(token: string): Promise<PendingFlow | undefined> {
+    // get + delete with NO await in between → atomic in single-threaded JS:
+    // a second consume() for the same token sees nothing.
+    const entry = this.pending.get(token);
+    if (!entry) return undefined;
+    this.pending.delete(token);
+    if (entry.expiresAt <= this.now()) return undefined;
+    return { ...entry.flow };
+  }
+
+  async delete(token: string): Promise<void> {
+    this.pending.delete(token);
+  }
+
+  async cleanup(): Promise<void> {
+    const now = this.now();
+    for (const [token, entry] of this.pending) {
+      if (entry.expiresAt <= now) this.pending.delete(token);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,8 @@ export {
   ProofGenerator,
   createProofResponse,
   extractCanonicalData,
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
   type ProofAgentIdentity,
   type ToolRequest,
   type ToolResponse,
@@ -240,6 +242,7 @@ export {
   ProofVerifier,
   validateMetaStructure,
   extractProofFromMeta,
+  isReservedMcpMetaKey,
   DEFAULT_CLOCK_SKEW_SECONDS,
   MIN_CLOCK_SKEW_SECONDS,
   MAX_CLOCK_SKEW_SECONDS,
@@ -259,8 +262,11 @@ export {
   SessionManager,
   createHandshakeRequest,
   validateHandshakeFormat,
+  SessionStore,
+  MemorySessionStore,
   type SessionConfig,
   type HandshakeResult,
+  type MemorySessionStoreOptions,
 } from './session/index.js';
 
 // Providers
@@ -291,6 +297,23 @@ export {
   NoopAuditLogProvider,
   buildAuditRecord,
 } from './providers/audit-log.js';
+
+// Durable grant store (the no-paste retry authority) — also reachable via the
+// ./providers subpath; re-exported here at the top level for discoverability.
+export {
+  GrantStore,
+  MemoryGrantStore,
+  type Grant,
+  type MemoryGrantStoreOptions,
+} from './providers/grant-store.js';
+
+// Pending OAuth/OIDC PKCE-flow store (durable resume across instances/restarts).
+export {
+  PendingFlowStore,
+  MemoryPendingFlowStore,
+  type PendingFlow,
+  type MemoryPendingFlowStoreOptions,
+} from './authz/oidc/pending-flow-store.js';
 
 // Middleware
 export {

--- a/src/middleware/__tests__/grant-resolution.test.ts
+++ b/src/middleware/__tests__/grant-resolution.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect } from 'vitest';
+import { createKyaOsMiddleware, type KyaOsDelegationConfig } from '../with-kya-os.js';
+import { NodeCryptoProvider } from '../../__tests__/utils/node-crypto-provider.js';
+import { generateDidKeyFromBase64 } from '../../utils/did-helpers.js';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import { createUnsignedVCJWT, completeVCJWT } from '../../delegation/utils.js';
+import { generateRequestProof } from '../../delegation/holder-binding.js';
+import { MemoryGrantStore, type Grant } from '../../providers/grant-store.js';
+import type { DelegationCredential, Proof } from '../../types/protocol.js';
+import type { ProofAgentIdentity } from '../../proof/generator.js';
+import { base64urlEncodeFromBytes } from '../../utils/base64.js';
+
+/**
+ * Durable-grant retry resolution (spec §A). On a no-delegation (retry) call the
+ * middleware resolves an existing grant from the GrantStore — holder-of-key
+ * first (agent-anchored, proof-gated), then the session bearer capability — so a
+ * fresh instance with empty memory authorizes the retry with NO re-paste of the
+ * VC. The confused-deputy gate (§A.4) is the security crux: a grant for agent A
+ * must never resolve without A's verified holder-of-key proof.
+ */
+
+const crypto = new NodeCryptoProvider();
+const SCOPE = 'cart:write';
+const TOOL = 'checkout';
+
+async function makeIdentity(): Promise<ProofAgentIdentity> {
+  const kp = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(kp.publicKey);
+  return {
+    did,
+    kid: `${did}#${did.replace('did:key:', '')}`,
+    privateKey: kp.privateKey,
+    publicKey: kp.publicKey,
+  };
+}
+
+async function makeServer(opts: {
+  server?: ProofAgentIdentity;
+  holderBinding?: KyaOsDelegationConfig['holderBinding'];
+  grantStore?: MemoryGrantStore;
+} = {}) {
+  const server = opts.server ?? (await makeIdentity());
+  const middleware = createKyaOsMiddleware(
+    {
+      identity: server,
+      session: { sessionTtlMinutes: 60 },
+      ...(opts.holderBinding ? { delegation: { holderBinding: opts.holderBinding } } : {}),
+      ...(opts.grantStore ? { grantStore: opts.grantStore } : {}),
+    },
+    crypto,
+  );
+  return { server, middleware };
+}
+
+/** Issue a delegation VC (issuer-signed) naming `subjectDid` as the holder. */
+async function issueVC(
+  subjectDid: string,
+  scopes: string[] = [SCOPE],
+  controller?: string,
+  crisp?: { resource: string; matcher: 'exact' | 'prefix' | 'regex' }[],
+): Promise<DelegationCredential> {
+  const issuer = await makeIdentity();
+  const signingFn = async (canonicalVC: string, _issuerDid: string, kid: string): Promise<Proof> => {
+    const sig = await crypto.sign(new TextEncoder().encode(canonicalVC), issuer.privateKey);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue: base64urlEncodeFromBytes(sig),
+    };
+  };
+  const credentialIssuer = new DelegationCredentialIssuer(
+    { getDid: () => issuer.did, getKeyId: () => issuer.kid, getPrivateKey: () => issuer.privateKey },
+    signingFn,
+  );
+  return credentialIssuer.createAndIssueDelegation({
+    id: `del-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    issuerDid: issuer.did,
+    subjectDid,
+    ...(controller ? { controller } : {}),
+    constraints: {
+      scopes,
+      ...(crisp ? { crisp: { scopes: crisp } } : {}),
+      notAfter: Math.floor(Date.now() / 1000) + 3600,
+    },
+  });
+}
+
+/** Issue a delegation as a VC-JWT string (compact JWT), naming `subjectDid`. */
+async function issueVCJWT(subjectDid: string, scopes: string[] = [SCOPE]): Promise<string> {
+  const issuer = await makeIdentity();
+  const signingFn = async (canonicalVC: string, _issuerDid: string, kid: string): Promise<Proof> => {
+    const sig = await crypto.sign(new TextEncoder().encode(canonicalVC), issuer.privateKey);
+    return {
+      type: 'Ed25519Signature2020',
+      created: new Date().toISOString(),
+      verificationMethod: kid,
+      proofPurpose: 'assertionMethod',
+      proofValue: base64urlEncodeFromBytes(sig),
+    };
+  };
+  const credentialIssuer = new DelegationCredentialIssuer(
+    { getDid: () => issuer.did, getKeyId: () => issuer.kid, getPrivateKey: () => issuer.privateKey },
+    signingFn,
+  );
+  const vc = await credentialIssuer.createAndIssueDelegation({
+    id: `del-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    issuerDid: issuer.did,
+    subjectDid,
+    constraints: { scopes, notAfter: Math.floor(Date.now() / 1000) + 3600 },
+  });
+  const vcWithoutProof = { ...vc } as Record<string, unknown>;
+  delete vcWithoutProof['proof'];
+  const { signingInput } = createUnsignedVCJWT(vcWithoutProof, { keyId: issuer.kid });
+  const sig = await crypto.sign(new TextEncoder().encode(signingInput), issuer.privateKey);
+  return completeVCJWT(signingInput, base64urlEncodeFromBytes(sig));
+}
+
+async function openSession(
+  middleware: Awaited<ReturnType<typeof makeServer>>['middleware'],
+  serverDid: string,
+): Promise<string> {
+  const hs = await middleware.handleHandshake({
+    nonce: `hs-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    audience: serverDid,
+    timestamp: Math.floor(Date.now() / 1000),
+  });
+  return JSON.parse(hs.content[0].text).sessionId as string;
+}
+
+function activeGrant(over: Partial<Grant>): Grant {
+  return {
+    id: over.id ?? `grant-${Math.random().toString(16).slice(2)}`,
+    agentDid: over.agentDid ?? 'did:key:zUnknown',
+    scopes: over.scopes ?? [SCOPE],
+    issuedAt: over.issuedAt ?? Date.now(),
+    status: over.status ?? 'active',
+    ...over,
+  };
+}
+
+const REACHED = { content: [{ type: 'text' as const, text: 'reached-handler' }] };
+const handlerThatRuns = async () => REACHED;
+const reached = (r: { content: Array<{ text: string }> }) => r.content[0]!.text === 'reached-handler';
+const challenged = (r: { content: Array<{ text: string }> }) =>
+  JSON.parse(r.content[0]!.text).error === 'needs_authorization';
+
+function delegationHandler(middleware: Awaited<ReturnType<typeof makeServer>>['middleware']) {
+  return middleware.wrapWithDelegation(
+    TOOL,
+    { scopeId: SCOPE, consentUrl: 'https://example.com/consent' },
+    handlerThatRuns,
+  );
+}
+
+describe('wrapWithDelegation — grant retry resolution', () => {
+  it('getBySession: a no-delegation retry on the same session reuses the grant (no re-paste)', async () => {
+    const store = new MemoryGrantStore();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    store.bind(activeGrant({ agentDid: 'did:key:zAgent', sessionId }));
+
+    const result = await delegationHandler(middleware)({ item: 'laptop' }, sessionId);
+    expect(reached(result)).toBe(true);
+  });
+
+  it('getByAgent: a session-less grant resolves behind a valid holder-of-key proof (portable)', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    store.bind(activeGrant({ agentDid: agent.did })); // no sessionId → agent-anchored
+
+    const args = { item: 'laptop' };
+    // The proof carries the agent's own session id (for structural validity);
+    // the grant is agent-anchored, so resolution needs no server-side session.
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: TOOL, args, audience: server.did, sessionId: 'kyaos_agent_local',
+    });
+    // No server session and no delegation — only the proof proves possession.
+    const result = await delegationHandler(middleware)({ ...args, _kyaos_proof: proof });
+    expect(reached(result)).toBe(true);
+  });
+
+  it('end-to-end: first call challenges, a verified delegation binds a grant, the retry reuses it', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    const handler = delegationHandler(middleware);
+
+    // 1. No delegation, no grant yet → needs_authorization.
+    const first = await handler({ item: 'laptop' }, sessionId);
+    expect(challenged(first)).toBe(true);
+
+    // 2. Paste the delegation once → handler runs AND a grant is bound.
+    const vc = await issueVC(agent.did);
+    const second = await handler({ item: 'laptop', _kyaos_delegation: vc }, sessionId);
+    expect(reached(second)).toBe(true);
+    const bound = await store.getByAgent(agent.did, [SCOPE]);
+    expect(bound).toHaveLength(1);
+    expect(bound[0]!.sessionId).toBe(sessionId);
+
+    // 3. Retry with NO delegation on the same session → reused, no re-paste.
+    const third = await handler({ item: 'laptop' }, sessionId);
+    expect(reached(third)).toBe(true);
+  });
+
+  it('cross-instance: a grant bound on instance A is resolved on a fresh instance B via the shared store', async () => {
+    const store = new MemoryGrantStore();
+    const server = await makeIdentity();
+    const agent = await makeIdentity();
+
+    // Instance A: paste the delegation once (binds a session grant into the store).
+    const a = await makeServer({ server, grantStore: store });
+    const sessionId = await openSession(a.middleware, server.did);
+    const vc = await issueVC(agent.did);
+    const rA = await delegationHandler(a.middleware)(
+      { item: 'laptop', _kyaos_delegation: vc },
+      sessionId,
+    );
+    expect(reached(rA)).toBe(true);
+
+    // Instance B: fresh middleware, EMPTY memory, same shared store + server DID.
+    // The client resends its sessionId; the grant resolves with no re-paste.
+    const b = await makeServer({ server, grantStore: store });
+    const rB = await delegationHandler(b.middleware)({ item: 'laptop' }, sessionId);
+    expect(reached(rB)).toBe(true);
+  });
+
+  // ── Confused-deputy safety (spec §A.4) ────────────────────────────────────
+
+  it('CONFUSED DEPUTY: an agent grant never resolves without a holder-of-key proof', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    // A session-less, agent-anchored grant exists for the agent.
+    store.bind(activeGrant({ agentDid: agent.did }));
+
+    // A caller who merely knows the agent DID but presents NO proof must be
+    // challenged — the agent grant is unreachable without proven possession.
+    const result = await delegationHandler(middleware)({ item: 'laptop' }, sessionId);
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('CONFUSED DEPUTY: a proof claiming agent A but signed by another key cannot resolve A\'s grant', async () => {
+    const store = new MemoryGrantStore();
+    const agentA = await makeIdentity();
+    const attacker = await makeIdentity();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    store.bind(activeGrant({ agentDid: agentA.did }));
+
+    const args = { item: 'laptop' };
+    // Forge a proof that DECLARES agent A as its subject but is signed by the
+    // attacker's key (attacker knows A's DID, not A's private key).
+    const forged = await generateRequestProof({
+      identity: { did: agentA.did, kid: agentA.kid, privateKey: attacker.privateKey, publicKey: attacker.publicKey },
+      crypto, toolName: TOOL, args, audience: server.did, sessionId: 'kyaos_attacker_local',
+    });
+    const result = await delegationHandler(middleware)({ ...args, _kyaos_proof: forged });
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('CONFUSED DEPUTY: a session-bound grant never resolves from another session', async () => {
+    const store = new MemoryGrantStore();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const s1 = await openSession(middleware, server.did);
+    const s2 = await openSession(middleware, server.did);
+    store.bind(activeGrant({ agentDid: 'did:key:zAgent', sessionId: s1 }));
+
+    // The grant is bound to s1; a call on s2 must be challenged.
+    const result = await delegationHandler(middleware)({ item: 'laptop' }, s2);
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('a malformed string _kyaos_proof falls through to the challenge (no crash, no resolution)', async () => {
+    const store = new MemoryGrantStore();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    store.bind(activeGrant({ agentDid: 'did:key:zAgent' }));
+
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_proof: 'not-json{{{' },
+      sessionId,
+    );
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('getByAgent: resolves when the holder-of-key proof is passed as a JSON string', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    store.bind(activeGrant({ agentDid: agent.did }));
+
+    const args = { item: 'laptop' };
+    const proof = await generateRequestProof({
+      identity: agent, crypto, toolName: TOOL, args, audience: server.did, sessionId: 'kyaos_agent_local',
+    });
+    const result = await delegationHandler(middleware)(
+      { ...args, _kyaos_proof: JSON.stringify(proof) },
+      undefined,
+    );
+    expect(reached(result)).toBe(true);
+  });
+
+  it('binds the user (controller) onto the grant when the delegation names one', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    const userDid = 'did:web:user.example.com';
+    const vc = await issueVC(agent.did, [SCOPE], userDid);
+
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_delegation: vc },
+      sessionId,
+    );
+    expect(reached(result)).toBe(true);
+
+    const [bound] = await store.getByAgent(agent.did, [SCOPE]);
+    expect(bound?.userDid).toBe(userDid);
+    expect(bound?.scopes).toContain(SCOPE);
+  });
+
+  it('with the default (un-injected) grant store, a no-delegation call still challenges', async () => {
+    const { server, middleware } = await makeServer(); // default MemoryGrantStore
+    const sessionId = await openSession(middleware, server.did);
+    const result = await delegationHandler(middleware)({ item: 'laptop' }, sessionId);
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('does NOT bind an unresolvable session-less grant under holderBinding off', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { middleware } = await makeServer({ grantStore: store }); // holderBinding 'off' (default)
+    const vc = await issueVC(agent.did);
+    // No sessionId threaded → a bound grant would be unresolvable on retry, so
+    // the bind is skipped (no orphan row). The verified call still runs.
+    const result = await delegationHandler(middleware)({ item: 'laptop', _kyaos_delegation: vc });
+    expect(reached(result)).toBe(true);
+    expect(await store.getByAgent(agent.did, [SCOPE])).toEqual([]);
+  });
+
+  it('binds the required scope so a prefix-scoped delegation resolves on retry (F1)', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+
+    // The delegation grants a PREFIX scope ("cart:") with NO exact "cart:write";
+    // getDelegationScopes returns [] for it, so without storing the required
+    // scope the retry would re-challenge (exact coversScopes can't match "cart:").
+    const vc = await issueVC(agent.did, [], undefined, [{ resource: 'cart:', matcher: 'prefix' }]);
+    const first = await delegationHandler(middleware)({ item: 'laptop', _kyaos_delegation: vc }, sessionId);
+    expect(reached(first)).toBe(true);
+
+    const retry = await delegationHandler(middleware)({ item: 'laptop' }, sessionId);
+    expect(reached(retry)).toBe(true);
+
+    const [bound] = await store.getBySession(sessionId, [SCOPE]);
+    expect(bound?.scopes).toContain(SCOPE);
+  });
+
+  it('upserts a single grant for repeated VC-paste of the same tuple (deterministic id) (F2)', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+
+    const vc = await issueVC(agent.did);
+    await delegationHandler(middleware)({ item: 'laptop', _kyaos_delegation: vc }, sessionId);
+    await delegationHandler(middleware)({ item: 'laptop', _kyaos_delegation: vc }, sessionId);
+
+    // Same (agentDid, sessionId, scopes) ⇒ one deterministic id ⇒ one row.
+    expect(await store.getByAgent(agent.did, [SCOPE])).toHaveLength(1);
+  });
+
+  // ── Branch coverage: VC-JWT bind, non-did:key proof, bind failure ─────────
+
+  it('binds a grant carrying the credentialJwt when the delegation is a VC-JWT string', async () => {
+    const store = new MemoryGrantStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+
+    const jwt = await issueVCJWT(agent.did);
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_delegation: jwt },
+      sessionId,
+    );
+    expect(reached(result)).toBe(true);
+
+    const [bound] = await store.getByAgent(agent.did, [SCOPE]);
+    expect(bound?.credentialJwt).toBe(jwt);
+  });
+
+  it('resolveAgentGrant ignores a proof with no subject DID', async () => {
+    const store = new MemoryGrantStore();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_proof: { jws: 'x.y.z', meta: {} } },
+      sessionId,
+    );
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('resolveAgentGrant ignores a proof whose subject is not did:key (deferred to cnf binding)', async () => {
+    const store = new MemoryGrantStore();
+    const { server, middleware } = await makeServer({ holderBinding: 'enforce', grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_proof: { jws: 'x.y.z', meta: { did: 'did:web:agent.example.com' } } },
+      sessionId,
+    );
+    expect(challenged(result)).toBe(true);
+  });
+
+  it('a grant-store bind failure does not break the already-authorized response', async () => {
+    class ThrowingBindStore extends MemoryGrantStore {
+      override async bind(): Promise<void> {
+        throw new Error('store unavailable');
+      }
+    }
+    const store = new ThrowingBindStore();
+    const agent = await makeIdentity();
+    const { server, middleware } = await makeServer({ grantStore: store });
+    const sessionId = await openSession(middleware, server.did);
+
+    const vc = await issueVC(agent.did);
+    const result = await delegationHandler(middleware)(
+      { item: 'laptop', _kyaos_delegation: vc },
+      sessionId,
+    );
+    // bindGrantOnSuccess swallows the store failure — the handler still runs.
+    expect(reached(result)).toBe(true);
+  });
+});

--- a/src/middleware/__tests__/with-kya-os-server.test.ts
+++ b/src/middleware/__tests__/with-kya-os-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { generateIdentity, withKyaOs } from "../with-kya-os-server.js";
 import { NodeCryptoProvider } from "../../__tests__/utils/node-crypto-provider.js";
+import { KYA_OS_PROOF_META_KEY, LEGACY_PROOF_META_KEY } from "../../proof/index.js";
 
 const crypto = new NodeCryptoProvider();
 
@@ -113,5 +114,36 @@ describe("withKyaOs", () => {
     expect(kyaos.wrapWithProof).toBeInstanceOf(Function);
     expect(kyaos.wrapWithDelegation).toBeInstanceOf(Function);
     expect(kyaos.handleKyaOs).toBeInstanceOf(Function);
+  });
+
+  it("threads emitLegacyProofKey through to the middleware (suppresses the legacy key)", async () => {
+    const server = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      registerTool: vi.fn(),
+    };
+    const identity = await generateIdentity(crypto);
+
+    const kyaos = await withKyaOs(server, {
+      crypto,
+      identity,
+      emitLegacyProofKey: false,
+    });
+
+    const hs = await kyaos.handleHandshake({
+      nonce: "test-nonce",
+      audience: identity.did,
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    const sessionId = JSON.parse(hs.content[0].text).sessionId;
+
+    const handler = kyaos.wrapWithProof("greet", async (args) => ({
+      content: [{ type: "text", text: `Hello, ${args["name"]}!` }],
+    }));
+    const result = await handler({ name: "DIF" }, sessionId);
+
+    // Proof is emitted under the namespaced key, but NOT the legacy bare key,
+    // because emitLegacyProofKey: false was threaded through withKyaOs.
+    expect(result._meta?.[KYA_OS_PROOF_META_KEY]).toBeDefined();
+    expect(result._meta?.[LEGACY_PROOF_META_KEY]).toBeUndefined();
   });
 });

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -17,11 +17,13 @@ import {
   base64urlEncodeFromBytes,
 } from '../../utils/base64.js';
 import { AuditLogProvider, MemoryAuditLogProvider } from '../../providers/audit-log.js';
+import { KYA_OS_PROOF_META_KEY, LEGACY_PROOF_META_KEY } from '../../proof/index.js';
 
 async function createTestMiddleware(options?: {
   autoSession?: boolean;
   delegation?: KyaOsDelegationConfig;
   auditLog?: AuditLogProvider;
+  emitLegacyProofKey?: boolean;
 }) {
   const crypto = new NodeCryptoProvider();
   const keyPair = await crypto.generateKeyPair();
@@ -35,6 +37,9 @@ async function createTestMiddleware(options?: {
       delegation: options?.delegation,
       autoSession: options?.autoSession,
       auditLog: options?.auditLog,
+      ...(options?.emitLegacyProofKey !== undefined
+        ? { emitLegacyProofKey: options.emitLegacyProofKey }
+        : {}),
     },
     crypto,
   );
@@ -248,8 +253,8 @@ describe('createKyaOsMiddleware', () => {
 
       // Proof in _meta, not in content
       expect(result._meta).toBeDefined();
-      expect(result._meta!.proof).toBeDefined();
-      const proof = result._meta!.proof as { jws: string; meta: Record<string, unknown> };
+      expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
+      const proof = result._meta![KYA_OS_PROOF_META_KEY] as { jws: string; meta: Record<string, unknown> };
       expect(proof.jws).toBeDefined();
       expect(proof.meta.did).toMatch(/^did:key:/);
       expect(proof.meta.sessionId).toBe(sessionId);
@@ -328,7 +333,7 @@ describe('createKyaOsMiddleware', () => {
 
       // The proofed response must be intact despite the sink failure.
       expect(result.content[0].text).toBe('hi');
-      expect(result._meta!.proof).toBeDefined();
+      expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
     });
 
     it('records the delegation scope when threaded via call context', async () => {
@@ -390,7 +395,7 @@ describe('createKyaOsMiddleware', () => {
       // But _meta signals the proof failure
       expect(result._meta).toBeDefined();
       expect(result._meta!.proofError).toBeDefined();
-      expect(result._meta!.proof).toBeUndefined();
+      expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeUndefined();
     });
   });
 
@@ -451,9 +456,9 @@ describe('createKyaOsMiddleware', () => {
       const result = await handler({ _kyaos_delegation: vc }, sessionId);
 
       expect(result.isError).toBe(true);
-      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
-      expect(meta?.proof?.meta?.['outcome']).toBe('denied');
-      expect(meta?.proof?.meta?.['responseHash']).toBeUndefined();
+      const meta = (result as { _meta?: Record<string, { meta?: Record<string, unknown> } | undefined> })._meta;
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['outcome']).toBe('denied');
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['responseHash']).toBeUndefined();
     });
 
     it('emits a signed proof (outcome=needs_authorization) on the no-delegation challenge', async () => {
@@ -481,9 +486,9 @@ describe('createKyaOsMiddleware', () => {
 
       // ...and now carries a signed proof that BINDS the challenge content via
       // responseHash (covering the authorizationUrl) — option B, anti-MITM.
-      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
-      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
-      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+      const meta = (result as { _meta?: Record<string, { meta?: Record<string, unknown> } | undefined> })._meta;
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['responseHash']).toBeDefined();
     });
 
     it('renders the challenge via formatChallenge and binds the proof over THAT content', async () => {
@@ -520,9 +525,9 @@ describe('createKyaOsMiddleware', () => {
 
       // The proof binds a responseHash over the rendered content (so a verifier
       // hashing what the client received matches) with outcome=needs_authorization.
-      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
-      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
-      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+      const meta = (result as { _meta?: Record<string, { meta?: Record<string, unknown> } | undefined> })._meta;
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['responseHash']).toBeDefined();
     });
 
     it('falls back to the default JSON challenge when formatChallenge throws (no -32603)', async () => {
@@ -557,9 +562,9 @@ describe('createKyaOsMiddleware', () => {
       expect(parsed.authorizationUrl).toBe('https://example.com/consent');
 
       // Still carries a signed proof binding the (default) challenge content.
-      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
-      expect(meta?.proof?.meta?.['outcome']).toBe('needs_authorization');
-      expect(meta?.proof?.meta?.['responseHash']).toBeDefined();
+      const meta = (result as { _meta?: Record<string, { meta?: Record<string, unknown> } | undefined> })._meta;
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['outcome']).toBe('needs_authorization');
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['responseHash']).toBeDefined();
     });
 
     it('returns delegation_invalid (not a crash) for structurally malformed delegations', async () => {
@@ -605,8 +610,8 @@ describe('createKyaOsMiddleware', () => {
 
       const result = await handler({ _kyaos_delegation: { bogus: true } }, sessionId);
       expect(result.isError).toBe(true);
-      const meta = (result as { _meta?: { proof?: { meta?: Record<string, unknown> } } })._meta;
-      expect(meta?.proof?.meta?.['outcome']).toBe('denied');
+      const meta = (result as { _meta?: Record<string, { meta?: Record<string, unknown> } | undefined> })._meta;
+      expect(meta?.[KYA_OS_PROOF_META_KEY]?.meta?.['outcome']).toBe('denied');
     });
 
     it('returns delegation_invalid (not a crash) when a delegation accessor throws', async () => {
@@ -981,7 +986,7 @@ describe('createKyaOsMiddleware', () => {
 
       // Proof should still be generated via auto-session
       expect(result._meta).toBeDefined();
-      const proof = result._meta!.proof as { jws: string; meta: Record<string, unknown> };
+      const proof = result._meta![KYA_OS_PROOF_META_KEY] as { jws: string; meta: Record<string, unknown> };
       expect(proof.jws).toBeDefined();
       expect(proof.meta.did).toMatch(/^did:key:/);
       expect(proof.meta.sessionId).toMatch(/^kyaos_/);
@@ -999,10 +1004,90 @@ describe('createKyaOsMiddleware', () => {
       const result1 = await handler({});
       const result2 = await handler({});
 
-      const proof1 = result1._meta!.proof as { meta: Record<string, unknown> };
-      const proof2 = result2._meta!.proof as { meta: Record<string, unknown> };
+      const proof1 = result1._meta![KYA_OS_PROOF_META_KEY] as { meta: Record<string, unknown> };
+      const proof2 = result2._meta![KYA_OS_PROOF_META_KEY] as { meta: Record<string, unknown> };
 
       expect(proof1.meta.sessionId).toBe(proof2.meta.sessionId);
+    });
+  });
+
+  describe('emitLegacyProofKey', () => {
+    async function proofedMeta(emitLegacyProofKey?: boolean): Promise<Record<string, unknown>> {
+      const { middleware, did } = await createTestMiddleware(
+        emitLegacyProofKey === undefined ? {} : { emitLegacyProofKey },
+      );
+      const hs = await middleware.handleHandshake({
+        nonce: `legacy-${Math.random().toString(16).slice(2)}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const sessionId = JSON.parse(hs.content[0].text).sessionId;
+      const handler = middleware.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'Hello!' }],
+      }));
+      const result = await handler({ name: 'DIF' }, sessionId);
+      return result._meta as Record<string, unknown>;
+    }
+
+    it('by default emits the proof under BOTH keys with an identical value', async () => {
+      const meta = await proofedMeta();
+      expect(meta[KYA_OS_PROOF_META_KEY]).toBeDefined();
+      expect(meta[LEGACY_PROOF_META_KEY]).toBeDefined();
+      expect(meta[LEGACY_PROOF_META_KEY]).toEqual(meta[KYA_OS_PROOF_META_KEY]);
+    });
+
+    it('emits ONLY the namespaced key when emitLegacyProofKey is false', async () => {
+      const meta = await proofedMeta(false);
+      expect(meta[KYA_OS_PROOF_META_KEY]).toBeDefined();
+      expect(meta[LEGACY_PROOF_META_KEY]).toBeUndefined();
+    });
+
+    it('the legacy mirror does not change the response hash (_meta is excluded from the hash)', async () => {
+      const both = await proofedMeta(true);
+      const single = await proofedMeta(false);
+      const responseHashOf = (m: Record<string, unknown>): string | undefined =>
+        (m[KYA_OS_PROOF_META_KEY] as { meta: { responseHash?: string } }).meta.responseHash;
+      // Same tool + same args ⇒ identical responseHash regardless of the _meta mirror.
+      expect(responseHashOf(both)).toBeDefined();
+      expect(responseHashOf(both)).toBe(responseHashOf(single));
+    });
+  });
+
+  describe('proof attribution safety (F5)', () => {
+    it('attributes the proof to the single session when exactly one exists', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      await kyaos.handleHandshake({
+        nonce: `f5-single-${Math.random().toString(16).slice(2)}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const handler = kyaos.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'Hello!' }],
+      }));
+      // No threaded sessionId, but exactly one session ⇒ unambiguous ⇒ proof attached.
+      const result = await handler({});
+      expect(result._meta![KYA_OS_PROOF_META_KEY]).toBeDefined();
+    });
+
+    it('does NOT borrow activeSessionId when multiple sessions exist and none is threaded', async () => {
+      const { middleware: kyaos, did } = await createTestMiddleware();
+      await kyaos.handleHandshake({
+        nonce: `f5-a-${Math.random().toString(16).slice(2)}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      await kyaos.handleHandshake({
+        nonce: `f5-b-${Math.random().toString(16).slice(2)}`,
+        audience: did,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+      const handler = kyaos.wrapWithProof('greet', async () => ({
+        content: [{ type: 'text', text: 'Hello!' }],
+      }));
+      // Two sessions + no threaded id ⇒ ambiguous ⇒ proof skipped (not mis-attributed).
+      const result = await handler({});
+      expect(result.content[0].text).toBe('Hello!');
+      expect(result._meta?.[KYA_OS_PROOF_META_KEY]).toBeUndefined();
     });
   });
 });

--- a/src/middleware/kya-os-transport.ts
+++ b/src/middleware/kya-os-transport.ts
@@ -6,7 +6,8 @@
  * private SDK internals accessed.
  *
  * The McpServer never knows this wrapper exists. It sees a normal transport.
- * The connected client sees normal MCP responses with an added `_meta.proof`.
+ * The connected client sees normal MCP responses with the detached proof added
+ * under the namespaced `_meta` key `org.kya-os/proof` (see KYA_OS_PROOF_META_KEY).
  *
  * How it works:
  *   1. Incoming `tools/call` requests are captured (by id) to record tool

--- a/src/middleware/with-kya-os-server.ts
+++ b/src/middleware/with-kya-os-server.ts
@@ -12,6 +12,8 @@
  */
 
 import type { CryptoProvider } from "../providers/base.js";
+import type { GrantStore } from "../providers/grant-store.js";
+import type { SessionConfig } from "../session/manager.js";
 import { generateDidKeyFromBase64, didKeyFragment } from "../utils/did-helpers.js";
 import {
   KYA_OS_ACTIONS,
@@ -28,16 +30,33 @@ export interface WithKyaOsOptions {
   crypto: CryptoProvider;
   /** Identity config — auto-generated if omitted */
   identity?: KyaOsIdentityConfig;
-  /** Session configuration */
-  session?: { sessionTtlMinutes?: number };
+  /**
+   * Session configuration. Accepts the full {@link SessionConfig} (minus the
+   * `nonceCache`, which is set at the top level), so an optional durable
+   * `sessionStore` can be injected for cross-instance session continuity.
+   */
+  session?: Omit<SessionConfig, "nonceCache">;
   /** Auto-create sessions for non-KYA-OS clients (default: true) */
   autoSession?: boolean;
   /** Attach proofs to all tool responses (default: true) */
   proofAllTools?: boolean;
+  /**
+   * Also emit the proof under the legacy bare `_meta.proof` key (default: true),
+   * in addition to the namespaced `org.kya-os/proof`. Set `false` for a clean
+   * single-key view once clients read the namespaced key. Passed through to the
+   * middleware.
+   */
+  emitLegacyProofKey?: boolean;
   /** Tools to skip proof generation for */
   excludeTools?: string[];
   /** Delegation verification config */
   delegation?: KyaOsDelegationConfig;
+  /**
+   * Durable store for approved grants, enabling the no-paste retry across
+   * instances / restarts. Defaults to in-memory; inject a durable
+   * {@link GrantStore} for production. Passed through to the middleware.
+   */
+  grantStore?: GrantStore;
   /**
    * How the KYA-OS protocol tool is exposed on the server.
    * - "tool" (default): auto-register `_kyaos`
@@ -108,6 +127,10 @@ export async function withKyaOs(
       session: options.session,
       delegation: options.delegation,
       autoSession: options.autoSession ?? true,
+      ...(options.grantStore ? { grantStore: options.grantStore } : {}),
+      ...(options.emitLegacyProofKey !== undefined
+        ? { emitLegacyProofKey: options.emitLegacyProofKey }
+        : {}),
     },
     options.crypto,
   );

--- a/src/middleware/with-kya-os.ts
+++ b/src/middleware/with-kya-os.ts
@@ -22,6 +22,7 @@ import {
 } from "../providers/base.js";
 import { RuntimeFetchProvider, NoopFetchProvider } from "../providers/runtime-fetch.js";
 import { AuditLogProvider, NoopAuditLogProvider } from "../providers/audit-log.js";
+import { GrantStore, MemoryGrantStore, type Grant } from "../providers/grant-store.js";
 import {
   SessionManager,
   type SessionConfig,
@@ -29,6 +30,8 @@ import {
 } from "../session/manager.js";
 import {
   ProofGenerator,
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
   type ProofAgentIdentity,
   type ToolRequest,
   type ToolResponse,
@@ -148,6 +151,38 @@ export interface KyaOsConfig {
    * `session`, so there is exactly one cache and the two cannot diverge.
    */
   nonceCache?: NonceCacheProvider;
+  /**
+   * Durable store for approved authorization grants, enabling the no-paste
+   * retry: an agent that already obtained a grant can call again — even on a
+   * fresh instance with empty memory, or after a restart — without re-pasting
+   * the delegation. Defaults to an in-memory {@link MemoryGrantStore}
+   * (single-process only); inject a Redis / Durable Object / DB-backed
+   * {@link GrantStore} for multi-instance deployments. Mirrors `nonceCache?`.
+   *
+   * For the no-paste retry to actually RESOLVE a bound grant, the call must be
+   * resolvable: either holder binding is `'enforce'` and the agent presents a
+   * per-request `_kyaos_proof` (agent-anchored `getByAgent`), or the client
+   * threads its `sessionId` (session-bearer `getBySession`). A grant that would
+   * be unresolvable — holder binding `'off'` with no threaded `sessionId` — is
+   * NOT bound (it would only orphan a store row); such flows achieve durability
+   * by re-presenting the delegation instead.
+   */
+  grantStore?: GrantStore;
+  /**
+   * Whether to ALSO emit the detached proof under the legacy bare `_meta.proof`
+   * key (in addition to the namespaced `org.kya-os/proof`). The value is
+   * identical under both keys and `_meta` is excluded from the response hash
+   * (§7.6), so the mirror never affects signatures or verification.
+   *
+   * Default `true` — a transition aid so pre-1.1 clients that still read bare
+   * `proof` keep working. Set `false` once your clients read the namespaced key
+   * (the examples do this for a clean single-key Inspector view).
+   *
+   * Stays ON by default for the whole 1.x line (a pre-1.1 reader of bare
+   * `_meta.proof` would otherwise silently get no proof); the legacy mirror is
+   * dropped at 2.0.
+   */
+  emitLegacyProofKey?: boolean;
   /** Delegation verification overrides */
   delegation?: KyaOsDelegationConfig;
   /**
@@ -403,10 +438,13 @@ function extractPolicyPrincipal(del: unknown): {
  * @returns Middleware components for session management and proof generation
  *
  * @remarks
- * **Single-process only**: This middleware stores session state in memory using closure
- * variables (`activeSessionId`, `sessionNonces`). It is NOT suitable for multi-instance
- * deployments behind a load balancer. For distributed deployments, implement a custom
- * `SessionStore` backed by Redis, DynamoDB, or similar and pass it via `config.session`.
+ * **Session resolution**: proof generation resolves the session from the explicit
+ * `sessionId` threaded into each wrapper. A single-process `activeSessionId`
+ * fallback (the established handshake/auto session) is consulted ONLY when no
+ * sessionId was threaded — e.g. non-KYA-OS clients (MCP Inspector) and the
+ * transport auto-proof path; a KYA-OS-aware call never depends on it. By default
+ * sessions live in an in-memory Map; for multi-instance deployments inject a
+ * durable `SessionStore` via `config.session.sessionStore`.
  */
 
 export function createKyaOsMiddleware(
@@ -434,6 +472,37 @@ export function createKyaOsMiddleware(
   const delegationConfig = config.delegation;
   const auditLog = config.auditLog ?? new NoopAuditLogProvider();
 
+  // Emit the proof under the legacy bare key as well, by default, for pre-1.1
+  // back-compat. The value is identical under both keys and `_meta` is never
+  // hashed (§7.6), so the mirror is purely additive.
+  const emitLegacyProofKey = config.emitLegacyProofKey ?? true;
+
+  /**
+   * Place a detached proof into a `_meta` object: always under the namespaced
+   * key, and (when {@link emitLegacyProofKey}) mirrored under the legacy bare
+   * key. The single place both emit paths build `_meta`, so they cannot drift.
+   */
+  const withProofMeta = (
+    base: Record<string, unknown>,
+    proof: DetachedProof,
+  ): Record<string, unknown> => ({
+    ...base,
+    [KYA_OS_PROOF_META_KEY]: proof,
+    ...(emitLegacyProofKey ? { [LEGACY_PROOF_META_KEY]: proof } : {}),
+  });
+
+  // Durable grant store for the no-paste retry. Defaults to in-memory; inject a
+  // shared, durable store for multi-instance / restart survival (mirrors the
+  // nonceCache precedent and its production warning).
+  const grantStore = config.grantStore ?? new MemoryGrantStore();
+  if (!config.grantStore) {
+    logger.warn(
+      "[kya-os] Using MemoryGrantStore — grants are lost on restart and not " +
+        "shared across instances. Inject a Redis / Durable Object / DB-backed " +
+        "GrantStore via config.grantStore for production / multi-instance use.",
+    );
+  }
+
   // Holder binding (spec §11.8). Built once so all tools share one replay cache.
   // The verifier derives the subject key from the did:key DID directly, so its
   // fetchProvider is unused on the phase-1 path — a never-called stub keeps
@@ -453,10 +522,12 @@ export function createKyaOsMiddleware(
               : new NoopFetchProvider()),
         });
 
-  // Session map: sessionId → last nonce (for proof generation)
-  const sessionNonces = new Map<string, string>();
-
-  // Active session tracking — set after handshake (manual or auto)
+  // Single-process fallback for the established (handshake or auto) session, used
+  // ONLY when no sessionId was threaded into the wrapper — e.g. non-KYA-OS clients
+  // (MCP Inspector) and the transport auto-proof path, which never thread one. The
+  // PRIMARY resolver is the explicit `sessionId` parameter, so a KYA-OS-aware call
+  // never depends on this fallback. The per-session proof nonce lives on the
+  // session record (`session.nonce`), so no separate nonce map is needed.
   let activeSessionId: string | undefined;
 
   const handshakeTool: KyaOsToolDefinition = {
@@ -534,8 +605,9 @@ export function createKyaOsMiddleware(
     const result: HandshakeResult =
       await sessionManager.validateHandshake(args);
 
+    // Cache the established session as the single-process fallback for callers
+    // that do not thread a sessionId (e.g. the transport auto-proof path).
     if (result.success && result.session) {
-      sessionNonces.set(result.session.sessionId, result.session.nonce);
       activeSessionId = result.session.sessionId;
     }
 
@@ -637,11 +709,30 @@ export function createKyaOsMiddleware(
    * In production, KYA-OS-aware runtimes should execute handshake before tool calls.
    * This convenience mode allows non-KYA-OS clients (like MCP Inspector) to
    * still see proofs without manual handshake.
+   *
+   * SINGLE-SESSION ONLY: the auto-proof transport path does not thread a
+   * sessionId, so it relies on the shared `activeSessionId`. That is only an
+   * unambiguous attribution when exactly one session exists. With multiple
+   * concurrent sessions and no threaded id, borrowing `activeSessionId` would
+   * sign the proof with another client's session/nonce/audience — so this
+   * refuses to borrow and returns undefined (the caller skips the proof). The
+   * `autoSession` create path is unaffected (it makes the single session).
    */
   async function ensureSession(): Promise<string | undefined> {
     if (activeSessionId) {
       const existing = await sessionManager.getSession(activeSessionId);
-      if (existing) return activeSessionId;
+      if (existing) {
+        if (sessionManager.getStats().activeSessions <= 1) {
+          return activeSessionId;
+        }
+        // Ambiguous: more than one session and none threaded — do NOT borrow.
+        logger.warn(
+          "[kya-os] Multiple sessions active and no sessionId threaded; skipping " +
+            "proof attribution to avoid signing with another client's session. " +
+            "Thread the sessionId (the auto-proof path is single-session only).",
+        );
+        return undefined;
+      }
     }
 
     if (!config.autoSession) return undefined;
@@ -659,7 +750,6 @@ export function createKyaOsMiddleware(
 
     if (result.success && result.session) {
       activeSessionId = result.session.sessionId;
-      sessionNonces.set(result.session.sessionId, result.session.nonce);
       return activeSessionId;
     }
 
@@ -703,8 +793,10 @@ export function createKyaOsMiddleware(
           { scopeId: context?.scopeId },
         );
 
-        // Attach proof as _meta (rendered by MCP Inspector, invisible to LLMs)
-        result._meta = { proof };
+        // Attach proof under the namespaced _meta key (rendered by MCP
+        // Inspector, invisible to LLMs), plus the legacy bare key when enabled.
+        // Other _meta keys may coexist (SEP-414).
+        result._meta = withProofMeta({}, proof);
 
         // Hand the verified call to the audit sink. A sink failure MUST NOT
         // break the tool response, so it is logged and swallowed.
@@ -790,7 +882,10 @@ export function createKyaOsMiddleware(
         outcome,
         reason: sanitizeForMessage(reason),
       });
-      response._meta = { ...(response._meta ?? {}), proof };
+      response._meta = withProofMeta(
+        (response._meta as Record<string, unknown> | undefined) ?? {},
+        proof,
+      );
     } catch (error) {
       logger.error("[kya-os] Outcome proof generation failed", {
         tool: toolName,
@@ -798,6 +893,170 @@ export function createKyaOsMiddleware(
       });
     }
     return response;
+  }
+
+  /**
+   * Deterministic grant id from (agentDid, sessionId, sorted scopes). Stable for
+   * the same tuple so a repeated VC-paste UPSERTS one grant rather than piling
+   * duplicate rows in a durable store.
+   */
+  async function grantId(
+    agentDid: string,
+    sessionId: string | undefined,
+    scopes: string[],
+  ): Promise<string> {
+    const key = `${agentDid}|${sessionId ?? ""}|${[...scopes].sort().join(",")}`;
+    const digest = await cryptoProvider.hash(new TextEncoder().encode(key));
+    return `grant_${digest.replace(/^sha256:/, "")}`;
+  }
+
+  /** Grant expiry (ms epoch) derived from the VC, or undefined for no expiry. */
+  function delegationExpiryMs(vc: DelegationCredential): number | undefined {
+    if (vc.expirationDate) {
+      const parsed = Date.parse(vc.expirationDate);
+      if (!Number.isNaN(parsed)) return parsed;
+    }
+    const notAfter = vc.credentialSubject?.delegation?.constraints?.notAfter;
+    if (typeof notAfter === "number") return notAfter * 1000;
+    return undefined;
+  }
+
+  /**
+   * Resolve a durable, agent-anchored grant for a no-delegation call — BUT ONLY
+   * behind a verified holder-of-key proof. The agent DID is taken from the
+   * `_kyaos_proof` and re-proven per request (possession of the subject key over
+   * THIS request), never trusted from a bearer hint. This is the single most
+   * security-sensitive gate of the durable-consent change: without it, any
+   * caller who knows agent A's DID could replay A's grant (confused-deputy
+   * escalation, spec §A.4). Returns undefined unless possession is proven.
+   */
+  async function resolveAgentGrant(
+    toolName: string,
+    args: Record<string, unknown>,
+    sessionId: string | undefined,
+    scopeId: string,
+  ): Promise<Grant | undefined> {
+    if (!holderBindingVerifier) return undefined; // inert unless holder binding is on
+    const proofArg = args["_kyaos_proof"];
+    if (proofArg === undefined) return undefined;
+    let parsedProof: unknown = proofArg;
+    if (typeof proofArg === "string") {
+      try {
+        parsedProof = JSON.parse(proofArg);
+      } catch {
+        return undefined;
+      }
+    }
+    const proof = parsedProof as DetachedProof;
+    const agentDid = proof?.meta?.did;
+    if (typeof agentDid !== "string" || !isHolderBindingApplicable(agentDid)) {
+      return undefined;
+    }
+    const binding = await assertHolderBinding({
+      proof,
+      subjectDid: agentDid,
+      request: toHolderBindingRequest(toolName, args),
+      expectedAudience: identity.did,
+      proofVerifier: holderBindingVerifier,
+    });
+    if (binding.status !== "bound") return undefined;
+    const grants = await grantStore.getByAgent(agentDid, [scopeId]);
+    // A session-bound grant is usable only from its own session; an
+    // agent-anchored (session-less) grant is portable across transports.
+    return grants.find(
+      (g) => g.sessionId === undefined || g.sessionId === sessionId,
+    );
+  }
+
+  /**
+   * Resolve an existing durable grant for a no-delegation (retry) call, so a
+   * fresh instance with empty memory authorizes the retry from the shared store.
+   * Fail-closed, holder-of-key first (agent-anchored, portable), then the
+   * session bearer capability (never crosses sessions). Returns undefined to
+   * fall through to the needs_authorization challenge.
+   */
+  async function resolveExistingGrant(
+    toolName: string,
+    args: Record<string, unknown>,
+    sessionId: string | undefined,
+    scopeId: string,
+  ): Promise<Grant | undefined> {
+    const agentGrant = await resolveAgentGrant(toolName, args, sessionId, scopeId);
+    if (agentGrant) return agentGrant;
+
+    if (sessionId) {
+      const [sessionGrant] = await grantStore.getBySession(sessionId, [scopeId]);
+      if (sessionGrant) return sessionGrant;
+    }
+    return undefined;
+  }
+
+  /**
+   * Mint a durable grant from a freshly-verified delegation so the NEXT call —
+   * on any instance — resolves via {@link resolveExistingGrant} without
+   * re-pasting the VC. Best-effort: a store failure must not break the
+   * already-authorized response.
+   */
+  async function bindGrantOnSuccess(
+    vc: DelegationCredential,
+    delegationArg: unknown,
+    isVCJWT: boolean,
+    sessionId: string | undefined,
+    scopeId: string,
+  ): Promise<void> {
+    try {
+      const agentDid = vc.credentialSubject?.id;
+      if (!agentDid) return;
+
+      // A session-less grant minted with holder binding OFF is unresolvable on
+      // retry (getByAgent needs a holder-of-key proof; getBySession needs a
+      // sessionId), so DON'T bind it — that would only orphan a row in a durable
+      // store. Durability for such flows comes from re-presenting the delegation,
+      // not from a grant. Enable holderBinding 'enforce' or thread a sessionId to
+      // use the grant-backed no-paste retry. (review F4)
+      if (holderBindingMode === "off" && sessionId === undefined) {
+        logger.debug(
+          `[kya-os] Skipping an unresolvable session-less grant for scope "${scopeId}" (holderBinding 'off', no sessionId).`,
+        );
+        return;
+      }
+
+      let delegatedScopes: string[];
+      try {
+        delegatedScopes = getDelegationScopes(vc);
+      } catch {
+        delegatedScopes = [];
+      }
+      // Store the EXACT required scope alongside the delegated scopes. The retry
+      // queries by the tool's exact scopeId, but the delegation may have granted
+      // a prefix/regex scope (e.g. "cart:*"); the store's exact `coversScopes`
+      // would never match the wildcard, so the no-paste retry would silently
+      // re-challenge. Including scopeId makes the grant resolvable. (review F1)
+      const scopes = Array.from(new Set([scopeId, ...delegatedScopes]));
+      const userDid = vc.credentialSubject?.delegation?.controller;
+      const expiresAt = delegationExpiryMs(vc);
+
+      const grant: Grant = {
+        id: await grantId(agentDid, sessionId, scopes),
+        agentDid,
+        ...(userDid !== undefined ? { userDid } : {}),
+        scopes,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+        authorization: { type: "delegation" },
+        ...(isVCJWT && typeof delegationArg === "string"
+          ? { credentialJwt: delegationArg }
+          : {}),
+        issuedAt: Date.now(),
+        ...(expiresAt !== undefined ? { expiresAt } : {}),
+        status: "active",
+      };
+      await grantStore.bind(grant);
+    } catch (error) {
+      logger.error("[kya-os] Grant bind failed", {
+        scope: scopeId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   function wrapWithDelegation(
@@ -931,6 +1190,28 @@ export function createKyaOsMiddleware(
       const delegationArg = args["_kyaos_delegation"];
 
       if (delegationArg === undefined || delegationArg === null) {
+        // No delegation pasted — a durable grant may already authorize this call
+        // (the no-paste retry), even on a fresh instance with empty memory.
+        // Holder-of-key first (agent-anchored, proof-gated), then the session
+        // bearer capability. On a hit, skip the challenge and run the handler
+        // with exactly the call shape a verified delegation would have produced.
+        const existingGrant = await resolveExistingGrant(
+          toolName,
+          args,
+          sessionId,
+          config.scopeId,
+        );
+        if (existingGrant) {
+          const grantArgs: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(args)) {
+            if (!isKyaOsControlArg(k)) grantArgs[k] = v;
+          }
+          logger.debug(
+            `[kya-os] Grant resolved for "${toolName}" (scope "${config.scopeId}") — no re-paste required`,
+          );
+          return handler(grantArgs, sessionId, { scopeId: config.scopeId });
+        }
+
         // No delegation provided — return needs_authorization response
         const tokenBytes = await cryptoProvider.randomBytes(16);
         const hex = Array.from(tokenBytes)
@@ -1164,6 +1445,10 @@ export function createKyaOsMiddleware(
       for (const [k, v] of Object.entries(args)) {
         if (!isKyaOsControlArg(k)) cleanArgs[k] = v;
       }
+
+      // Mint a durable grant from this verified delegation so the next call —
+      // on any instance — resolves via resolveExistingGrant with no re-paste.
+      await bindGrantOnSuccess(vc, delegationArg, isVCJWT, sessionId, config.scopeId);
 
       logger.debug(
         `[kya-os] Delegation verified for "${toolName}", scope "${config.scopeId}"`,

--- a/src/proof/__tests__/verifier.test.ts
+++ b/src/proof/__tests__/verifier.test.ts
@@ -17,6 +17,11 @@ import {
   MIN_CLOCK_SKEW_SECONDS,
   MAX_CLOCK_SKEW_SECONDS,
 } from '../verifier.js';
+import {
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
+} from '../generator.js';
+import { isReservedMcpMetaKey } from '../verifier.js';
 import { CryptoService, type Ed25519JWK } from '../../utils/crypto-service.js';
 import type {
   CryptoProvider,
@@ -526,6 +531,42 @@ describe('ProofVerifier Security', () => {
       }
     });
 
+    it('throws VERIFICATION_METHOD_NOT_FOUND when the kid matches no method', async () => {
+      mockFetchProvider.resolveDID = vi.fn().mockResolvedValue({
+        verificationMethod: [
+          { id: 'did:key:z123#other', publicKeyJwk: { kty: 'OKP', crv: 'Ed25519', x: 'AAA' } },
+        ],
+      });
+
+      await expect(
+        proofVerifier.fetchPublicKeyFromDID('did:key:z123', 'no-such-kid'),
+      ).rejects.toThrow(ProofVerificationError);
+      try {
+        await proofVerifier.fetchPublicKeyFromDID('did:key:z123', 'no-such-kid');
+      } catch (error) {
+        expect((error as ProofVerificationError).code).toBe(
+          PROOF_VERIFICATION_ERROR_CODES.VERIFICATION_METHOD_NOT_FOUND,
+        );
+      }
+    });
+
+    it('throws PUBLIC_KEY_NOT_FOUND when the verification method has no publicKeyJwk', async () => {
+      mockFetchProvider.resolveDID = vi.fn().mockResolvedValue({
+        verificationMethod: [{ id: 'did:key:z123#z123' }],
+      });
+
+      await expect(
+        proofVerifier.fetchPublicKeyFromDID('did:key:z123'),
+      ).rejects.toThrow(ProofVerificationError);
+      try {
+        await proofVerifier.fetchPublicKeyFromDID('did:key:z123');
+      } catch (error) {
+        expect((error as ProofVerificationError).code).toBe(
+          PROOF_VERIFICATION_ERROR_CODES.PUBLIC_KEY_NOT_FOUND,
+        );
+      }
+    });
+
     it('should throw ProofVerificationError if JWK is not Ed25519', async () => {
       mockFetchProvider.resolveDID = vi.fn().mockResolvedValue({
         verificationMethod: [{
@@ -640,24 +681,76 @@ describe('Meta Policy Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should reject _meta with extra keys in strict mode', () => {
+    it('IGNORES (does not reject) non-KYA-OS keys in strict mode (SEP-414)', () => {
       const meta = { proof: { jws: 'test', meta: {} }, extra: 'evil' };
       const result = validateMetaStructure(meta, 'strict');
-      expect(result.valid).toBe(false);
-      expect(result.reason).toContain('extra');
-      expect(result.extraKeys).toContain('extra');
+      // strict no longer rejects foreign keys — it discards them.
+      expect(result.valid).toBe(true);
+      expect(result.extraKeys).toBeUndefined();
     });
 
-    it('should accept _meta with extra keys in allow-extensions mode', () => {
-      const meta = { proof: { jws: 'test', meta: {} }, extra: 'allowed' };
-      const result = validateMetaStructure(meta, 'allow-extensions');
+    it('strict tolerates MCP-reserved _meta keys (must not reject conformant RC traffic)', () => {
+      const meta = {
+        [KYA_OS_PROOF_META_KEY]: { jws: 'test', meta: {} },
+        'io.modelcontextprotocol/foo': { any: 'thing' },
+        traceparent: '00-abc-def-01',
+        tracestate: 'vendor=1',
+        baggage: 'k=v',
+      };
+      const result = validateMetaStructure(meta, 'strict');
       expect(result.valid).toBe(true);
     });
 
-    it('should default to strict mode', () => {
+    it('surfaces non-KYA-OS keys in allow-extensions mode', () => {
+      const meta = { proof: { jws: 'test', meta: {} }, extra: 'allowed' };
+      const result = validateMetaStructure(meta, 'allow-extensions');
+      expect(result.valid).toBe(true);
+      expect(result.extraKeys).toContain('extra');
+    });
+
+    it('allow-extensions with no extra keys surfaces nothing', () => {
+      const meta = { [KYA_OS_PROOF_META_KEY]: { jws: 'test', meta: {} } };
+      const result = validateMetaStructure(meta, 'allow-extensions');
+      expect(result.valid).toBe(true);
+      expect(result.extraKeys).toBeUndefined();
+    });
+
+    it('should default to strict (ignore) mode', () => {
       const meta = { proof: { jws: 'test', meta: {} }, extra: 'evil' };
       const result = validateMetaStructure(meta);
-      expect(result.valid).toBe(false);
+      expect(result.valid).toBe(true);
+      expect(result.extraKeys).toBeUndefined();
+    });
+
+    it('should accept the namespaced proof key in strict mode (SEP-414)', () => {
+      const meta = { [KYA_OS_PROOF_META_KEY]: { jws: 'test', meta: {} } };
+      const result = validateMetaStructure(meta, 'strict');
+      expect(result.valid).toBe(true);
+    });
+
+    it('treats the namespaced key as the proof key, not an extra', () => {
+      // A response carrying ONLY the namespaced proof key is not "extra keys".
+      const meta = { [KYA_OS_PROOF_META_KEY]: { jws: 'test', meta: {} } };
+      const result = validateMetaStructure(meta, 'strict');
+      expect(result.extraKeys ?? []).not.toContain(KYA_OS_PROOF_META_KEY);
+    });
+  });
+
+  describe('isReservedMcpMetaKey', () => {
+    it('recognizes the io.modelcontextprotocol/* reserved namespace', () => {
+      expect(isReservedMcpMetaKey('io.modelcontextprotocol/anything')).toBe(true);
+    });
+
+    it('recognizes the W3C trace-context keys', () => {
+      expect(isReservedMcpMetaKey('traceparent')).toBe(true);
+      expect(isReservedMcpMetaKey('tracestate')).toBe(true);
+      expect(isReservedMcpMetaKey('baggage')).toBe(true);
+    });
+
+    it('does not flag the KYA-OS proof key or arbitrary keys', () => {
+      expect(isReservedMcpMetaKey(KYA_OS_PROOF_META_KEY)).toBe(false);
+      expect(isReservedMcpMetaKey('proof')).toBe(false);
+      expect(isReservedMcpMetaKey('whatever')).toBe(false);
     });
   });
 
@@ -685,12 +778,13 @@ describe('Meta Policy Validation', () => {
       }
     });
 
-    it('should reject _meta with extra keys in strict mode', () => {
-      const meta = { proof: validProof, extra: 'evil' };
+    it('extracts the proof even when foreign _meta keys coexist in strict mode', () => {
+      // strict ignores non-KYA-OS keys rather than rejecting (SEP-414).
+      const meta = { proof: validProof, extra: 'evil', traceparent: '00-a-b-01' };
       const result = extractProofFromMeta(meta, 'strict');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.errorCode).toBe(PROOF_VERIFICATION_ERROR_CODES.META_POLICY_VIOLATION);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.proof).toEqual(validProof);
       }
     });
 
@@ -706,6 +800,45 @@ describe('Meta Policy Validation', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.errorCode).toBe(PROOF_VERIFICATION_ERROR_CODES.MISSING_REQUIRED_FIELD);
+      }
+    });
+
+    it('extracts the proof from the namespaced key (SEP-414)', () => {
+      const meta = { [KYA_OS_PROOF_META_KEY]: validProof };
+      const result = extractProofFromMeta(meta, 'strict');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.proof).toEqual(validProof);
+      }
+    });
+
+    it('still accepts a proof published under the legacy bare key (back-compat)', () => {
+      const meta = { [LEGACY_PROOF_META_KEY]: validProof };
+      const result = extractProofFromMeta(meta, 'strict');
+      expect(result.success).toBe(true);
+    });
+
+    it('prefers the namespaced key when both are present (namespaced wins)', () => {
+      const legacyOnly = { ...validProof, jws: 'legacy.jws.sig' };
+      const meta = {
+        [KYA_OS_PROOF_META_KEY]: validProof,
+        [LEGACY_PROOF_META_KEY]: legacyOnly,
+      };
+      const result = extractProofFromMeta(meta, 'strict');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.proof.jws).toBe(validProof.jws);
+      }
+    });
+
+    it('reads a dual-emitted response (both keys, identical value)', () => {
+      // The default producer mirrors the proof under both keys; a verifier reads
+      // it cleanly (namespaced wins, identical value) with no policy violation.
+      const meta = { [KYA_OS_PROOF_META_KEY]: validProof, [LEGACY_PROOF_META_KEY]: validProof };
+      const result = extractProofFromMeta(meta, 'strict');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.proof).toEqual(validProof);
       }
     });
   });

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -20,6 +20,29 @@ import { CryptoService, type Ed25519JWK } from '../utils/crypto-service.js';
 import { base64ToBytes, base64urlEncodeFromBytes, bytesToBase64 } from '../utils/base64.js';
 import { ED25519_PKCS8_DER_HEADER, ED25519_KEY_SIZE } from '../utils/ed25519-constants.js';
 
+/**
+ * Canonical reverse-DNS `_meta` key under which KYA-OS attaches its detached
+ * proof. MCP 2026-07-28 (SEP-414) makes `_meta` shared, reverse-DNS–namespaced
+ * real estate — it also carries `io.modelcontextprotocol/*` and W3C trace
+ * context keys — so KYA-OS namespaces its own payload rather than owning bare
+ * `proof`.
+ *
+ * SINGLE SOURCE OF TRUTH: every emit site (middleware) and verify site
+ * (`extractProofFromMeta` / `validateMetaStructure`) references this constant,
+ * so renaming the namespace — e.g. once KYA-OS registers as an MCP Extension
+ * under SEP-2133 — is a one-line change. See SPEC §7.6.
+ */
+export const KYA_OS_PROOF_META_KEY = 'org.kya-os/proof';
+
+/**
+ * Legacy bare `_meta.proof` key — the legacy `_meta.proof` mirror; drop at 2.0.
+ * For one major version verifiers MUST keep accepting a proof published here
+ * (back-compat); producers SHOULD emit under {@link KYA_OS_PROOF_META_KEY}. When
+ * both keys are present the namespaced key wins. The mirror is emitted by default
+ * for the whole 1.x line (see `emitLegacyProofKey`) and removed at 2.0. SPEC §7.6.
+ */
+export const LEGACY_PROOF_META_KEY = 'proof';
+
 export interface ProofAgentIdentity {
   did: string;
   kid: string;

--- a/src/proof/index.ts
+++ b/src/proof/index.ts
@@ -2,6 +2,8 @@ export {
   ProofGenerator,
   createProofResponse,
   extractCanonicalData,
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
   type ProofAgentIdentity,
   type ToolRequest,
   type ToolResponse,

--- a/src/proof/verifier.ts
+++ b/src/proof/verifier.ts
@@ -24,6 +24,8 @@ import {
 import { logger } from "../logging/index.js";
 import {
   computeCanonicalHashes,
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
   type ToolRequest,
   type ToolResponse,
 } from "./generator.js";
@@ -580,28 +582,67 @@ export class ProofVerifier {
 }
 
 /**
+ * MCP-reserved / standard `_meta` keys a KYA-OS verifier MUST tolerate but
+ * never hash or trust (MCP 2026-07-28 / SEP-414): the `io.modelcontextprotocol/*`
+ * reverse-DNS namespace reserved by the MCP maintainers, and the W3C Trace
+ * Context propagation keys. Allowlisted so their presence is unambiguously not a
+ * cause for rejection under any policy.
+ */
+const RESERVED_MCP_META_PREFIXES = ['io.modelcontextprotocol/'] as const;
+const RESERVED_MCP_META_KEYS = ['traceparent', 'tracestate', 'baggage'] as const;
+
+/**
+ * Whether `key` is an MCP-reserved / standard `_meta` key (SEP-414) that KYA-OS
+ * tolerates: never hashed, never trusted, never a cause for rejection. Exposed
+ * so adopters can classify coexisting `_meta` keys with the same allowlist the
+ * verifier uses. See {@link validateMetaStructure}.
+ */
+export function isReservedMcpMetaKey(key: string): boolean {
+  return (
+    (RESERVED_MCP_META_KEYS as readonly string[]).includes(key) ||
+    RESERVED_MCP_META_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}
+
+/**
  * Validate _meta structure according to meta policy.
  *
- * In 'strict' mode, _meta must contain only 'proof'.
- * In 'allow-extensions' mode, additional keys are permitted.
+ * The KYA-OS proof rides under {@link KYA_OS_PROOF_META_KEY} (reverse-DNS,
+ * SEP-414); the legacy bare {@link LEGACY_PROOF_META_KEY} is still accepted for
+ * back-compat. Both are treated as the proof key. Every other key is a
+ * non-KYA-OS `_meta` key.
+ *
+ * Under MCP 2026-07-28 `_meta` is shared real estate (it also carries
+ * `io.modelcontextprotocol/*` and W3C trace-context keys), so NEITHER policy
+ * rejects foreign keys — the prior `strict` reject-extras behavior would have
+ * made a conformant KYA-OS verifier reject conformant RC traffic. Both policies
+ * carry the identical zero-trust boundary: only the proof key is ever hashed or
+ * trusted; reserved/foreign keys ({@link isReservedMcpMetaKey} and any other)
+ * pass through untouched.
+ *
+ * - `strict` (default): non-KYA-OS keys are IGNORED (discarded) — never hashed,
+ *   trusted, or rejected.
+ * - `allow-extensions`: identical trust boundary, but the non-KYA-OS keys are
+ *   surfaced back to the caller (`extraKeys`) instead of discarded.
  *
  * @param meta - The _meta object from a response
  * @param policy - Meta policy ('strict' or 'allow-extensions')
- * @returns Validation result with valid flag and optional reason
+ * @returns Validation result; always valid. Under 'allow-extensions' any
+ *   non-KYA-OS keys are surfaced in `extraKeys`.
  */
 export function validateMetaStructure(
   meta: Record<string, unknown>,
   policy: MetaPolicy = 'strict'
 ): { valid: boolean; reason?: string; extraKeys?: string[] } {
-  const keys = Object.keys(meta);
-  const extraKeys = keys.filter(k => k !== 'proof');
+  const extraKeys = Object.keys(meta).filter(
+    k => k !== KYA_OS_PROOF_META_KEY && k !== LEGACY_PROOF_META_KEY,
+  );
 
-  if (policy === 'strict' && extraKeys.length > 0) {
-    return {
-      valid: false,
-      reason: `_meta contains keys other than 'proof' in strict mode: ${extraKeys.join(', ')}`,
-      extraKeys,
-    };
+  // allow-extensions surfaces coexisting keys; strict discards them. Neither
+  // rejects — a reserved key (io.modelcontextprotocol/*, traceparent, …) or any
+  // other foreign key never fails verification.
+  if (policy === 'allow-extensions' && extraKeys.length > 0) {
+    return { valid: true, extraKeys };
   }
 
   return { valid: true };
@@ -618,25 +659,22 @@ export function extractProofFromMeta(
   meta: Record<string, unknown>,
   policy: MetaPolicy = 'strict'
 ): { success: true; proof: DetachedProof } | { success: false; reason: string; errorCode: string } {
-  // Check for required proof field first
-  const proof = meta.proof;
+  // Check for the proof field first. Prefer the namespaced key; fall back to
+  // the legacy bare key for back-compat. When both are present the namespaced
+  // key wins (SPEC §7.6).
+  const proof = meta[KYA_OS_PROOF_META_KEY] ?? meta[LEGACY_PROOF_META_KEY];
   if (!proof) {
     return {
       success: false,
-      reason: '_meta does not contain proof',
+      reason: '_meta does not contain a proof',
       errorCode: PROOF_VERIFICATION_ERROR_CODES.MISSING_REQUIRED_FIELD,
     };
   }
 
-  // Validate meta structure according to policy
-  const validation = validateMetaStructure(meta, policy);
-  if (!validation.valid) {
-    return {
-      success: false,
-      reason: validation.reason!,
-      errorCode: PROOF_VERIFICATION_ERROR_CODES.META_POLICY_VIOLATION,
-    };
-  }
+  // Run the policy check for its semantics (strict ignores / allow-extensions
+  // surfaces coexisting keys). Under MCP 2026-07-28 (SEP-414) it never rejects,
+  // so it cannot block extraction — there is no policy-violation path here.
+  validateMetaStructure(meta, policy);
 
   const proofValidation = validateDetachedProof(proof);
   if (!proofValidation.success) {

--- a/src/providers/grant-store.ts
+++ b/src/providers/grant-store.ts
@@ -59,7 +59,16 @@ export abstract class GrantStore {
   abstract bind(grant: Grant): Promise<void>;
   /** Active grants for an agent DID, optionally narrowed to required scopes. */
   abstract getByAgent(agentDid: string, requiredScopes?: string[]): Promise<Grant[]>;
-  /** Active grants bound to a session, optionally narrowed to required scopes. */
+  /**
+   * Active grants bound to a session, optionally narrowed to required scopes.
+   *
+   * SECURITY: this path resolves on possession of the `sessionId` ALONE — there
+   * is no per-request proof here — so the session id is a bearer capability and
+   * its confidentiality is load-bearing (treat it like a secret; never log or
+   * expose it). For privileged scopes prefer holder-of-key (`holderBinding:
+   * 'enforce'` + {@link GrantStore.getByAgent}), which re-proves possession of
+   * the agent's key on every request and does not rely on session secrecy.
+   */
   abstract getBySession(sessionId: string, requiredScopes?: string[]): Promise<Grant[]>;
   /** A grant by id regardless of status (returns revoked/expired records too). */
   abstract getById(id: string): Promise<Grant | undefined>;

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { SessionManager, createHandshakeRequest, validateHandshakeFormat } from "../manager.js";
 import type { SessionConfig } from "../manager.js";
+import { MemorySessionStore } from "../session-store.js";
 import type { HandshakeRequest } from "../../types/protocol.js";
 import { AUTH_NONCE_TTL_MS, ANON_NONCE_TTL_MS } from "../../types/protocol.js";
 
@@ -238,10 +239,30 @@ describe("SessionManager", () => {
   describe("clearSessions", () => {
     it("should clear all sessions", async () => {
       await manager.validateHandshake(makeRequest());
-      manager.clearSessions();
+      await manager.clearSessions();
 
       const stats = manager.getStats();
       expect(stats.activeSessions).toBe(0);
+    });
+  });
+
+  describe("injected SessionStore", () => {
+    it("routes get/set/delete through an injected store (parity with the default)", async () => {
+      const store = new MemorySessionStore();
+      const sm = makeSessionManager({ sessionStore: store });
+
+      const result = await sm.validateHandshake(makeRequest());
+      expect(result.success).toBe(true);
+      const sessionId = result.session!.sessionId;
+
+      // The injected store holds the session, and the manager reads through it.
+      expect(store.size()).toBe(1);
+      expect(await sm.getSession(sessionId)).not.toBeNull();
+      expect((await store.get(sessionId))?.sessionId).toBe(sessionId);
+
+      await sm.clearSessions();
+      expect(store.size()).toBe(0);
+      expect(await sm.getSession(sessionId)).toBeNull();
     });
   });
 

--- a/src/session/__tests__/session-store.test.ts
+++ b/src/session/__tests__/session-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { MemorySessionStore } from '../session-store.js';
+import type { SessionContext } from '../../types/protocol.js';
+
+/**
+ * MemorySessionStore is the default, dev/reference impl of the optional
+ * SessionStore seam. It must reproduce the prior in-Map behavior: get/set/
+ * delete, an entries() snapshot for the manager's TTL sweep, insertion-order
+ * eviction past maxSessions, and a synchronous best-effort size().
+ */
+
+function session(id: string, over: Partial<SessionContext> = {}): SessionContext {
+  return {
+    sessionId: id,
+    audience: 'did:key:zServer',
+    nonce: `nonce-${id}`,
+    timestamp: 1000,
+    createdAt: 1000,
+    lastActivity: 1000,
+    ttlMinutes: 30,
+    identityState: 'anonymous',
+    ...over,
+  };
+}
+
+describe('MemorySessionStore', () => {
+  it('set then get returns the session and counts it', async () => {
+    const store = new MemorySessionStore();
+    await store.set('s1', session('s1'));
+    expect((await store.get('s1'))?.sessionId).toBe('s1');
+    expect(store.size()).toBe(1);
+  });
+
+  it('get returns undefined for an unknown id', async () => {
+    const store = new MemorySessionStore();
+    expect(await store.get('nope')).toBeUndefined();
+  });
+
+  it('delete removes the session', async () => {
+    const store = new MemorySessionStore();
+    await store.set('s1', session('s1'));
+    await store.delete('s1');
+    expect(await store.get('s1')).toBeUndefined();
+    expect(store.size()).toBe(0);
+  });
+
+  it('entries snapshots all sessions', async () => {
+    const store = new MemorySessionStore();
+    await store.set('s1', session('s1'));
+    await store.set('s2', session('s2'));
+    const ids = (await store.entries()).map(([id]) => id).sort();
+    expect(ids).toEqual(['s1', 's2']);
+  });
+
+  it('clear removes everything', async () => {
+    const store = new MemorySessionStore();
+    await store.set('s1', session('s1'));
+    await store.clear();
+    expect(store.size()).toBe(0);
+    expect(await store.entries()).toEqual([]);
+  });
+
+  it('evicts the oldest session past maxSessions (insertion order)', async () => {
+    const store = new MemorySessionStore({ maxSessions: 2 });
+    await store.set('s1', session('s1'));
+    await store.set('s2', session('s2'));
+    await store.set('s3', session('s3')); // evicts s1
+    expect(await store.get('s1')).toBeUndefined();
+    expect(await store.get('s2')).toBeDefined();
+    expect(await store.get('s3')).toBeDefined();
+    expect(store.size()).toBe(2);
+  });
+
+  it('updating an existing session neither double-counts nor evicts', async () => {
+    const store = new MemorySessionStore({ maxSessions: 2 });
+    await store.set('s1', session('s1'));
+    await store.set('s1', session('s1', { lastActivity: 2000 })); // update, not new
+    await store.set('s2', session('s2'));
+    expect(await store.get('s1')).toBeDefined();
+    expect(await store.get('s2')).toBeDefined();
+    expect(store.size()).toBe(2);
+  });
+
+  it('cleanup compacts bookkeeping for deleted ids without resurrecting them', async () => {
+    const store = new MemorySessionStore({ maxSessions: 2 });
+    await store.set('s1', session('s1'));
+    await store.delete('s1');
+    await store.cleanup();
+    await store.set('s2', session('s2'));
+    await store.set('s3', session('s3'));
+    expect(await store.get('s1')).toBeUndefined();
+    expect(await store.get('s2')).toBeDefined();
+    expect(await store.get('s3')).toBeDefined();
+  });
+});

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -5,3 +5,9 @@ export {
   type SessionConfig,
   type HandshakeResult,
 } from './manager.js';
+
+export {
+  SessionStore,
+  MemorySessionStore,
+  type MemorySessionStoreOptions,
+} from './session-store.js';

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -22,6 +22,7 @@ import {
 } from '../types/protocol.js';
 import type { CryptoProvider } from '../providers/base.js';
 import { MemoryNonceCacheProvider } from '../providers/memory.js';
+import { SessionStore, MemorySessionStore } from './session-store.js';
 import { logger } from '../logging/index.js';
 
 export interface SessionConfig {
@@ -32,7 +33,20 @@ export interface SessionConfig {
   serverDid?: string;
   /** Maximum number of concurrent sessions. Oldest sessions are evicted when exceeded. Default: 10000 */
   maxSessions?: number;
-  /** Policy for _meta field validation in proof verification. Default: 'strict' */
+  /**
+   * Optional pluggable session store. Defaults to an in-memory
+   * {@link MemorySessionStore} that reproduces the prior single-process
+   * behavior. Inject a durable {@link SessionStore} (Redis / Durable Object /
+   * DB) to make sessions survive restarts and resolve across instances (enables
+   * the wallet-less cross-instance retry + proof-nonce continuity).
+   */
+  sessionStore?: SessionStore;
+  /**
+   * Policy for non-KYA-OS `_meta` keys during proof verification (SEP-414).
+   * Default 'strict' IGNORES foreign keys (never hashed, trusted, or rejected);
+   * 'allow-extensions' surfaces them. Neither rejects coexisting reserved keys
+   * such as `io.modelcontextprotocol/*` or `traceparent`. See {@link MetaPolicy}.
+   */
   metaPolicy?: MetaPolicy;
 }
 
@@ -47,19 +61,19 @@ export interface HandshakeResult {
 }
 
 export class SessionManager {
-  private config: Required<Omit<SessionConfig, 'absoluteSessionLifetime' | 'serverDid' | 'maxSessions' | 'metaPolicy'>> & {
+  private config: Required<Omit<SessionConfig, 'absoluteSessionLifetime' | 'serverDid' | 'maxSessions' | 'metaPolicy' | 'sessionStore'>> & {
     absoluteSessionLifetime?: number;
     serverDid?: string;
     metaPolicy: MetaPolicy;
   };
   private cryptoProvider: CryptoProvider;
-  private sessions = new Map<string, SessionContext>();
-  private sessionInsertionOrder: string[] = [];
-  private maxSessions: number;
+  private sessionStore: SessionStore;
 
   constructor(cryptoProvider: CryptoProvider, config: SessionConfig = {}) {
     this.cryptoProvider = cryptoProvider;
-    this.maxSessions = config.maxSessions ?? 10_000;
+    this.sessionStore =
+      config.sessionStore ??
+      new MemorySessionStore({ maxSessions: config.maxSessions ?? 10_000 });
     this.config = {
       timestampSkewSeconds: config.timestampSkewSeconds ?? 120,
       sessionTtlMinutes: config.sessionTtlMinutes ?? 30,
@@ -165,9 +179,7 @@ export class SessionManager {
         ...(clientInfo && { clientInfo }),
       };
 
-      this.evictIfNeeded();
-      this.sessions.set(sessionId, session);
-      this.sessionInsertionOrder.push(sessionId);
+      await this.sessionStore.set(sessionId, session);
 
       return { success: true, session };
     } catch (error) {
@@ -192,7 +204,7 @@ export class SessionManager {
    * @returns Session context if valid, null if expired or not found
    */
   async getSession(sessionId: string): Promise<SessionContext | null> {
-    const session = this.sessions.get(sessionId);
+    const session = await this.sessionStore.get(sessionId);
     if (!session) return null;
 
     const now = Math.floor(Date.now() / 1000);
@@ -200,7 +212,7 @@ export class SessionManager {
     const maxIdleSeconds = session.ttlMinutes * 60;
 
     if (idleTimeSeconds > maxIdleSeconds) {
-      this.sessions.delete(sessionId);
+      await this.sessionStore.delete(sessionId);
       return null;
     }
 
@@ -208,13 +220,13 @@ export class SessionManager {
       const sessionAgeSeconds = now - session.createdAt;
       const maxAgeSeconds = this.config.absoluteSessionLifetime * 60;
       if (sessionAgeSeconds > maxAgeSeconds) {
-        this.sessions.delete(sessionId);
+        await this.sessionStore.delete(sessionId);
         return null;
       }
     }
 
     session.lastActivity = now;
-    this.sessions.set(sessionId, session);
+    await this.sessionStore.set(sessionId, session);
     return session;
   }
 
@@ -283,19 +295,10 @@ export class SessionManager {
       .replace(/=/g, '');
   }
 
-  private evictIfNeeded(): void {
-    while (this.sessions.size >= this.maxSessions && this.sessionInsertionOrder.length > 0) {
-      const oldest = this.sessionInsertionOrder.shift();
-      if (oldest) {
-        this.sessions.delete(oldest);
-      }
-    }
-  }
-
   async cleanup(): Promise<void> {
     const now = Math.floor(Date.now() / 1000);
 
-    for (const [sessionId, session] of this.sessions.entries()) {
+    for (const [sessionId, session] of await this.sessionStore.entries()) {
       const idleTimeSeconds = now - session.lastActivity;
       const maxIdleSeconds = session.ttlMinutes * 60;
       let expired = idleTimeSeconds > maxIdleSeconds;
@@ -307,14 +310,11 @@ export class SessionManager {
       }
 
       if (expired) {
-        this.sessions.delete(sessionId);
+        await this.sessionStore.delete(sessionId);
       }
     }
 
-    this.sessionInsertionOrder = this.sessionInsertionOrder.filter(
-      id => this.sessions.has(id)
-    );
-
+    await this.sessionStore.cleanup();
     await this.config.nonceCache.cleanup();
   }
 
@@ -328,7 +328,7 @@ export class SessionManager {
     };
   } {
     return {
-      activeSessions: this.sessions.size,
+      activeSessions: this.sessionStore.size(),
       config: {
         timestampSkewSeconds: this.config.timestampSkewSeconds,
         sessionTtlMinutes: this.config.sessionTtlMinutes,
@@ -338,9 +338,8 @@ export class SessionManager {
     };
   }
 
-  clearSessions(): void {
-    this.sessions.clear();
-    this.sessionInsertionOrder = [];
+  async clearSessions(): Promise<void> {
+    await this.sessionStore.clear();
   }
 }
 

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -1,0 +1,120 @@
+/**
+ * SessionStore — the optional provider seam for KYA-OS session persistence.
+ *
+ * The KYA-OS session is a convenience layer (a stable context for proof-nonce
+ * generation and wallet-less `getBySession` grant resolution), NOT the durable
+ * authority — that is the per-request holder-of-key proof (§7) and the
+ * DID-anchored grant (§6). So this seam is OPTIONAL: it defaults to an in-memory
+ * implementation wrapping a Map, exactly reproducing the prior single-process
+ * behavior. Inject a Redis / Durable Object / database-backed store to make
+ * sessions (and therefore the wallet-less cross-instance retry and proof-nonce
+ * continuity) survive restarts and resolve across load-balanced instances —
+ * mirroring the {@link NonceCacheProvider} / GrantStore precedent.
+ *
+ * Expiry POLICY (idle TTL, absolute lifetime) lives in the SessionManager, which
+ * owns the session config; the store is plain persistence. The manager sweeps
+ * expired records by iterating {@link SessionStore.entries} and deleting them, so
+ * a durable backing MAY instead rely on a backend TTL and return `[]` from
+ * `entries()`.
+ */
+
+import type { SessionContext } from '../types/protocol.js';
+
+/**
+ * Persistence seam for KYA-OS sessions. Implementations store a session by id,
+ * read it back, delete it, enumerate for the manager's TTL sweep, and report a
+ * best-effort count.
+ */
+export abstract class SessionStore {
+  /** Read a session by id, or undefined if absent. */
+  abstract get(sessionId: string): Promise<SessionContext | undefined>;
+  /** Persist (or replace) a session. Implementations enforce their own capacity. */
+  abstract set(sessionId: string, session: SessionContext): Promise<void>;
+  /** Delete a session by id. */
+  abstract delete(sessionId: string): Promise<void>;
+  /**
+   * Snapshot of all (sessionId, session) entries — the SessionManager's TTL
+   * sweep iterates this. Durable backings that rely on a backend TTL MAY return
+   * an empty array.
+   */
+  abstract entries(): Promise<Array<[string, SessionContext]>>;
+  /** Maintenance hook (e.g. compact bookkeeping / drop expired). */
+  abstract cleanup(): Promise<void>;
+  /** Remove all sessions (admin / test reset). */
+  abstract clear(): Promise<void>;
+  /**
+   * Best-effort current count for diagnostics: exact for the in-memory impl,
+   * a last-known/approximate value for durable backings.
+   */
+  abstract size(): number;
+}
+
+export interface MemorySessionStoreOptions {
+  /**
+   * Maximum concurrent sessions. The oldest (by insertion order) are evicted
+   * when the limit is reached, matching the prior SessionManager behavior.
+   * Default: 10000.
+   */
+  maxSessions?: number;
+}
+
+/**
+ * In-memory {@link SessionStore} — the dev/reference implementation, wrapping a
+ * Map plus insertion-order eviction. This is the default and reproduces the
+ * prior single-process session behavior bit-for-bit. NOT for multi-instance
+ * deployments: sessions are lost on restart and not shared across instances.
+ */
+export class MemorySessionStore extends SessionStore {
+  private readonly sessions = new Map<string, SessionContext>();
+  private insertionOrder: string[] = [];
+  private readonly maxSessions: number;
+
+  constructor(options: MemorySessionStoreOptions = {}) {
+    super();
+    this.maxSessions = options.maxSessions ?? 10_000;
+  }
+
+  async get(sessionId: string): Promise<SessionContext | undefined> {
+    return this.sessions.get(sessionId);
+  }
+
+  async set(sessionId: string, session: SessionContext): Promise<void> {
+    if (!this.sessions.has(sessionId)) {
+      this.evictIfNeeded();
+      this.insertionOrder.push(sessionId);
+    }
+    this.sessions.set(sessionId, session);
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+    // insertionOrder is compacted lazily in cleanup()/evictIfNeeded — a deleted
+    // id left behind is simply skipped, never resurrected.
+  }
+
+  async entries(): Promise<Array<[string, SessionContext]>> {
+    return [...this.sessions.entries()];
+  }
+
+  async cleanup(): Promise<void> {
+    this.insertionOrder = this.insertionOrder.filter((id) => this.sessions.has(id));
+  }
+
+  async clear(): Promise<void> {
+    this.sessions.clear();
+    this.insertionOrder = [];
+  }
+
+  size(): number {
+    return this.sessions.size;
+  }
+
+  /** Evict oldest sessions (insertion order) until below capacity. */
+  private evictIfNeeded(): void {
+    while (this.sessions.size >= this.maxSessions && this.insertionOrder.length > 0) {
+      const oldest = this.insertionOrder.shift();
+      // Skip ids already deleted; only a live id counts as an eviction.
+      if (oldest !== undefined) this.sessions.delete(oldest);
+    }
+  }
+}

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -422,9 +422,15 @@ export const AUTH_NONCE_TTL_MS = 120_000;
 export const ANON_NONCE_TTL_MS = 60_000;
 
 /**
- * Policy for _meta field validation in proof verification.
- * - 'strict': reject responses with _meta keys other than 'proof'
- * - 'allow-extensions': permit additional keys in _meta (not included in hashes)
+ * Policy for non-KYA-OS `_meta` keys during proof verification (MCP 2026-07-28 /
+ * SEP-414). `_meta` is shared real estate, so both policies share one zero-trust
+ * boundary — only the KYA-OS proof key is ever hashed or trusted, and no foreign
+ * key is ever a cause for rejection.
+ * - 'strict' (default): non-KYA-OS keys (including reserved
+ *   `io.modelcontextprotocol/*` and W3C trace-context keys) are ignored — never
+ *   hashed, trusted, or rejected.
+ * - 'allow-extensions': identical trust boundary, but non-KYA-OS keys are
+ *   surfaced to the application layer instead of discarded.
  */
 export type MetaPolicy = 'strict' | 'allow-extensions';
 


### PR DESCRIPTION
Updates the package's `_meta` handling to bring it in line with the upcoming MCP 2026-07-28 RC.

All new seams are optional and default to in-memory, so single-process behavior is unchanged unless you opt in.

- `_meta`: emit the detached proof under `org.kya-os/proof` (single constant `KYA_OS_PROOF_META_KEY`); the verifier still accepts legacy bare `proof`. Relax `strict` metaPolicy to ignore reserved MCP/trace keys rather than reject them.
- `PendingFlowStore`: a pluggable seam for the OAuth PKCE/pending state (was an in-process Map), so the consent callback can complete on any instance.
- `GrantStore` wired into the retry path: on a no-delegation call, resolve an existing grant — holder-of-key first (`getByAgent`, gated on a verified `_kyaos_proof`; the agent DID is re-proven per request, never trusted from a hint), then the session bearer capability (`getBySession`, which never crosses sessions). On a verified delegation, bind a durable grant so the next call, on any instance, avoiding static handling.
- Confused-deputy gate + tests: a grant for agent A never resolves without A's verified holder-of-key proof (no proof, a proof forged with another key, and cross-session grants are all challenged).
- De-globalize the middleware: drop the redundant `sessionNonces` map (the nonce already lives on the session record) and make the threaded `sessionId` the primary resolver. `activeSessionId` is kept only as the single-process autoSession/Inspector fallback — the transport layer doesn't thread a sessionId into the proof path, so removing it regressed the transport tests.
- Optional `SessionStore` seam for the wallet-less cross-instance path.
- New `examples/consent-persistence` demo (file-backed stores, two instances + restart) wired into `pnpm demo`.


Companion spec: #97