### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-17
+
+Durable consent persistence. Pluggable `GrantStore` / `PendingFlowStore` /
+`SessionStore` seams so consent, grant, and PKCE state survive restarts and
+resolve across load-balanced instances — the holder-of-key (`getByAgent`)
+no-paste retry, with session-bearer (`getBySession`) as a fallback. The detached
+proof is namespaced under `_meta["org.kya-os/proof"]` and still dual-emitted
+under the legacy bare key (ON for all of 1.x, dropped at 2.0). Additive over
+1.6.x, with one documented behavioral change: a `strict` verifier now ignores
+MCP-reserved foreign `_meta` keys instead of rejecting them.
+
 ### Added
 
 - **Durable consent persistence (optional, in-memory defaults — no breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Releases **v1.7.0** (minor) — the durable consent persistence work merged in #98, with the Appendix A error-code alignment from #97 also carried in these release notes.

### Highlights
- **Durable consent persistence** — pluggable `GrantStore` / `PendingFlowStore` / `SessionStore` so consent, grant, and PKCE state survive restarts and resolve across load-balanced instances. The holder-of-key `getByAgent` no-paste retry, with session-bearer `getBySession` as a fallback. In-memory defaults — no breaking change.
- **Namespaced + dual-emitted proof** — the detached proof now lives under `_meta["org.kya-os/proof"]`, still emitted and accepted under the legacy bare `proof` key. The legacy mirror stays ON for all of 1.x and is dropped at 2.0 (`emitLegacyProofKey`).
- **Behavioral (documented):** a `strict` `metaPolicy` now *ignores* MCP-reserved foreign `_meta` keys (`io.modelcontextprotocol/*`, W3C trace-context) instead of rejecting them — the zero-trust boundary is unchanged (only the KYA-OS proof key is hashed/trusted). Migration note in the CHANGELOG.

### Why minor, not major
Additive over 1.6.x. The one behavioral change is a relaxation that aligns with MCP 2026-07-28, leaves the security boundary intact, and is documented with a migration line. 2.0 is reserved for removing the legacy proof key.

### Changes
- `package.json` 1.6.1 → 1.7.0
- `CHANGELOG.md` `[Unreleased]` → `[1.7.0] - 2026-06-17`
