### PR TITLE
Conformance: independent protocol test-vector harness + governance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # npm — the package itself and its tooling.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the CI/coverage/conformance workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,35 @@ jobs:
           }
           Write-Host "No product contamination found"
 
+  conformance:
+    name: Protocol Conformance Harness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Type-check the harness against the live source (it is outside src/, so
+      # the package build does not cover it).
+      - name: Type check conformance harness
+        run: pnpm run conformance:typecheck
+
+      # Run every committed conformance vector through the reference adapter.
+      # Exits non-zero on ANY mismatch — a tampered/negative vector the
+      # implementation fails to reject, or a positive vector it fails to accept.
+      - name: Run conformance vectors
+        run: pnpm run conformance
+
   codeql:
     name: CodeQL Security Scan
     runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,33 @@
+# Adjust handles/teams as needed; @H0BB5 is a safe default owner.
+#
+# Default owner for everything in the repo.
+* @H0BB5
+
+# ── Security-critical paths (explicit ownership) ──────────────────────────────
+# Cryptographic primitives, proof signing/verification, and canonicalization.
+/src/proof/                 @H0BB5
+/src/utils/crypto-service.ts @H0BB5
+/src/utils/ed25519-constants.ts @H0BB5
+/src/providers/node-crypto.ts @H0BB5
+/src/providers/web-crypto.ts @H0BB5
+
+# Delegation, DID resolution (did:key / did:web), status-list revocation,
+# chain enforcement, audience binding, and holder binding — the authorization
+# and SSRF-adjacent surface.
+/src/delegation/            @H0BB5
+
+# Authentication handshake and authorization subsystems.
+/src/auth/                  @H0BB5
+/src/authz/                 @H0BB5
+/src/policy/                @H0BB5
+
+# Session management (nonce replay, session identity state).
+/src/session/               @H0BB5
+
+# The independent conformance harness and its test vectors — changes here alter
+# what "conformant" means for every implementation.
+/conformance/               @H0BB5
+
+# CI, governance, and dependency automation.
+/.github/                   @H0BB5
+/CODEOWNERS                 @H0BB5

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -394,4 +394,88 @@ Badge assets will be provided upon successful conformance submission.
 
 ---
 
+## Independent Conformance Harness
+
+The `conformance/` directory contains an **implementation-agnostic** test harness:
+a set of versioned, pre-signed test vectors plus a runner that asserts a verifier
+ACCEPTS every positive vector and REJECTS every negative one. It exercises the
+protocol's **public** verify primitives — it does not fork verification logic — so
+the reference implementation and any third-party implementation are held to the
+exact same evidence.
+
+### What it covers
+
+Each vector is a self-contained JSON object — `{ id, category, description, input,
+expected: "pass" | "fail", reason }` — and carries fully-formed signed artifacts
+so it is reproducible against any implementation without re-signing.
+
+| File | Category | Positive | Negative |
+|------|----------|----------|----------|
+| `vectors/signed-proof.json` | Detached proof verification | valid signature + in-window ts | tampered signature, tampered meta, wrong key, timestamp skew exceeded |
+| `vectors/delegation-chain.json` | Delegation chain verification | single-hop, two-hop attenuated | broken issuer↔subject linkage, scope widening, tampered signature, audience mismatch |
+| `vectors/status-list.json` | StatusList2021 revocation | active (bit unset) | revoked (bit set) |
+| `vectors/did-key-resolution.json` | did:key resolution | valid Ed25519 | malformed multibase, wrong method |
+| `vectors/did-web-resolution.json` | did:web resolution | well-formed id-matched document | document id mismatch, not found |
+
+A `fail` vector passes the suite only when the implementation correctly **rejects**
+it. The runner exits non-zero on any mismatch.
+
+### Running the reference implementation
+
+```bash
+pnpm install
+pnpm run conformance               # run all vectors, exit non-zero on any mismatch
+pnpm run conformance -- --category signed-proof   # one category
+pnpm run conformance -- --json     # machine-readable report
+```
+
+CI runs this on every push/PR (the **Protocol Conformance Harness** job).
+
+### Regenerating the vectors
+
+The committed JSON is produced from the reference primitives:
+
+```bash
+pnpm run conformance:generate
+```
+
+Re-running mints fresh keys but preserves every positive/negative relationship by
+construction.
+
+### Running the harness against YOUR implementation
+
+The harness is decoupled from `@kya-os/mcp` through a single documented port,
+`ConformanceAdapter` (`conformance/types.ts`). Implement its methods over your own
+verifier and feed it the same vectors:
+
+```ts
+import { loadVectors } from "./conformance/loader.js";
+import { runConformance, formatReport } from "./conformance/runner.js";
+import type { ConformanceAdapter } from "./conformance/types.js";
+
+const myAdapter: ConformanceAdapter = {
+  name: "my-implementation",
+  async verifySignedProof(input)      { /* return { outcome: "pass" | "fail" } */ },
+  async verifyDelegationChain(input)  { /* ... */ },
+  async verifyStatusList(input)       { /* ... */ },
+  async resolveDidKey(input)          { /* ... */ },
+  async resolveDidWeb(input)          { /* ... */ },
+};
+
+const report = await runConformance(myAdapter, loadVectors());
+console.log(formatReport(report));
+process.exit(report.allMatched ? 0 : 1);
+```
+
+**Adapter contract.** Every method takes a vector's `input` and returns
+`{ outcome: "pass" | "fail", detail? }`, where `pass` means your implementation
+ACCEPTED the artifact and `fail` means it REJECTED it. Methods MUST be
+**fail-closed**: any error, malformed input, or unmet security property maps to
+`{ outcome: "fail" }` — never throw. The runner records a thrown error as a
+harness failure, not a rejection. The reference adapter
+(`conformance/reference-adapter.ts`) is the worked example wiring these methods to
+the public `@kya-os/mcp` primitives.
+
+---
+
 *End of Conformance Requirements*

--- a/conformance/__tests__/conformance.test.ts
+++ b/conformance/__tests__/conformance.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Conformance harness TDD/regression test.
+ *
+ * The reference implementation MUST pass 100% of positive vectors and reject
+ * 100% of negative vectors. This test runs the bundled vectors through the
+ * reference adapter — the same path `npm run conformance` and CI use — and fails
+ * the build on ANY mismatch, so a regression in a verify primitive surfaces here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadVectors } from '../loader.js';
+import { runConformance } from '../runner.js';
+import { ReferenceConformanceAdapter } from '../reference-adapter.js';
+import type { VectorCategory } from '../types.js';
+
+const REQUIRED_CATEGORIES: VectorCategory[] = [
+  'signed-proof',
+  'delegation-chain',
+  'status-list',
+  'did-key-resolution',
+  'did-web-resolution',
+];
+
+describe('KYA-OS conformance — reference implementation', () => {
+  const vectors = loadVectors();
+
+  it('covers every required category with both positive and negative vectors', () => {
+    for (const category of REQUIRED_CATEGORIES) {
+      const inCategory = vectors.filter((v) => v.category === category);
+      expect(inCategory.length, `category ${category} has vectors`).toBeGreaterThan(0);
+      expect(
+        inCategory.some((v) => v.expected === 'pass'),
+        `category ${category} has a positive vector`,
+      ).toBe(true);
+      expect(
+        inCategory.some((v) => v.expected === 'fail'),
+        `category ${category} has a negative vector`,
+      ).toBe(true);
+    }
+  });
+
+  it('passes 100% of positive vectors and rejects 100% of negative vectors', async () => {
+    const report = await runConformance(new ReferenceConformanceAdapter(), vectors);
+    const mismatches = report.results.filter((r) => !r.ok);
+    // Surface a readable diff if anything fails.
+    expect(
+      mismatches.map((m) => `${m.id}: expected ${m.expected}, got ${m.actual} (${m.detail ?? ''})`),
+    ).toEqual([]);
+    expect(report.allMatched).toBe(true);
+    expect(report.passed).toBe(vectors.length);
+  });
+
+  it('the runner exits clean only when every vector matches (allMatched invariant)', async () => {
+    const report = await runConformance(new ReferenceConformanceAdapter(), vectors);
+    expect(report.failed).toBe(0);
+  });
+});

--- a/conformance/bin.ts
+++ b/conformance/bin.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * KYA-OS conformance harness CLI.
+ *
+ * Loads the bundled vectors, runs them through the reference adapter (or a
+ * filtered subset), prints the report, and exits non-zero on ANY mismatch — so a
+ * single tampered proof that the implementation fails to reject breaks CI.
+ *
+ * Usage:
+ *   tsx conformance/bin.ts                 # run all vectors (reference adapter)
+ *   tsx conformance/bin.ts --category signed-proof
+ *   tsx conformance/bin.ts --json          # machine-readable report
+ *
+ * Third parties: import { runConformance } from './runner.js' and pass your own
+ * ConformanceAdapter. See CONFORMANCE.md.
+ */
+
+import { Command } from 'commander';
+import { loadVectors } from './loader.js';
+import { runConformance, formatReport } from './runner.js';
+import { ReferenceConformanceAdapter } from './reference-adapter.js';
+import type { VectorCategory } from './types.js';
+
+const program = new Command();
+
+program
+  .name('kya-os-conformance')
+  .description('Run the KYA-OS protocol conformance vectors against the reference implementation')
+  .option('-c, --category <category>', 'only run vectors in this category')
+  .option('--json', 'emit a machine-readable JSON report')
+  .action(async (opts: { category?: string; json?: boolean }) => {
+    let vectors = loadVectors();
+    if (opts.category) {
+      vectors = vectors.filter((v) => v.category === (opts.category as VectorCategory));
+      if (vectors.length === 0) {
+        console.error(`No vectors found for category "${opts.category}"`);
+        process.exit(2);
+      }
+    }
+
+    const report = await runConformance(new ReferenceConformanceAdapter(), vectors);
+
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(formatReport(report));
+    }
+
+    process.exit(report.allMatched ? 0 : 1);
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error(`Conformance runner error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(2);
+});

--- a/conformance/crypto-kit.ts
+++ b/conformance/crypto-kit.ts
@@ -1,0 +1,102 @@
+/**
+ * Crypto kit shared by the reference adapter and the vector generator.
+ *
+ * Centralizes the Ed25519 VC signing/verification convention
+ * (`Ed25519Signature2020` over RFC 8785 canonicalized VC, minus `proof`) and the
+ * gzip compression StatusList2021 uses, so the generator and the verifier cannot
+ * drift. Pure Node built-ins + the package's public canonicalize/bitstring
+ * primitives — no test-only helpers.
+ */
+
+import * as zlib from 'node:zlib';
+import { canonicalizeJSON } from '../src/delegation/utils.js';
+import type {
+  CompressionFunction,
+  DecompressionFunction,
+} from '../src/delegation/bitstring.js';
+import type { NodeCryptoProvider } from '../src/providers/node-crypto.js';
+import type { DelegationCredential, Proof } from '../src/index.js';
+import type { SignatureVerificationFunction } from '../src/delegation/vc-verifier.js';
+
+/** gzip compressor matching StatusList2021's expected encoding. */
+export const conformanceCompressor: CompressionFunction = {
+  compress(data: Uint8Array): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      zlib.gzip(Buffer.from(data), (err, result) =>
+        err ? reject(err) : resolve(new Uint8Array(result)),
+      );
+    });
+  },
+};
+
+export const conformanceDecompressor: DecompressionFunction = {
+  decompress(data: Uint8Array): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      zlib.gunzip(Buffer.from(data), (err, result) =>
+        err ? reject(err) : resolve(new Uint8Array(result)),
+      );
+    });
+  },
+};
+
+/**
+ * Sign a VC-shaped object (`Ed25519Signature2020`). Strips any existing `proof`,
+ * canonicalizes (RFC 8785), signs with `privateKeyBase64`, and returns the proof
+ * block. This is the exact convention {@link ed25519SignatureVerifier} checks.
+ */
+export async function signVC(
+  crypto: NodeCryptoProvider,
+  vcWithoutProof: Record<string, unknown>,
+  privateKeyBase64: string,
+  verificationMethod: string,
+): Promise<Proof> {
+  const unsigned = { ...vcWithoutProof };
+  delete unsigned['proof'];
+  const canonical = canonicalizeJSON(unsigned);
+  const signature = await crypto.sign(new TextEncoder().encode(canonical), privateKeyBase64);
+  return {
+    type: 'Ed25519Signature2020',
+    created: '2026-01-01T00:00:00.000Z',
+    verificationMethod,
+    proofPurpose: 'assertionMethod',
+    proofValue: Buffer.from(signature).toString('base64url'),
+  };
+}
+
+/**
+ * Verify the `Ed25519Signature2020` proof a {@link signVC}-produced credential
+ * carries. Wired into {@link DelegationCredentialVerifier} as its
+ * `signatureVerifier`.
+ */
+export function ed25519SignatureVerifier(
+  crypto: NodeCryptoProvider,
+): SignatureVerificationFunction {
+  return async (vc: DelegationCredential, publicKeyJwk: unknown) => {
+    try {
+      const jwk = publicKeyJwk as { x?: string };
+      if (!jwk.x) {
+        return { valid: false, reason: 'missing public key x coordinate' };
+      }
+      const publicKeyBase64 = Buffer.from(jwk.x, 'base64url').toString('base64');
+      const unsigned = { ...(vc as Record<string, unknown>) };
+      delete unsigned['proof'];
+      const canonical = canonicalizeJSON(unsigned);
+      const proofValue = vc.proof?.proofValue;
+      if (!proofValue) {
+        return { valid: false, reason: 'missing proofValue' };
+      }
+      const signature = new Uint8Array(Buffer.from(proofValue as string, 'base64url'));
+      const valid = await crypto.verify(
+        new TextEncoder().encode(canonical),
+        signature,
+        publicKeyBase64,
+      );
+      return { valid, reason: valid ? undefined : 'signature verification failed' };
+    } catch (error) {
+      return {
+        valid: false,
+        reason: `verification error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  };
+}

--- a/conformance/generate-vectors.ts
+++ b/conformance/generate-vectors.ts
@@ -1,0 +1,582 @@
+#!/usr/bin/env node
+/**
+ * Generator for the KYA-OS conformance vectors.
+ *
+ * Produces the committed `conformance/vectors/*.json` files by minting real
+ * signed artifacts (proofs, delegation credentials, status lists, DID
+ * documents) with the package's own primitives, then deriving negative variants
+ * by surgical tampering. The OUTPUT (the JSON) is what ships and is
+ * implementation-agnostic; this generator is a dev tool, run via
+ * `npm run conformance:generate`.
+ *
+ * Determinism: keypairs are minted once per run; the resulting JSON is committed,
+ * so the suite is stable across machines/CI. Re-running regenerates fresh keys —
+ * that is fine because positive/negative relationships are preserved by
+ * construction.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { canonicalize } from 'json-canonicalize';
+import { CompactSign, importPKCS8 } from 'jose';
+import { NodeCryptoProvider } from '../src/providers/node-crypto.js';
+import { ED25519_PKCS8_DER_HEADER, ED25519_KEY_SIZE } from '../src/utils/ed25519-constants.js';
+import { base64ToBytes, bytesToBase64 } from '../src/utils/base64.js';
+import {
+  ProofGenerator,
+  generateDidKeyFromBase64,
+  didKeyFragment,
+  wrapDelegationAsVC,
+  BitstringManager,
+  buildDidWebDocument,
+  type DelegationCredential,
+  type StatusList2021Credential,
+  type CredentialStatus,
+  type DetachedProof,
+} from '../src/index.js';
+import { extractPublicKeyFromDidKey, publicKeyToJwk } from '../src/delegation/did-key-resolver.js';
+import { VECTORS_DIR } from './loader.js';
+import {
+  signVC,
+  conformanceCompressor,
+  conformanceDecompressor,
+} from './crypto-kit.js';
+import type {
+  ConformanceVector,
+  VectorFile,
+} from './types.js';
+
+const crypto = new NodeCryptoProvider();
+const NOW = 1_750_000_000; // fixed epoch-seconds anchor for proof timestamps
+const SERVER_DID = 'did:web:server.example.com';
+
+interface Party {
+  did: string;
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+}
+
+async function mintParty(): Promise<Party> {
+  const { privateKey, publicKey } = await crypto.generateKeyPair();
+  const did = generateDidKeyFromBase64(publicKey);
+  return { did, kid: `${did}#${didKeyFragment(did)}`, privateKey, publicKey };
+}
+
+function jwkFor(party: Party) {
+  const raw = extractPublicKeyFromDidKey(party.did)!;
+  const jwk = publicKeyToJwk(raw);
+  return { ...jwk, kid: party.kid };
+}
+
+function writeFile(file: VectorFile, name: string): void {
+  writeFileSync(join(VECTORS_DIR, name), JSON.stringify(file, null, 2) + '\n', 'utf8');
+  console.log(`wrote ${name} (${file.vectors.length} vectors)`);
+}
+
+// ── signed-proof vectors ──────────────────────────────────────────────────────
+
+async function signedProofVectors(): Promise<VectorFile> {
+  const agent = await mintParty();
+  const gen = new ProofGenerator(
+    { did: agent.did, kid: agent.kid, privateKey: agent.privateKey, publicKey: agent.publicKey },
+    crypto,
+  );
+  const session = {
+    sessionId: 'sess_conformance',
+    audience: SERVER_DID,
+    nonce: 'nonce-conformance-0001',
+    timestamp: NOW,
+    createdAt: NOW,
+    lastActivity: NOW,
+    ttlMinutes: 30,
+    identityState: 'anonymous' as const,
+  };
+
+  const draft = await gen.generateProof(
+    { method: 'tools/call', params: { name: 'echo', arguments: { msg: 'hi' } } },
+    { data: { output: 'hi' } },
+    session,
+  );
+  // Pin the timestamp to the anchor and re-sign so the JWS matches the pinned ts.
+  const validRetimed = await signProofMeta(agent, { ...draft.meta, ts: NOW });
+
+  const jwk = jwkFor(agent);
+
+  // Negative: tampered signature (flip the JWS).
+  const tamperedSig: DetachedProof = {
+    ...validRetimed,
+    jws: flipLastChar(validRetimed.jws),
+  };
+
+  // Negative: tampered meta (requestHash mutated; signature no longer matches).
+  const tamperedMeta: DetachedProof = {
+    ...validRetimed,
+    meta: { ...validRetimed.meta, requestHash: 'sha256:' + 'de'.repeat(32) },
+  };
+
+  // Negative: wrong public key (different agent).
+  const wrongAgent = await mintParty();
+  const wrongJwk = jwkFor(wrongAgent);
+
+  // Negative: timestamp outside the skew window (authentically signed at a stale ts).
+  const staleSigned = await signProofMeta(agent, { ...validRetimed.meta, ts: NOW - 10_000 });
+
+  const vectors: ConformanceVector[] = [
+    {
+      id: 'signed-proof/valid-basic',
+      category: 'signed-proof',
+      description: 'A well-formed proof with a valid Ed25519 signature and in-window timestamp',
+      expected: 'pass',
+      reason: 'Signature verifies against the signer key and ts is within skew',
+      input: { proof: validRetimed, publicKeyJwk: jwk, now: NOW, skewSeconds: 300 },
+    },
+    {
+      id: 'signed-proof/tampered-signature',
+      category: 'signed-proof',
+      description: 'Proof whose JWS signature bytes were altered',
+      expected: 'fail',
+      reason: 'A mutated signature must fail EdDSA verification',
+      input: { proof: tamperedSig, publicKeyJwk: jwk, now: NOW, skewSeconds: 300 },
+    },
+    {
+      id: 'signed-proof/tampered-meta',
+      category: 'signed-proof',
+      description: 'Proof whose signed requestHash was altered after signing',
+      expected: 'fail',
+      reason: 'The reconstructed canonical payload no longer matches the signature',
+      input: { proof: tamperedMeta, publicKeyJwk: jwk, now: NOW, skewSeconds: 300 },
+    },
+    {
+      id: 'signed-proof/wrong-key',
+      category: 'signed-proof',
+      description: 'Valid proof verified against a different agent public key',
+      expected: 'fail',
+      reason: 'Signature does not verify under an unrelated key',
+      input: { proof: validRetimed, publicKeyJwk: wrongJwk, now: NOW, skewSeconds: 300 },
+    },
+    {
+      id: 'signed-proof/timestamp-skew-exceeded',
+      category: 'signed-proof',
+      description: 'Authentically signed proof whose timestamp is far outside the skew window',
+      expected: 'fail',
+      reason: 'ts is 10000s before now with a 300s skew — replay/stale guard must reject',
+      input: { proof: staleSigned, publicKeyJwk: jwk, now: NOW, skewSeconds: 300 },
+    },
+  ];
+
+  return { version: '1.0.0', category: 'signed-proof', vectors };
+}
+
+/**
+ * Sign a proof meta into a DetachedProof using the SAME canonical payload shape
+ * the package's ProofGenerator/ProofVerifier use (RFC 8785). The generator needs
+ * to mint proofs at arbitrary pinned timestamps; ProofGenerator only signs at
+ * Date.now(), so the generator reproduces the documented payload shape directly.
+ */
+async function signProofMeta(party: Party, meta: DetachedProof['meta']): Promise<DetachedProof> {
+  const payload = {
+    aud: meta.audience,
+    sub: meta.did,
+    iss: meta.did,
+    requestHash: meta.requestHash,
+    ...(meta.responseHash !== undefined && { responseHash: meta.responseHash }),
+    ts: meta.ts,
+    nonce: meta.nonce,
+    sessionId: meta.sessionId,
+    ...(meta.scopeId && { scopeId: meta.scopeId }),
+    ...(meta.delegationRef && { delegationRef: meta.delegationRef }),
+    ...(meta.clientDid && { clientDid: meta.clientDid }),
+    ...(meta.outcome && { outcome: meta.outcome }),
+    ...(meta.reason && { reason: meta.reason }),
+  };
+  const canonical = canonicalize(payload as Parameters<typeof canonicalize>[0]);
+  const pem = formatPrivateKeyAsPEM(party.privateKey);
+  const key = await importPKCS8(pem, 'EdDSA');
+  const jws = await new CompactSign(new TextEncoder().encode(canonical))
+    .setProtectedHeader({ alg: 'EdDSA', kid: party.kid })
+    .sign(key);
+  return { jws, meta };
+}
+
+function formatPrivateKeyAsPEM(base64PrivateKey: string): string {
+  const keyData = base64ToBytes(base64PrivateKey);
+  const rawKey = keyData.subarray(0, ED25519_KEY_SIZE);
+  const fullKey = new Uint8Array(ED25519_PKCS8_DER_HEADER.length + rawKey.length);
+  fullKey.set(ED25519_PKCS8_DER_HEADER);
+  fullKey.set(rawKey, ED25519_PKCS8_DER_HEADER.length);
+  const b64 = bytesToBase64(fullKey);
+  const formatted = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${formatted}\n-----END PRIVATE KEY-----`;
+}
+
+function flipLastChar(jws: string): string {
+  const last = jws[jws.length - 1];
+  const swap = last === 'A' ? 'B' : 'A';
+  return jws.slice(0, -1) + swap;
+}
+
+// ── delegation-chain vectors ───────────────────────────────────────────────────
+
+function didDocFor(party: Party): Record<string, unknown> {
+  const raw = extractPublicKeyFromDidKey(party.did)!;
+  return {
+    id: party.did,
+    verificationMethod: [
+      {
+        id: party.kid,
+        type: 'Ed25519VerificationKey2020',
+        controller: party.did,
+        publicKeyJwk: publicKeyToJwk(raw),
+      },
+    ],
+    assertionMethod: [party.kid],
+    authentication: [party.kid],
+  };
+}
+
+async function buildSignedDelegation(args: {
+  issuer: Party;
+  subjectDid: string;
+  id: string;
+  parentId?: string;
+  scopes: string[];
+  audience: string | string[];
+  status?: 'active' | 'revoked';
+  credentialStatus?: CredentialStatus;
+}): Promise<DelegationCredential> {
+  const unsigned = wrapDelegationAsVC(
+    {
+      id: args.id,
+      issuerDid: args.issuer.did,
+      subjectDid: args.subjectDid,
+      vcId: `urn:uuid:${args.id}`,
+      parentId: args.parentId,
+      constraints: { scopes: args.scopes, audience: args.audience },
+      signature: '',
+      status: args.status ?? 'active',
+      createdAt: NOW * 1000,
+    },
+    {
+      issuanceDate: '2026-01-01T00:00:00.000Z',
+      ...(args.credentialStatus ? { credentialStatus: args.credentialStatus } : {}),
+    },
+  );
+  const proof = await signVC(crypto, unsigned as Record<string, unknown>, args.issuer.privateKey, args.issuer.kid);
+  return { ...unsigned, proof } as DelegationCredential;
+}
+
+async function delegationChainVectors(): Promise<VectorFile> {
+  const root = await mintParty(); // issuer (user/org)
+  const agent = await mintParty(); // leaf subject
+  const intermediary = await mintParty();
+
+  const didDocuments = {
+    [root.did]: didDocFor(root),
+    [agent.did]: didDocFor(agent),
+    [intermediary.did]: didDocFor(intermediary),
+  };
+
+  // Single-hop valid delegation root → agent.
+  const validSingle = await buildSignedDelegation({
+    issuer: root,
+    subjectDid: agent.did,
+    id: 'del-root-agent',
+    scopes: ['greeting:read'],
+    audience: SERVER_DID,
+  });
+
+  // Valid two-hop chain: root → intermediary → agent, attenuated scope.
+  const parent = await buildSignedDelegation({
+    issuer: root,
+    subjectDid: intermediary.did,
+    id: 'del-root-interm',
+    scopes: ['greeting:read', 'greeting:write'],
+    audience: SERVER_DID,
+  });
+  const child = await buildSignedDelegation({
+    issuer: intermediary,
+    subjectDid: agent.did,
+    id: 'del-interm-agent',
+    parentId: 'del-root-interm',
+    scopes: ['greeting:read'], // attenuated subset of parent
+    audience: SERVER_DID,
+  });
+
+  // Negative: broken chain — child claims a parentId that the resolved chain's
+  // parent does not match (issuerDid != parent.subjectDid).
+  const forgedChild = await buildSignedDelegation({
+    issuer: agent, // NOT the intermediary the parent delegated to
+    subjectDid: agent.did,
+    id: 'del-forged-child',
+    parentId: 'del-root-interm',
+    scopes: ['greeting:read'],
+    audience: SERVER_DID,
+  });
+
+  // Negative: scope widening — child requests a scope absent from parent.
+  const wideningChild = await buildSignedDelegation({
+    issuer: intermediary,
+    subjectDid: agent.did,
+    id: 'del-widening-child',
+    parentId: 'del-root-interm',
+    scopes: ['admin:all'], // not a subset of parent scopes
+    audience: SERVER_DID,
+  });
+
+  // Negative: tampered leaf signature.
+  const tamperedLeaf: DelegationCredential = {
+    ...validSingle,
+    proof: { ...validSingle.proof!, proofValue: flipB64url(validSingle.proof!.proofValue as string) },
+  };
+
+  // Negative: audience mismatch — credential bound to a different server.
+  const wrongAudience = await buildSignedDelegation({
+    issuer: root,
+    subjectDid: agent.did,
+    id: 'del-wrong-audience',
+    scopes: ['greeting:read'],
+    audience: 'did:web:other.example.com',
+  });
+
+  const vectors: ConformanceVector[] = [
+    {
+      id: 'delegation-chain/valid-single-hop',
+      category: 'delegation-chain',
+      description: 'A directly-issued, signed delegation bound to the server',
+      expected: 'pass',
+      reason: 'Signature, audience, and shape all valid; no parent to resolve',
+      input: { leaf: validSingle, serverDid: SERVER_DID, didDocuments },
+    },
+    {
+      id: 'delegation-chain/valid-two-hop-attenuated',
+      category: 'delegation-chain',
+      description: 'Root → intermediary → agent with a correctly attenuated child scope',
+      expected: 'pass',
+      reason: 'Linkage, audience, and scope subset all hold across the chain',
+      input: { leaf: child, ancestors: [parent], serverDid: SERVER_DID, didDocuments },
+    },
+    {
+      id: 'delegation-chain/broken-linkage',
+      category: 'delegation-chain',
+      description: 'Child issuerDid does not equal the parent subjectDid',
+      expected: 'fail',
+      reason: 'A broken issuer↔subject link must reject the chain',
+      input: { leaf: forgedChild, ancestors: [parent], serverDid: SERVER_DID, didDocuments },
+    },
+    {
+      id: 'delegation-chain/scope-widening',
+      category: 'delegation-chain',
+      description: 'Child introduces a scope absent from its parent',
+      expected: 'fail',
+      reason: 'A re-delegation may only narrow authority; widening must reject',
+      input: { leaf: wideningChild, ancestors: [parent], serverDid: SERVER_DID, didDocuments },
+    },
+    {
+      id: 'delegation-chain/tampered-signature',
+      category: 'delegation-chain',
+      description: 'Leaf credential whose Ed25519 proofValue was altered',
+      expected: 'fail',
+      reason: 'A mutated VC signature must fail verification',
+      input: { leaf: tamperedLeaf, serverDid: SERVER_DID, didDocuments },
+    },
+    {
+      id: 'delegation-chain/audience-mismatch',
+      category: 'delegation-chain',
+      description: 'Credential bound to a different server than the verifier',
+      expected: 'fail',
+      reason: 'Audience binding (confused-deputy guard) must reject a mismatched server',
+      input: { leaf: wrongAudience, serverDid: SERVER_DID, didDocuments },
+    },
+  ];
+
+  return { version: '1.0.0', category: 'delegation-chain', vectors };
+}
+
+function flipB64url(value: string): string {
+  const last = value[value.length - 1];
+  const swap = last === 'A' ? 'B' : 'A';
+  return value.slice(0, -1) + swap;
+}
+
+// ── status-list vectors ─────────────────────────────────────────────────────────
+
+async function statusListVectors(): Promise<VectorFile> {
+  const issuer = await mintParty();
+  const agent = await mintParty();
+  const didDocuments = { [issuer.did]: didDocFor(issuer) };
+
+  const listId = 'https://status.example.com/revocation/v1';
+  const listSize = 131072;
+
+  async function buildStatusList(revokedIndices: number[]): Promise<StatusList2021Credential> {
+    const bitstring = new BitstringManager(listSize, conformanceCompressor, conformanceDecompressor);
+    for (const i of revokedIndices) bitstring.setBit(i, true);
+    const encodedList = await bitstring.encode();
+    const unsigned = {
+      '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://w3id.org/vc/status-list/2021/v1',
+      ],
+      id: listId,
+      type: ['VerifiableCredential', 'StatusList2021Credential'],
+      issuer: issuer.did,
+      issuanceDate: '2026-01-01T00:00:00.000Z',
+      credentialSubject: {
+        id: `${listId}#list`,
+        type: 'StatusList2021' as const,
+        statusPurpose: 'revocation' as const,
+        encodedList,
+      },
+    };
+    const proof = await signVC(crypto, unsigned, issuer.privateKey, issuer.kid);
+    return { ...unsigned, proof } as StatusList2021Credential;
+  }
+
+  const activeIndex = 7;
+  const revokedIndex = 42;
+  const statusFor = (index: number): CredentialStatus => ({
+    id: `${listId}#${index}`,
+    type: 'StatusList2021Entry',
+    statusPurpose: 'revocation',
+    statusListIndex: index.toString(),
+    statusListCredential: listId,
+  });
+
+  const activeCred = await buildSignedDelegationWith(issuer, agent.did, 'del-active', statusFor(activeIndex));
+  const revokedCred = await buildSignedDelegationWith(issuer, agent.did, 'del-revoked', statusFor(revokedIndex));
+  const statusLists = { [listId]: await buildStatusList([revokedIndex]) };
+
+  const vectors: ConformanceVector[] = [
+    {
+      id: 'status-list/active-credential',
+      category: 'status-list',
+      description: 'Delegation whose StatusList2021 bit is 0 (not revoked)',
+      expected: 'pass',
+      reason: 'An unset revocation bit means the credential is active',
+      input: { credential: activeCred, statusLists, didDocuments, serverDid: SERVER_DID },
+    },
+    {
+      id: 'status-list/revoked-credential',
+      category: 'status-list',
+      description: 'Delegation whose StatusList2021 bit is 1 (revoked)',
+      expected: 'fail',
+      reason: 'A set revocation bit must reject the credential',
+      input: { credential: revokedCred, statusLists, didDocuments, serverDid: SERVER_DID },
+    },
+  ];
+
+  return { version: '1.0.0', category: 'status-list', vectors };
+}
+
+async function buildSignedDelegationWith(
+  issuer: Party,
+  subjectDid: string,
+  id: string,
+  credentialStatus: CredentialStatus,
+): Promise<DelegationCredential> {
+  return buildSignedDelegation({
+    issuer,
+    subjectDid,
+    id,
+    scopes: ['greeting:read'],
+    audience: SERVER_DID,
+    credentialStatus,
+  });
+}
+
+// ── did:key resolution vectors ──────────────────────────────────────────────────
+
+async function didKeyVectors(): Promise<VectorFile> {
+  const party = await mintParty();
+  const vectors: ConformanceVector[] = [
+    {
+      id: 'did-key/valid-ed25519',
+      category: 'did-key-resolution',
+      description: 'A well-formed Ed25519 did:key',
+      expected: 'pass',
+      reason: 'Resolves to a single Ed25519 verification method',
+      input: { did: party.did },
+    },
+    {
+      id: 'did-key/malformed-multibase',
+      category: 'did-key-resolution',
+      description: 'A did:key with corrupted base58 multibase payload',
+      expected: 'fail',
+      reason: 'Invalid multibase cannot decode to a key — must reject',
+      input: { did: 'did:key:z6MkNOTVALIDbase58!!!!' },
+    },
+    {
+      id: 'did-key/wrong-method',
+      category: 'did-key-resolution',
+      description: 'A non-did:key DID passed to the did:key resolver',
+      expected: 'fail',
+      reason: 'did:web is out of scope for the did:key resolver — must not resolve',
+      input: { did: 'did:web:example.com' },
+    },
+  ];
+  return { version: '1.0.0', category: 'did-key-resolution', vectors };
+}
+
+// ── did:web resolution vectors ──────────────────────────────────────────────────
+
+async function didWebVectors(): Promise<VectorFile> {
+  const party = await mintParty();
+  const webDid = 'did:web:agent.example.com';
+  const webKid = `${webDid}#keys-1`;
+  const document = buildDidWebDocument({
+    did: webDid,
+    kid: webKid,
+    publicKey: party.publicKey,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  // Negative: served document whose id does not match the requested DID.
+  const mismatched = { ...document, id: 'did:web:evil.example.com' };
+
+  const vectors: ConformanceVector[] = [
+    {
+      id: 'did-web/valid',
+      category: 'did-web-resolution',
+      description: 'A did:web whose well-known document is well-formed and id-matched',
+      expected: 'pass',
+      reason: 'Resolves to a usable Ed25519 verification method',
+      input: { did: webDid, didDocument: document },
+    },
+    {
+      id: 'did-web/id-mismatch',
+      category: 'did-web-resolution',
+      description: 'Served document id does not equal the requested DID',
+      expected: 'fail',
+      reason: 'An id mismatch is a substitution attempt — must reject',
+      input: { did: webDid, didDocument: mismatched },
+    },
+    {
+      id: 'did-web/not-found',
+      category: 'did-web-resolution',
+      description: 'No document served at the well-known URL',
+      expected: 'fail',
+      reason: 'Resolution must fail closed when the document cannot be fetched',
+      input: { did: webDid },
+    },
+  ];
+  return { version: '1.0.0', category: 'did-web-resolution', vectors };
+}
+
+// ── orchestration ───────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  mkdirSync(VECTORS_DIR, { recursive: true });
+
+  writeFile(await signedProofVectors(), 'signed-proof.json');
+  writeFile(await delegationChainVectors(), 'delegation-chain.json');
+  writeFile(await statusListVectors(), 'status-list.json');
+  writeFile(await didKeyVectors(), 'did-key-resolution.json');
+  writeFile(await didWebVectors(), 'did-web-resolution.json');
+  console.log('All conformance vectors generated.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/conformance/loader.ts
+++ b/conformance/loader.ts
@@ -1,0 +1,123 @@
+/**
+ * Vector loader for the KYA-OS conformance harness.
+ *
+ * Reads every `*.json` under `conformance/vectors/`, validates each file's shape
+ * (version + category + vectors), and returns a flat, deduplicated list of
+ * {@link ConformanceVector}. Fails loudly on a malformed vector file so a typo in
+ * a vector never silently weakens the suite.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { ConformanceVector, VectorCategory, VectorFile } from './types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the bundled `conformance/vectors/` directory. */
+export const VECTORS_DIR = join(HERE, 'vectors');
+
+const VALID_CATEGORIES: readonly VectorCategory[] = [
+  'signed-proof',
+  'delegation-chain',
+  'status-list',
+  'did-key-resolution',
+  'did-web-resolution',
+];
+
+function assertVectorFile(file: unknown, source: string): asserts file is VectorFile {
+  if (typeof file !== 'object' || file === null) {
+    throw new Error(`Vector file ${source} is not an object`);
+  }
+  const f = file as Record<string, unknown>;
+  if (typeof f['version'] !== 'string') {
+    throw new Error(`Vector file ${source} is missing a string "version"`);
+  }
+  if (!VALID_CATEGORIES.includes(f['category'] as VectorCategory)) {
+    throw new Error(
+      `Vector file ${source} has invalid "category": ${String(f['category'])}`,
+    );
+  }
+  if (!Array.isArray(f['vectors'])) {
+    throw new Error(`Vector file ${source} is missing a "vectors" array`);
+  }
+  for (const v of f['vectors'] as unknown[]) {
+    assertVector(v, f['category'] as VectorCategory, source);
+  }
+}
+
+function assertVector(
+  vector: unknown,
+  fileCategory: VectorCategory,
+  source: string,
+): asserts vector is ConformanceVector {
+  if (typeof vector !== 'object' || vector === null) {
+    throw new Error(`A vector in ${source} is not an object`);
+  }
+  const v = vector as Record<string, unknown>;
+  for (const field of ['id', 'description', 'reason'] as const) {
+    if (typeof v[field] !== 'string' || (v[field] as string).length === 0) {
+      throw new Error(`Vector in ${source} is missing string "${field}"`);
+    }
+  }
+  if (v['expected'] !== 'pass' && v['expected'] !== 'fail') {
+    throw new Error(
+      `Vector ${String(v['id'])} in ${source} has invalid "expected": ${String(v['expected'])}`,
+    );
+  }
+  // A vector may omit category and inherit the file's; if present it must match.
+  const category = (v['category'] as VectorCategory | undefined) ?? fileCategory;
+  if (category !== fileCategory) {
+    throw new Error(
+      `Vector ${String(v['id'])} category "${category}" does not match file category "${fileCategory}" in ${source}`,
+    );
+  }
+  if (!('input' in v)) {
+    throw new Error(`Vector ${String(v['id'])} in ${source} is missing "input"`);
+  }
+}
+
+/**
+ * Load and validate all conformance vectors from {@link VECTORS_DIR}.
+ *
+ * @returns Flat list of vectors with `category` always populated.
+ * @throws if a vector file is malformed or two vectors share an id.
+ */
+export function loadVectors(dir: string = VECTORS_DIR): ConformanceVector[] {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
+  const vectors: ConformanceVector[] = [];
+  const seenIds = new Set<string>();
+
+  for (const fileName of files) {
+    const source = join(dir, fileName);
+    const raw = readFileSync(source, 'utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(
+        `Vector file ${source} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+    assertVectorFile(parsed, source);
+
+    for (const vector of parsed.vectors) {
+      const normalized: ConformanceVector = {
+        ...vector,
+        category: vector.category ?? parsed.category,
+      };
+      if (seenIds.has(normalized.id)) {
+        throw new Error(`Duplicate vector id "${normalized.id}" (in ${source})`);
+      }
+      seenIds.add(normalized.id);
+      vectors.push(normalized);
+    }
+  }
+
+  if (vectors.length === 0) {
+    throw new Error(`No conformance vectors found in ${dir}`);
+  }
+
+  return vectors;
+}

--- a/conformance/reference-adapter.ts
+++ b/conformance/reference-adapter.ts
@@ -1,0 +1,299 @@
+/**
+ * Reference {@link ConformanceAdapter} for `@kya-os/mcp`.
+ *
+ * DRY: every method delegates to the package's PUBLIC verify primitives — it does
+ * NOT re-implement any verification logic. This is exactly the surface a third
+ * party would wire their own implementation into, so passing the suite here
+ * proves the reference implementation is conformant against the same vectors any
+ * other implementation would run.
+ *
+ *   - signed proofs        → {@link ProofVerifier.verifyProof}
+ *   - delegation chains    → {@link validateDelegationChain} + {@link DelegationCredentialVerifier}
+ *   - status-list checks   → {@link StatusList2021Manager.checkStatus} via the chain's status resolver
+ *   - did:key resolution   → {@link createDidKeyResolver}
+ *   - did:web resolution   → {@link createDidWebResolver}
+ *
+ * All methods are fail-closed: any thrown error or unmet property becomes
+ * `{ outcome: 'fail' }`.
+ */
+
+import {
+  ProofVerifier,
+  DelegationCredentialVerifier,
+  createDidKeyResolver,
+  createDidWebResolver,
+  MemoryNonceCacheProvider,
+  type DIDDocument,
+  type CredentialStatus,
+  type DelegationCredential,
+  type StatusList2021Credential,
+} from '../src/index.js';
+import type { Ed25519JWK } from '../src/utils/crypto-service.js';
+import { NodeCryptoProvider } from '../src/providers/node-crypto.js';
+import {
+  validateDelegationChain,
+  type DelegationCredentialVerifierPort,
+} from '../src/delegation/chain-enforcement.js';
+import { BitstringManager } from '../src/delegation/bitstring.js';
+import { ClockProvider, FetchProvider } from '../src/providers/base.js';
+import type {
+  AdapterResult,
+  ConformanceAdapter,
+  DelegationChainInput,
+  DidResolutionInput,
+  SignedProofInput,
+  StatusListInput,
+} from './types.js';
+import {
+  conformanceCompressor,
+  conformanceDecompressor,
+  ed25519SignatureVerifier,
+} from './crypto-kit.js';
+
+const PASS: AdapterResult = { outcome: 'pass' };
+function fail(detail: string): AdapterResult {
+  return { outcome: 'fail', detail };
+}
+
+/**
+ * Clock pinned to a fixed epoch-seconds "now" so timestamp-skew vectors are
+ * deterministic regardless of wall-clock time. Implements the package's
+ * `ClockProvider` port with a fixed time source.
+ */
+class PinnedClock extends ClockProvider {
+  constructor(private readonly nowMs: number) {
+    super();
+  }
+  now(): number {
+    return this.nowMs;
+  }
+  isWithinSkew(timestampMs: number, skewSeconds: number): boolean {
+    return Math.abs(this.nowMs - timestampMs) <= skewSeconds * 1000;
+  }
+  hasExpired(expiresAt: number): boolean {
+    return this.nowMs > expiresAt;
+  }
+  calculateExpiry(ttlSeconds: number): number {
+    return this.nowMs + ttlSeconds * 1000;
+  }
+  format(timestamp: number): string {
+    return new Date(timestamp).toISOString();
+  }
+}
+
+/**
+ * Offline FetchProvider serving DID documents and status lists from in-memory
+ * maps the vector supplies. The harness MUST do no network I/O so vectors are
+ * hermetic and reproducible.
+ */
+class StaticFetchProvider extends FetchProvider {
+  constructor(
+    private readonly didDocuments: Record<string, unknown> = {},
+    private readonly urlBodies: Record<string, unknown> = {},
+  ) {
+    super();
+  }
+  async resolveDID(did: string): Promise<DIDDocument | null> {
+    return (this.didDocuments[did] as DIDDocument) ?? null;
+  }
+  async fetchStatusList(): Promise<StatusList2021Credential | null> {
+    return null;
+  }
+  async fetchDelegationChain(): Promise<never[]> {
+    return [];
+  }
+  async fetch(url: string): Promise<Response> {
+    const body = this.urlBodies[url];
+    if (body === undefined) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}
+
+export class ReferenceConformanceAdapter implements ConformanceAdapter {
+  readonly name = '@kya-os/mcp (reference)';
+  private readonly crypto = new NodeCryptoProvider();
+
+  async verifySignedProof(input: SignedProofInput): Promise<AdapterResult> {
+    try {
+      const verifier = new ProofVerifier({
+        cryptoProvider: this.crypto,
+        clockProvider: new PinnedClock(input.now * 1000),
+        nonceCacheProvider: new MemoryNonceCacheProvider(),
+        fetchProvider: new StaticFetchProvider(),
+        timestampSkewSeconds: input.skewSeconds,
+      });
+      const result = await verifier.verifyProof(
+        input.proof as Parameters<ProofVerifier['verifyProof']>[0],
+        input.publicKeyJwk as Ed25519JWK,
+      );
+      return result.valid ? PASS : fail(result.reason ?? 'proof rejected');
+    } catch (error) {
+      return fail(`verifySignedProof threw: ${asMessage(error)}`);
+    }
+  }
+
+  async verifyDelegationChain(input: DelegationChainInput): Promise<AdapterResult> {
+    try {
+      const fetchProvider = new StaticFetchProvider(input.didDocuments);
+      const didResolver = makeMultiResolver(input.didDocuments, fetchProvider);
+
+      const credentialVerifier = new DelegationCredentialVerifier({
+        didResolver,
+        signatureVerifier: ed25519SignatureVerifier(this.crypto),
+      });
+      const verifierPort: DelegationCredentialVerifierPort = {
+        verifyDelegationCredential: (credential, options) =>
+          credentialVerifier.verifyDelegationCredential(credential, {
+            skipStatus: true, // status handled by the dedicated status-list vectors
+            ...(options?.skipSignature ? { skipSignature: true } : {}),
+          }),
+      };
+
+      const ancestors = (input.ancestors ?? []) as DelegationCredential[];
+      const result = await validateDelegationChain(
+        input.leaf as DelegationCredential,
+        {
+          serverDid: input.serverDid,
+          verifier: verifierPort,
+          statusListConfigured: false,
+          resolveDelegationChain:
+            ancestors.length > 0
+              ? async () => [...ancestors, input.leaf as DelegationCredential]
+              : undefined,
+        },
+      );
+      return result.valid ? PASS : fail(result.reason ?? 'chain rejected');
+    } catch (error) {
+      return fail(`verifyDelegationChain threw: ${asMessage(error)}`);
+    }
+  }
+
+  async verifyStatusList(input: StatusListInput): Promise<AdapterResult> {
+    try {
+      const credential = input.credential as DelegationCredential;
+      const status = credential.credentialStatus;
+      if (!status) {
+        return fail('credential has no credentialStatus to verify');
+      }
+
+      // Status resolver backed by the supplied StatusList2021Credentials, decoded
+      // with the SAME bitstring primitive the manager uses (DRY).
+      const statusListResolver = {
+        checkStatus: async (s: CredentialStatus): Promise<boolean> => {
+          const list = input.statusLists[s.statusListCredential] as
+            | StatusList2021Credential
+            | undefined;
+          if (!list) {
+            throw new Error(`status list not found: ${s.statusListCredential}`);
+          }
+          const manager = await BitstringManager.decode(
+            list.credentialSubject.encodedList,
+            conformanceCompressor,
+            conformanceDecompressor,
+          );
+          return manager.getBit(parseInt(s.statusListIndex, 10));
+        },
+      };
+
+      const fetchProvider = new StaticFetchProvider(input.didDocuments);
+      const didResolver = makeMultiResolver(input.didDocuments, fetchProvider);
+      const verifier = new DelegationCredentialVerifier({
+        didResolver,
+        statusListResolver,
+        signatureVerifier: ed25519SignatureVerifier(this.crypto),
+      });
+
+      const result = await verifier.verifyDelegationCredential(credential, {
+        skipCache: true,
+      });
+      return result.valid ? PASS : fail(result.reason ?? 'credential rejected');
+    } catch (error) {
+      return fail(`verifyStatusList threw: ${asMessage(error)}`);
+    }
+  }
+
+  async resolveDidKey(input: DidResolutionInput): Promise<AdapterResult> {
+    try {
+      const resolver = createDidKeyResolver();
+      const doc = await resolver.resolve(input.did);
+      return isUsableEd25519Document(doc)
+        ? PASS
+        : fail(`did:key resolution produced no usable verification method for ${input.did}`);
+    } catch (error) {
+      return fail(`resolveDidKey threw: ${asMessage(error)}`);
+    }
+  }
+
+  async resolveDidWeb(input: DidResolutionInput): Promise<AdapterResult> {
+    try {
+      // did:web is fetched from its well-known URL; serve the vector's document
+      // there (or nothing, for the not-found negative case).
+      const url = didWebUrl(input.did);
+      const urlBodies = url && input.didDocument !== undefined
+        ? { [url]: input.didDocument }
+        : {};
+      const resolver = createDidWebResolver(new StaticFetchProvider({}, urlBodies));
+      const doc = await resolver.resolve(input.did);
+      return isUsableEd25519Document(doc)
+        ? PASS
+        : fail(`did:web resolution produced no usable verification method for ${input.did}`);
+    } catch (error) {
+      return fail(`resolveDidWeb threw: ${asMessage(error)}`);
+    }
+  }
+}
+
+/**
+ * Resolve a DID against the vector's supplied documents, falling back to the
+ * offline method resolvers (did:key derives from the DID itself; did:web reads
+ * the static fetch map). Keeps signature verification self-contained.
+ */
+function makeMultiResolver(
+  didDocuments: Record<string, unknown>,
+  fetchProvider: StaticFetchProvider,
+): { resolve(did: string): Promise<DIDDocument | null> } {
+  const didKey = createDidKeyResolver();
+  const didWeb = createDidWebResolver(fetchProvider);
+  return {
+    resolve: async (did: string): Promise<DIDDocument | null> => {
+      const supplied = didDocuments[did];
+      if (supplied) {
+        return supplied as DIDDocument;
+      }
+      if (did.startsWith('did:key:')) {
+        return didKey.resolve(did);
+      }
+      if (did.startsWith('did:web:')) {
+        return didWeb.resolve(did);
+      }
+      return null;
+    },
+  };
+}
+
+function isUsableEd25519Document(doc: DIDDocument | null): boolean {
+  const vm = doc?.verificationMethod?.[0];
+  const jwk = vm?.publicKeyJwk as { kty?: string; crv?: string; x?: string } | undefined;
+  return Boolean(jwk && jwk.kty === 'OKP' && jwk.crv === 'Ed25519' && jwk.x);
+}
+
+function didWebUrl(did: string): string | null {
+  if (!did.startsWith('did:web:')) return null;
+  const remainder = did.slice('did:web:'.length);
+  const parts = remainder.split(':').map((p) => decodeURIComponent(p));
+  const domain = parts[0];
+  if (!domain) return null;
+  const path = parts.slice(1);
+  return path.length === 0
+    ? `https://${domain}/.well-known/did.json`
+    : `https://${domain}/${path.join('/')}/did.json`;
+}
+
+function asMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/conformance/runner.ts
+++ b/conformance/runner.ts
@@ -1,0 +1,137 @@
+/**
+ * KYA-OS Conformance Runner.
+ *
+ * Feeds each loaded vector to the supplied {@link ConformanceAdapter}, compares
+ * the adapter's accept/reject outcome to the vector's `expected`, and aggregates
+ * a {@link ConformanceReport}. A vector PASSES the suite when the adapter's
+ * outcome equals `expected` — so a `fail` vector (a tampered proof, broken chain,
+ * revoked credential, malformed DID) passes the suite only when the
+ * implementation correctly REJECTS it.
+ *
+ * The runner is implementation-agnostic: it never imports `@kya-os/mcp`. To run
+ * the reference implementation, pass {@link ./reference-adapter}; a third party
+ * passes their own adapter (see CONFORMANCE.md).
+ */
+
+import type {
+  AdapterResult,
+  ConformanceAdapter,
+  ConformanceVector,
+  DelegationChainInput,
+  DidResolutionInput,
+  ExpectedOutcome,
+  SignedProofInput,
+  StatusListInput,
+} from './types.js';
+
+export interface VectorRunResult {
+  id: string;
+  category: ConformanceVector['category'];
+  description: string;
+  expected: ExpectedOutcome;
+  actual: ExpectedOutcome | 'error';
+  ok: boolean;
+  detail?: string;
+}
+
+export interface ConformanceReport {
+  adapter: string;
+  total: number;
+  passed: number;
+  failed: number;
+  results: VectorRunResult[];
+  /** True iff every vector's actual outcome matched its expected outcome. */
+  allMatched: boolean;
+}
+
+/** Dispatch a single vector to the adapter method for its category. */
+async function dispatch(
+  adapter: ConformanceAdapter,
+  vector: ConformanceVector,
+): Promise<AdapterResult> {
+  switch (vector.category) {
+    case 'signed-proof':
+      return adapter.verifySignedProof(vector.input as SignedProofInput);
+    case 'delegation-chain':
+      return adapter.verifyDelegationChain(vector.input as DelegationChainInput);
+    case 'status-list':
+      return adapter.verifyStatusList(vector.input as StatusListInput);
+    case 'did-key-resolution':
+      return adapter.resolveDidKey(vector.input as DidResolutionInput);
+    case 'did-web-resolution':
+      return adapter.resolveDidWeb(vector.input as DidResolutionInput);
+    default: {
+      const exhaustive: never = vector.category;
+      throw new Error(`Unknown vector category: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Run every vector through the adapter and aggregate the report.
+ *
+ * A thrown error from an adapter method is recorded as `actual: 'error'` and
+ * counts as a mismatch — adapters are required to be fail-closed and return
+ * `{ outcome: 'fail' }` rather than throw.
+ */
+export async function runConformance(
+  adapter: ConformanceAdapter,
+  vectors: ConformanceVector[],
+): Promise<ConformanceReport> {
+  const results: VectorRunResult[] = [];
+
+  for (const vector of vectors) {
+    let actual: ExpectedOutcome | 'error';
+    let detail: string | undefined;
+    try {
+      const result = await dispatch(adapter, vector);
+      actual = result.outcome;
+      detail = result.detail;
+    } catch (error) {
+      actual = 'error';
+      detail = `adapter threw: ${error instanceof Error ? error.message : String(error)}`;
+    }
+    const ok = actual === vector.expected;
+    results.push({
+      id: vector.id,
+      category: vector.category,
+      description: vector.description,
+      expected: vector.expected,
+      actual,
+      ok,
+      detail,
+    });
+  }
+
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.length - passed;
+
+  return {
+    adapter: adapter.name,
+    total: results.length,
+    passed,
+    failed,
+    results,
+    allMatched: failed === 0,
+  };
+}
+
+/** Render a human-readable report suitable for CI logs. */
+export function formatReport(report: ConformanceReport): string {
+  const lines: string[] = [];
+  lines.push(`KYA-OS Conformance — adapter: ${report.adapter}`);
+  lines.push('');
+  for (const r of report.results) {
+    const mark = r.ok ? 'PASS' : 'FAIL';
+    lines.push(`  [${mark}] ${r.id} (${r.category}) — expected ${r.expected}, got ${r.actual}`);
+    if (!r.ok && r.detail) {
+      lines.push(`         ${r.detail}`);
+    }
+  }
+  lines.push('');
+  lines.push(
+    `Total: ${report.total}  Passed: ${report.passed}  Failed: ${report.failed}`,
+  );
+  lines.push(report.allMatched ? 'RESULT: PASS (all vectors matched)' : 'RESULT: FAIL');
+  return lines.join('\n');
+}

--- a/conformance/tsconfig.json
+++ b/conformance/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["../node_modules", "../dist"]
+}

--- a/conformance/types.ts
+++ b/conformance/types.ts
@@ -1,0 +1,142 @@
+/**
+ * KYA-OS Conformance Harness — shared types and the implementation-agnostic
+ * adapter contract.
+ *
+ * The harness is independent of the reference implementation: it reads versioned
+ * JSON test vectors (`conformance/vectors/*.json`) and runs each one through a
+ * {@link ConformanceAdapter}. A third party brings their OWN implementation by
+ * implementing this single interface — every primitive a vector exercises maps to
+ * one adapter method. The reference adapter
+ * ({@link ./reference-adapter.ReferenceConformanceAdapter}) wires these methods to
+ * `@kya-os/mcp`'s PUBLIC verify primitives and does not fork their logic.
+ *
+ * See CONFORMANCE.md § "Running the harness against your implementation".
+ */
+
+/** Categories a vector can target. One adapter method per category. */
+export type VectorCategory =
+  | 'signed-proof'
+  | 'delegation-chain'
+  | 'status-list'
+  | 'did-key-resolution'
+  | 'did-web-resolution';
+
+/** The outcome a conformant implementation MUST produce for a vector. */
+export type ExpectedOutcome = 'pass' | 'fail';
+
+/**
+ * A single, self-contained conformance vector. `input` is category-specific and
+ * carries fully-formed, pre-signed artifacts so the vector is reproducible
+ * against ANY implementation without re-signing.
+ */
+export interface ConformanceVector {
+  /** Stable, unique id (e.g. `signed-proof/valid-basic`). */
+  id: string;
+  /** Which adapter method verifies this vector. */
+  category: VectorCategory;
+  /** Human-readable description of what the vector exercises. */
+  description: string;
+  /** Whether a conformant verifier MUST accept (`pass`) or reject (`fail`). */
+  expected: ExpectedOutcome;
+  /** Why the expected outcome holds (the security property under test). */
+  reason: string;
+  /** Category-specific input. Validated structurally by the loader. */
+  input: unknown;
+}
+
+/** A versioned file of vectors as stored on disk under `conformance/vectors/`. */
+export interface VectorFile {
+  /** Vector-format version (semver). Bump on a breaking input-shape change. */
+  version: string;
+  /** Category every vector in this file targets. */
+  category: VectorCategory;
+  vectors: ConformanceVector[];
+}
+
+/**
+ * The result an adapter returns for a single vector. `pass`/`fail` mirrors the
+ * vector's `expected`; the runner compares them.
+ */
+export interface AdapterResult {
+  /** `pass` = the implementation ACCEPTED the artifact; `fail` = it REJECTED it. */
+  outcome: ExpectedOutcome;
+  /** Optional human-readable reason (especially useful on rejection). */
+  detail?: string;
+}
+
+// ── Category-specific input shapes ────────────────────────────────────────────
+// These are the wire shapes embedded in the JSON vectors. They are intentionally
+// minimal and JSON-serializable so any implementation can consume them.
+
+export interface SignedProofInput {
+  /** A DetachedProof: `{ jws, meta }`. */
+  proof: unknown;
+  /** The signer's Ed25519 public key in JWK form (`{ kty, crv, x, kid }`). */
+  publicKeyJwk: { kty: string; crv: string; x: string; kid?: string };
+  /** Reference epoch-seconds the verifier should treat as "now" (skew anchor). */
+  now: number;
+  /** Allowed timestamp skew in seconds for this vector. */
+  skewSeconds: number;
+}
+
+export interface DelegationChainInput {
+  /** The leaf DelegationCredential (signed). */
+  leaf: unknown;
+  /** Ancestors root→parent (signed), if the leaf is a re-delegation. */
+  ancestors?: unknown[];
+  /** The verifying server's DID; every credential's audience must include it. */
+  serverDid: string;
+  /** DID documents the verifier may resolve, keyed by DID. */
+  didDocuments: Record<string, unknown>;
+}
+
+export interface StatusListInput {
+  /** The DelegationCredential carrying a `credentialStatus`. */
+  credential: unknown;
+  /** The signed StatusList2021Credential the entry points at, keyed by its id. */
+  statusLists: Record<string, unknown>;
+  /** DID documents for signature verification, keyed by DID. */
+  didDocuments: Record<string, unknown>;
+  /** The verifying server's DID. */
+  serverDid: string;
+}
+
+export interface DidResolutionInput {
+  /** The DID to resolve. */
+  did: string;
+  /**
+   * For did:web: the JSON the resolver's fetch should return for the DID's
+   * well-known URL. Omitted for did:key (resolution is offline).
+   */
+  didDocument?: unknown;
+}
+
+/**
+ * The contract a third party implements to run the KYA-OS conformance vectors
+ * against their own implementation.
+ *
+ * Each method takes a vector's `input` and returns whether the implementation
+ * ACCEPTED (`pass`) or REJECTED (`fail`) the artifact. Methods MUST be
+ * fail-closed: any error, malformed input, or unmet security property maps to
+ * `{ outcome: 'fail' }` — they MUST NOT throw. The runner treats a thrown error
+ * as a harness failure, not a rejection.
+ */
+export interface ConformanceAdapter {
+  /** Implementation name, surfaced in the runner report. */
+  readonly name: string;
+
+  /** Verify a signed detached proof (signature + nonce + timestamp skew). */
+  verifySignedProof(input: SignedProofInput): Promise<AdapterResult>;
+
+  /** Verify a delegation credential and its full chain to the root. */
+  verifyDelegationChain(input: DelegationChainInput): Promise<AdapterResult>;
+
+  /** Verify a credential's StatusList2021 revocation status. */
+  verifyStatusList(input: StatusListInput): Promise<AdapterResult>;
+
+  /** Resolve a did:key DID to a usable Ed25519 verification method. */
+  resolveDidKey(input: DidResolutionInput): Promise<AdapterResult>;
+
+  /** Resolve a did:web DID to a usable Ed25519 verification method. */
+  resolveDidWeb(input: DidResolutionInput): Promise<AdapterResult>;
+}

--- a/conformance/vectors/delegation-chain.json
+++ b/conformance/vectors/delegation-chain.json
@@ -1,0 +1,822 @@
+{
+  "version": "1.0.0",
+  "category": "delegation-chain",
+  "vectors": [
+    {
+      "id": "delegation-chain/valid-single-hop",
+      "category": "delegation-chain",
+      "description": "A directly-issued, signed delegation bound to the server",
+      "expected": "pass",
+      "reason": "Signature, audience, and shape all valid; no parent to resolve",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-root-agent",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-root-agent",
+              "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "greeting:read"
+              ],
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "2It7v4CrriyMgMU0tn0k7LZuc7XQMWwPWhsQimOPKvPUusoD0dMrtzV_822u_rKIUvtVSwarNvPFprxh4wLsDw"
+          }
+        },
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "delegation-chain/valid-two-hop-attenuated",
+      "category": "delegation-chain",
+      "description": "Root → intermediary → agent with a correctly attenuated child scope",
+      "expected": "pass",
+      "reason": "Linkage, audience, and scope subset all hold across the chain",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-interm-agent",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-interm-agent",
+              "issuerDid": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "greeting:read"
+              ],
+              "parentId": "del-root-interm",
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "fBVmEl6TeurDltEEr4adwLMqitAaw6b0UK7Zu6F0fLWicAhWJbamaSysSS3wJsd9tDy2QRce7-pnehj4Kv_WCQ"
+          }
+        },
+        "ancestors": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+            ],
+            "id": "urn:uuid:del-root-interm",
+            "type": [
+              "VerifiableCredential",
+              "DelegationCredential"
+            ],
+            "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "issuanceDate": "2026-01-01T00:00:00.000Z",
+            "credentialSubject": {
+              "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+              "delegation": {
+                "id": "del-root-interm",
+                "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "subjectDid": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "scopes": [
+                  "greeting:read",
+                  "greeting:write"
+                ],
+                "constraints": {
+                  "scopes": [
+                    "greeting:read",
+                    "greeting:write"
+                  ],
+                  "audience": "did:web:server.example.com"
+                },
+                "status": "active",
+                "createdAt": 1750000000000
+              }
+            },
+            "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2026-01-01T00:00:00.000Z",
+              "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "tNgjHF-eOSbxi2G8OomXFg-O6UXiLddXvQWVP9XZDrh1cN5H9dg3VEm2NrywMaT64cgPCXPheSdfuPykpM9dAw"
+            }
+          }
+        ],
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "delegation-chain/broken-linkage",
+      "category": "delegation-chain",
+      "description": "Child issuerDid does not equal the parent subjectDid",
+      "expected": "fail",
+      "reason": "A broken issuer↔subject link must reject the chain",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-forged-child",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-forged-child",
+              "issuerDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "greeting:read"
+              ],
+              "parentId": "del-root-interm",
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "BAF5tYR8gevNmjYmbo39JurUdHyovHn3KUdjJ9YL0did8GvI9kvdd4b1QlzFRRow0byKu3H5nAsxatFMne7dAw"
+          }
+        },
+        "ancestors": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+            ],
+            "id": "urn:uuid:del-root-interm",
+            "type": [
+              "VerifiableCredential",
+              "DelegationCredential"
+            ],
+            "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "issuanceDate": "2026-01-01T00:00:00.000Z",
+            "credentialSubject": {
+              "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+              "delegation": {
+                "id": "del-root-interm",
+                "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "subjectDid": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "scopes": [
+                  "greeting:read",
+                  "greeting:write"
+                ],
+                "constraints": {
+                  "scopes": [
+                    "greeting:read",
+                    "greeting:write"
+                  ],
+                  "audience": "did:web:server.example.com"
+                },
+                "status": "active",
+                "createdAt": 1750000000000
+              }
+            },
+            "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2026-01-01T00:00:00.000Z",
+              "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "tNgjHF-eOSbxi2G8OomXFg-O6UXiLddXvQWVP9XZDrh1cN5H9dg3VEm2NrywMaT64cgPCXPheSdfuPykpM9dAw"
+            }
+          }
+        ],
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "delegation-chain/scope-widening",
+      "category": "delegation-chain",
+      "description": "Child introduces a scope absent from its parent",
+      "expected": "fail",
+      "reason": "A re-delegation may only narrow authority; widening must reject",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-widening-child",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-widening-child",
+              "issuerDid": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "admin:all"
+              ],
+              "parentId": "del-root-interm",
+              "constraints": {
+                "scopes": [
+                  "admin:all"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "fcCw61O9Ti_tQlaEBbC6dEHwGejRKfWYUWtNBsjY5lenyKB8RLRqaicw21VGShLDtov4X0Kj4kmERD1Q-PRhAQ"
+          }
+        },
+        "ancestors": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+            ],
+            "id": "urn:uuid:del-root-interm",
+            "type": [
+              "VerifiableCredential",
+              "DelegationCredential"
+            ],
+            "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "issuanceDate": "2026-01-01T00:00:00.000Z",
+            "credentialSubject": {
+              "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+              "delegation": {
+                "id": "del-root-interm",
+                "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "subjectDid": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "scopes": [
+                  "greeting:read",
+                  "greeting:write"
+                ],
+                "constraints": {
+                  "scopes": [
+                    "greeting:read",
+                    "greeting:write"
+                  ],
+                  "audience": "did:web:server.example.com"
+                },
+                "status": "active",
+                "createdAt": 1750000000000
+              }
+            },
+            "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2026-01-01T00:00:00.000Z",
+              "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "tNgjHF-eOSbxi2G8OomXFg-O6UXiLddXvQWVP9XZDrh1cN5H9dg3VEm2NrywMaT64cgPCXPheSdfuPykpM9dAw"
+            }
+          }
+        ],
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "delegation-chain/tampered-signature",
+      "category": "delegation-chain",
+      "description": "Leaf credential whose Ed25519 proofValue was altered",
+      "expected": "fail",
+      "reason": "A mutated VC signature must fail verification",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-root-agent",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-root-agent",
+              "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "greeting:read"
+              ],
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "2It7v4CrriyMgMU0tn0k7LZuc7XQMWwPWhsQimOPKvPUusoD0dMrtzV_822u_rKIUvtVSwarNvPFprxh4wLsDA"
+          }
+        },
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "delegation-chain/audience-mismatch",
+      "category": "delegation-chain",
+      "description": "Credential bound to a different server than the verifier",
+      "expected": "fail",
+      "reason": "Audience binding (confused-deputy guard) must reject a mismatched server",
+      "input": {
+        "leaf": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-wrong-audience",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "delegation": {
+              "id": "del-wrong-audience",
+              "issuerDid": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+              "subjectDid": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+              "scopes": [
+                "greeting:read"
+              ],
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:other.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "nJPg7kQTPLwtV9rym-_cjC27jTlR4-Xxm7FvE1DXn7xxeXjBi5Rf6PpqvsPv7hEg_v4Fy-TRaIf7vjh2ZiFSBw"
+          }
+        },
+        "serverDid": "did:web:server.example.com",
+        "didDocuments": {
+          "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz": {
+            "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "UJ8v4Gt_Qie3EyOSqC5961Lk46FxEzAxb_RnGcdSCj0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ],
+            "authentication": [
+              "did:key:z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz#z6MkjsyStKSVg2GBBinMo3R2GCUMLWVGzUrbLVqHmZY62RXz"
+            ]
+          },
+          "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc": {
+            "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "D7rRLGiB8xLOK6JkM_uLrwduxWiqpwBBU7DfBHZq9MM"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ],
+            "authentication": [
+              "did:key:z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc#z6MkfWfPAQKRKCbfntVqUYyo8Qbfu71WRV4zRpQ22CtBRHqc"
+            ]
+          },
+          "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU": {
+            "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "2l84VwwDFeQnJfkhjBsePaJAA7K8K8aM9S8HB-34mY0"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ],
+            "authentication": [
+              "did:key:z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU#z6Mku9h8t9gFw8CopA69UJG8T96nLkWmZpn1Lyyv5QFWmkQU"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/vectors/did-key-resolution.json
+++ b/conformance/vectors/did-key-resolution.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0.0",
+  "category": "did-key-resolution",
+  "vectors": [
+    {
+      "id": "did-key/valid-ed25519",
+      "category": "did-key-resolution",
+      "description": "A well-formed Ed25519 did:key",
+      "expected": "pass",
+      "reason": "Resolves to a single Ed25519 verification method",
+      "input": {
+        "did": "did:key:z6MkiupQ1QPitvNtmEwCb47mkfCtCoU9A6znu7ECSqyFbVXH"
+      }
+    },
+    {
+      "id": "did-key/malformed-multibase",
+      "category": "did-key-resolution",
+      "description": "A did:key with corrupted base58 multibase payload",
+      "expected": "fail",
+      "reason": "Invalid multibase cannot decode to a key — must reject",
+      "input": {
+        "did": "did:key:z6MkNOTVALIDbase58!!!!"
+      }
+    },
+    {
+      "id": "did-key/wrong-method",
+      "category": "did-key-resolution",
+      "description": "A non-did:key DID passed to the did:key resolver",
+      "expected": "fail",
+      "reason": "did:web is out of scope for the did:key resolver — must not resolve",
+      "input": {
+        "did": "did:web:example.com"
+      }
+    }
+  ]
+}

--- a/conformance/vectors/did-web-resolution.json
+++ b/conformance/vectors/did-web-resolution.json
@@ -1,0 +1,88 @@
+{
+  "version": "1.0.0",
+  "category": "did-web-resolution",
+  "vectors": [
+    {
+      "id": "did-web/valid",
+      "category": "did-web-resolution",
+      "description": "A did:web whose well-known document is well-formed and id-matched",
+      "expected": "pass",
+      "reason": "Resolves to a usable Ed25519 verification method",
+      "input": {
+        "did": "did:web:agent.example.com",
+        "didDocument": {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1"
+          ],
+          "id": "did:web:agent.example.com",
+          "verificationMethod": [
+            {
+              "id": "did:web:agent.example.com#keys-1",
+              "type": "Ed25519VerificationKey2020",
+              "controller": "did:web:agent.example.com",
+              "publicKeyJwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": "zIbzE7nNFfU0i62mv43FWCPYS4i5sS8-NeRy_O7ptW8"
+              },
+              "publicKeyMultibase": "z6MktDeZmp9n8K334seLnTYeKkePNmWRfSVhoighWct9zK74"
+            }
+          ],
+          "authentication": [
+            "did:web:agent.example.com#keys-1"
+          ],
+          "assertionMethod": [
+            "did:web:agent.example.com#keys-1"
+          ]
+        }
+      }
+    },
+    {
+      "id": "did-web/id-mismatch",
+      "category": "did-web-resolution",
+      "description": "Served document id does not equal the requested DID",
+      "expected": "fail",
+      "reason": "An id mismatch is a substitution attempt — must reject",
+      "input": {
+        "did": "did:web:agent.example.com",
+        "didDocument": {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1"
+          ],
+          "id": "did:web:evil.example.com",
+          "verificationMethod": [
+            {
+              "id": "did:web:agent.example.com#keys-1",
+              "type": "Ed25519VerificationKey2020",
+              "controller": "did:web:agent.example.com",
+              "publicKeyJwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": "zIbzE7nNFfU0i62mv43FWCPYS4i5sS8-NeRy_O7ptW8"
+              },
+              "publicKeyMultibase": "z6MktDeZmp9n8K334seLnTYeKkePNmWRfSVhoighWct9zK74"
+            }
+          ],
+          "authentication": [
+            "did:web:agent.example.com#keys-1"
+          ],
+          "assertionMethod": [
+            "did:web:agent.example.com#keys-1"
+          ]
+        }
+      }
+    },
+    {
+      "id": "did-web/not-found",
+      "category": "did-web-resolution",
+      "description": "No document served at the well-known URL",
+      "expected": "fail",
+      "reason": "Resolution must fail closed when the document cannot be fetched",
+      "input": {
+        "did": "did:web:agent.example.com"
+      }
+    }
+  ]
+}

--- a/conformance/vectors/signed-proof.json
+++ b/conformance/vectors/signed-proof.json
@@ -1,0 +1,156 @@
+{
+  "version": "1.0.0",
+  "category": "signed-proof",
+  "vectors": [
+    {
+      "id": "signed-proof/valid-basic",
+      "category": "signed-proof",
+      "description": "A well-formed proof with a valid Ed25519 signature and in-window timestamp",
+      "expected": "pass",
+      "reason": "Signature verifies against the signer key and ts is within skew",
+      "input": {
+        "proof": {
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXI3o2TWtwWThMOGdINWV5VmZnc2ZZOXRGSnNjNjlpNlBpUmdHaUIyRWQ1U3dxeXpqVyJ9.eyJhdWQiOiJkaWQ6d2ViOnNlcnZlci5leGFtcGxlLmNvbSIsImlzcyI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwibm9uY2UiOiJub25jZS1jb25mb3JtYW5jZS0wMDAxIiwicmVxdWVzdEhhc2giOiJzaGEyNTY6YzhmM2Q1OTk1OWM5MjQ3MjExZGU4Yzc2Yjk0ZWYxN2YwYzI3OWYwOTM2MjM1MGNlZDY3ZjY5ZWNkYjg5ZDZjNyIsInJlc3BvbnNlSGFzaCI6InNoYTI1Njo0YmNmYTVkNzg4NjczZDBhMmE3OTZkMjJiMGFkMjhiYmI0ODJlYzA4Nzc3MGNkODcwZDZhOGNlMmU5MGVjMTQyIiwic2Vzc2lvbklkIjoic2Vzc19jb25mb3JtYW5jZSIsInN1YiI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwidHMiOjE3NTAwMDAwMDB9.m3CbTG0TIru4niqLMUVXLrm8tCRHrDP4aV3bzGEvZyGEN3-omMo6N6mKWrrcuqvNx1U7AHioIhpdCAYdzyPlBw",
+          "meta": {
+            "did": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "ts": 1750000000,
+            "nonce": "nonce-conformance-0001",
+            "audience": "did:web:server.example.com",
+            "sessionId": "sess_conformance",
+            "requestHash": "sha256:c8f3d59959c9247211de8c76b94ef17f0c279f09362350ced67f69ecdb89d6c7",
+            "responseHash": "sha256:4bcfa5d788673d0a2a796d22b0ad28bbb482ec087770cd870d6a8ce2e90ec142"
+          }
+        },
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "ldQM13vcDqdmYsSGBhimaFY0DWIag2PoLyxsznMykmU",
+          "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW"
+        },
+        "now": 1750000000,
+        "skewSeconds": 300
+      }
+    },
+    {
+      "id": "signed-proof/tampered-signature",
+      "category": "signed-proof",
+      "description": "Proof whose JWS signature bytes were altered",
+      "expected": "fail",
+      "reason": "A mutated signature must fail EdDSA verification",
+      "input": {
+        "proof": {
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXI3o2TWtwWThMOGdINWV5VmZnc2ZZOXRGSnNjNjlpNlBpUmdHaUIyRWQ1U3dxeXpqVyJ9.eyJhdWQiOiJkaWQ6d2ViOnNlcnZlci5leGFtcGxlLmNvbSIsImlzcyI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwibm9uY2UiOiJub25jZS1jb25mb3JtYW5jZS0wMDAxIiwicmVxdWVzdEhhc2giOiJzaGEyNTY6YzhmM2Q1OTk1OWM5MjQ3MjExZGU4Yzc2Yjk0ZWYxN2YwYzI3OWYwOTM2MjM1MGNlZDY3ZjY5ZWNkYjg5ZDZjNyIsInJlc3BvbnNlSGFzaCI6InNoYTI1Njo0YmNmYTVkNzg4NjczZDBhMmE3OTZkMjJiMGFkMjhiYmI0ODJlYzA4Nzc3MGNkODcwZDZhOGNlMmU5MGVjMTQyIiwic2Vzc2lvbklkIjoic2Vzc19jb25mb3JtYW5jZSIsInN1YiI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwidHMiOjE3NTAwMDAwMDB9.m3CbTG0TIru4niqLMUVXLrm8tCRHrDP4aV3bzGEvZyGEN3-omMo6N6mKWrrcuqvNx1U7AHioIhpdCAYdzyPlBA",
+          "meta": {
+            "did": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "ts": 1750000000,
+            "nonce": "nonce-conformance-0001",
+            "audience": "did:web:server.example.com",
+            "sessionId": "sess_conformance",
+            "requestHash": "sha256:c8f3d59959c9247211de8c76b94ef17f0c279f09362350ced67f69ecdb89d6c7",
+            "responseHash": "sha256:4bcfa5d788673d0a2a796d22b0ad28bbb482ec087770cd870d6a8ce2e90ec142"
+          }
+        },
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "ldQM13vcDqdmYsSGBhimaFY0DWIag2PoLyxsznMykmU",
+          "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW"
+        },
+        "now": 1750000000,
+        "skewSeconds": 300
+      }
+    },
+    {
+      "id": "signed-proof/tampered-meta",
+      "category": "signed-proof",
+      "description": "Proof whose signed requestHash was altered after signing",
+      "expected": "fail",
+      "reason": "The reconstructed canonical payload no longer matches the signature",
+      "input": {
+        "proof": {
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXI3o2TWtwWThMOGdINWV5VmZnc2ZZOXRGSnNjNjlpNlBpUmdHaUIyRWQ1U3dxeXpqVyJ9.eyJhdWQiOiJkaWQ6d2ViOnNlcnZlci5leGFtcGxlLmNvbSIsImlzcyI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwibm9uY2UiOiJub25jZS1jb25mb3JtYW5jZS0wMDAxIiwicmVxdWVzdEhhc2giOiJzaGEyNTY6YzhmM2Q1OTk1OWM5MjQ3MjExZGU4Yzc2Yjk0ZWYxN2YwYzI3OWYwOTM2MjM1MGNlZDY3ZjY5ZWNkYjg5ZDZjNyIsInJlc3BvbnNlSGFzaCI6InNoYTI1Njo0YmNmYTVkNzg4NjczZDBhMmE3OTZkMjJiMGFkMjhiYmI0ODJlYzA4Nzc3MGNkODcwZDZhOGNlMmU5MGVjMTQyIiwic2Vzc2lvbklkIjoic2Vzc19jb25mb3JtYW5jZSIsInN1YiI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwidHMiOjE3NTAwMDAwMDB9.m3CbTG0TIru4niqLMUVXLrm8tCRHrDP4aV3bzGEvZyGEN3-omMo6N6mKWrrcuqvNx1U7AHioIhpdCAYdzyPlBw",
+          "meta": {
+            "did": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "ts": 1750000000,
+            "nonce": "nonce-conformance-0001",
+            "audience": "did:web:server.example.com",
+            "sessionId": "sess_conformance",
+            "requestHash": "sha256:dededededededededededededededededededededededededededededededede",
+            "responseHash": "sha256:4bcfa5d788673d0a2a796d22b0ad28bbb482ec087770cd870d6a8ce2e90ec142"
+          }
+        },
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "ldQM13vcDqdmYsSGBhimaFY0DWIag2PoLyxsznMykmU",
+          "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW"
+        },
+        "now": 1750000000,
+        "skewSeconds": 300
+      }
+    },
+    {
+      "id": "signed-proof/wrong-key",
+      "category": "signed-proof",
+      "description": "Valid proof verified against a different agent public key",
+      "expected": "fail",
+      "reason": "Signature does not verify under an unrelated key",
+      "input": {
+        "proof": {
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXI3o2TWtwWThMOGdINWV5VmZnc2ZZOXRGSnNjNjlpNlBpUmdHaUIyRWQ1U3dxeXpqVyJ9.eyJhdWQiOiJkaWQ6d2ViOnNlcnZlci5leGFtcGxlLmNvbSIsImlzcyI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwibm9uY2UiOiJub25jZS1jb25mb3JtYW5jZS0wMDAxIiwicmVxdWVzdEhhc2giOiJzaGEyNTY6YzhmM2Q1OTk1OWM5MjQ3MjExZGU4Yzc2Yjk0ZWYxN2YwYzI3OWYwOTM2MjM1MGNlZDY3ZjY5ZWNkYjg5ZDZjNyIsInJlc3BvbnNlSGFzaCI6InNoYTI1Njo0YmNmYTVkNzg4NjczZDBhMmE3OTZkMjJiMGFkMjhiYmI0ODJlYzA4Nzc3MGNkODcwZDZhOGNlMmU5MGVjMTQyIiwic2Vzc2lvbklkIjoic2Vzc19jb25mb3JtYW5jZSIsInN1YiI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwidHMiOjE3NTAwMDAwMDB9.m3CbTG0TIru4niqLMUVXLrm8tCRHrDP4aV3bzGEvZyGEN3-omMo6N6mKWrrcuqvNx1U7AHioIhpdCAYdzyPlBw",
+          "meta": {
+            "did": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "ts": 1750000000,
+            "nonce": "nonce-conformance-0001",
+            "audience": "did:web:server.example.com",
+            "sessionId": "sess_conformance",
+            "requestHash": "sha256:c8f3d59959c9247211de8c76b94ef17f0c279f09362350ced67f69ecdb89d6c7",
+            "responseHash": "sha256:4bcfa5d788673d0a2a796d22b0ad28bbb482ec087770cd870d6a8ce2e90ec142"
+          }
+        },
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "NxJT_wy6jD-u4Ggup26cWtuKuz6ntNREzk-xIP8pTuc",
+          "kid": "did:key:z6MkiAEgJA1vxX2PJRhG7qwbEHBZkD6mvzEhmQ4VNMT3R2AS#z6MkiAEgJA1vxX2PJRhG7qwbEHBZkD6mvzEhmQ4VNMT3R2AS"
+        },
+        "now": 1750000000,
+        "skewSeconds": 300
+      }
+    },
+    {
+      "id": "signed-proof/timestamp-skew-exceeded",
+      "category": "signed-proof",
+      "description": "Authentically signed proof whose timestamp is far outside the skew window",
+      "expected": "fail",
+      "reason": "ts is 10000s before now with a 300s skew — replay/stale guard must reject",
+      "input": {
+        "proof": {
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXI3o2TWtwWThMOGdINWV5VmZnc2ZZOXRGSnNjNjlpNlBpUmdHaUIyRWQ1U3dxeXpqVyJ9.eyJhdWQiOiJkaWQ6d2ViOnNlcnZlci5leGFtcGxlLmNvbSIsImlzcyI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwibm9uY2UiOiJub25jZS1jb25mb3JtYW5jZS0wMDAxIiwicmVxdWVzdEhhc2giOiJzaGEyNTY6YzhmM2Q1OTk1OWM5MjQ3MjExZGU4Yzc2Yjk0ZWYxN2YwYzI3OWYwOTM2MjM1MGNlZDY3ZjY5ZWNkYjg5ZDZjNyIsInJlc3BvbnNlSGFzaCI6InNoYTI1Njo0YmNmYTVkNzg4NjczZDBhMmE3OTZkMjJiMGFkMjhiYmI0ODJlYzA4Nzc3MGNkODcwZDZhOGNlMmU5MGVjMTQyIiwic2Vzc2lvbklkIjoic2Vzc19jb25mb3JtYW5jZSIsInN1YiI6ImRpZDprZXk6ejZNa3BZOEw4Z0g1ZXlWZmdzZlk5dEZKc2M2OWk2UGlSZ0dpQjJFZDVTd3F5empXIiwidHMiOjE3NDk5OTAwMDB9.Xi32lZ-eg8KZf-CkK0_Ok8hazAot3gUAbmxFi27jcCixGEMiOCA96gzswLBUvbQI6xYkhLdRiy3m4OQhuI2wAQ",
+          "meta": {
+            "did": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW",
+            "ts": 1749990000,
+            "nonce": "nonce-conformance-0001",
+            "audience": "did:web:server.example.com",
+            "sessionId": "sess_conformance",
+            "requestHash": "sha256:c8f3d59959c9247211de8c76b94ef17f0c279f09362350ced67f69ecdb89d6c7",
+            "responseHash": "sha256:4bcfa5d788673d0a2a796d22b0ad28bbb482ec087770cd870d6a8ce2e90ec142"
+          }
+        },
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "ldQM13vcDqdmYsSGBhimaFY0DWIag2PoLyxsznMykmU",
+          "kid": "did:key:z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW#z6MkpY8L8gH5eyVfgsfY9tFJsc69i6PiRgGiB2Ed5SwqyzjW"
+        },
+        "now": 1750000000,
+        "skewSeconds": 300
+      }
+    }
+  ]
+}

--- a/conformance/vectors/status-list.json
+++ b/conformance/vectors/status-list.json
@@ -1,0 +1,220 @@
+{
+  "version": "1.0.0",
+  "category": "status-list",
+  "vectors": [
+    {
+      "id": "status-list/active-credential",
+      "category": "status-list",
+      "description": "Delegation whose StatusList2021 bit is 0 (not revoked)",
+      "expected": "pass",
+      "reason": "An unset revocation bit means the credential is active",
+      "input": {
+        "credential": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-active",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkeggQWvuoyisNKLpdVXfAn9xhCc2RepHf2tifw4T4g5P9",
+            "delegation": {
+              "id": "del-active",
+              "issuerDid": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+              "subjectDid": "did:key:z6MkeggQWvuoyisNKLpdVXfAn9xhCc2RepHf2tifw4T4g5P9",
+              "scopes": [
+                "greeting:read"
+              ],
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "credentialStatus": {
+            "id": "https://status.example.com/revocation/v1#7",
+            "type": "StatusList2021Entry",
+            "statusPurpose": "revocation",
+            "statusListIndex": "7",
+            "statusListCredential": "https://status.example.com/revocation/v1"
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "9D0WeVC2HPVsiYPmxEJwd5GZU-7NsHwrofpT7bfTJtwPf7VbYSo7oAwah4SDSkptdG1DqStAed-3mTfnt7E1CA"
+          }
+        },
+        "statusLists": {
+          "https://status.example.com/revocation/v1": {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/vc/status-list/2021/v1"
+            ],
+            "id": "https://status.example.com/revocation/v1",
+            "type": [
+              "VerifiableCredential",
+              "StatusList2021Credential"
+            ],
+            "issuer": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "issuanceDate": "2026-01-01T00:00:00.000Z",
+            "credentialSubject": {
+              "id": "https://status.example.com/revocation/v1#list",
+              "type": "StatusList2021",
+              "statusPurpose": "revocation",
+              "encodedList": "H4sIAAAAAAAAE-3BMQEAAAzDoBzzr3ky-gBVXQAAAAAAAAAAAAAAAAAAAMDQA3hY9W4AQAAA"
+            },
+            "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2026-01-01T00:00:00.000Z",
+              "verificationMethod": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "UDws4jAsxE630KMcnztweRT0AG-vsNiIJPg6yuaJWbQQ8kwnvsm_XbuTKwC3oacGkXobg_H2359ogPCE7cSdAQ"
+            }
+          }
+        },
+        "didDocuments": {
+          "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC": {
+            "id": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "mdDj3O3iv9wFTm9U-qETuatpiy1blSY7CfpraW6Zauk"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC"
+            ],
+            "authentication": [
+              "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC"
+            ]
+          }
+        },
+        "serverDid": "did:web:server.example.com"
+      }
+    },
+    {
+      "id": "status-list/revoked-credential",
+      "category": "status-list",
+      "description": "Delegation whose StatusList2021 bit is 1 (revoked)",
+      "expected": "fail",
+      "reason": "A set revocation bit must reject the credential",
+      "input": {
+        "credential": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.kya-os.org/v1/protocol/delegation/context/v1.0.0"
+          ],
+          "id": "urn:uuid:del-revoked",
+          "type": [
+            "VerifiableCredential",
+            "DelegationCredential"
+          ],
+          "issuer": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+          "issuanceDate": "2026-01-01T00:00:00.000Z",
+          "credentialSubject": {
+            "id": "did:key:z6MkeggQWvuoyisNKLpdVXfAn9xhCc2RepHf2tifw4T4g5P9",
+            "delegation": {
+              "id": "del-revoked",
+              "issuerDid": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+              "subjectDid": "did:key:z6MkeggQWvuoyisNKLpdVXfAn9xhCc2RepHf2tifw4T4g5P9",
+              "scopes": [
+                "greeting:read"
+              ],
+              "constraints": {
+                "scopes": [
+                  "greeting:read"
+                ],
+                "audience": "did:web:server.example.com"
+              },
+              "status": "active",
+              "createdAt": 1750000000000
+            }
+          },
+          "credentialStatus": {
+            "id": "https://status.example.com/revocation/v1#42",
+            "type": "StatusList2021Entry",
+            "statusPurpose": "revocation",
+            "statusListIndex": "42",
+            "statusListCredential": "https://status.example.com/revocation/v1"
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-01-01T00:00:00.000Z",
+            "verificationMethod": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "d3689VwmE9XAlgxV_bGJ4Yu3eTdqfD-uX5ULi7yCYP17aCjLueUcyZ-vYdimuLzY3bpcxO0ENmtI8dBMu-XUAQ"
+          }
+        },
+        "statusLists": {
+          "https://status.example.com/revocation/v1": {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/vc/status-list/2021/v1"
+            ],
+            "id": "https://status.example.com/revocation/v1",
+            "type": [
+              "VerifiableCredential",
+              "StatusList2021Credential"
+            ],
+            "issuer": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "issuanceDate": "2026-01-01T00:00:00.000Z",
+            "credentialSubject": {
+              "id": "https://status.example.com/revocation/v1#list",
+              "type": "StatusList2021",
+              "statusPurpose": "revocation",
+              "encodedList": "H4sIAAAAAAAAE-3BMQEAAAzDoBzzr3ky-gBVXQAAAAAAAAAAAAAAAAAAAMDQA3hY9W4AQAAA"
+            },
+            "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2026-01-01T00:00:00.000Z",
+              "verificationMethod": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "UDws4jAsxE630KMcnztweRT0AG-vsNiIJPg6yuaJWbQQ8kwnvsm_XbuTKwC3oacGkXobg_H2359ogPCE7cSdAQ"
+            }
+          }
+        },
+        "didDocuments": {
+          "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC": {
+            "id": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+            "verificationMethod": [
+              {
+                "id": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "Ed25519",
+                  "x": "mdDj3O3iv9wFTm9U-qETuatpiy1blSY7CfpraW6Zauk"
+                }
+              }
+            ],
+            "assertionMethod": [
+              "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC"
+            ],
+            "authentication": [
+              "did:key:z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC#z6MkpohAd19HtQbX6koPcsk5HgKoDXYm1RrJNJfQvuDCB4nC"
+            ]
+          }
+        },
+        "serverDid": "did:web:server.example.com"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
+    "conformance": "tsx conformance/bin.ts",
+    "conformance:generate": "tsx conformance/generate-vectors.ts",
+    "conformance:typecheck": "tsc --noEmit -p conformance/tsconfig.json",
     "lint": "eslint src --ext .ts",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run clean && npm run build && npm run test",
@@ -105,6 +108,7 @@
     "commander": "^14.0.3",
     "eslint": "^10.0.3",
     "express": "^5.2.1",
+    "tsx": "^4.22.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.57.0",
     "vitest": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.5.3
         version: 5.9.3
@@ -93,9 +96,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -105,9 +120,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -117,9 +144,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -129,9 +168,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -141,9 +192,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -153,9 +216,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -165,9 +240,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -177,9 +264,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -189,11 +288,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -201,9 +324,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -213,15 +354,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -788,6 +947,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-html@1.0.3:
@@ -1371,6 +1535,11 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1531,70 +1700,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3)':
@@ -2172,6 +2419,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-html@1.0.3: {}
 
@@ -2799,6 +3075,12 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## What & why

Part of the cross-repo engineering-hardening initiative (the 5 highest-ROI items from the 2026-06 code audit). This PR covers kya-os-mcp's slice.

## Verification
```
pnpm install
pnpm exec tsx conformance/generate-vectors.ts (generated 19 vectors across 5 files)
pnpm run conformance (exit 0; 19/19 match)
forced-mismatch check: flipped one vector's expected, pnpm run conformance exit 1; restored
pnpm exec vitest run conformance/__tests__/conformance.test.ts (3 passed)
pnpm run conformance:typecheck / tsc --noEmit -p conformance/tsconfig.json (clean)
pnpm exec tsc --noEmit (root, clean)
pnpm exec eslint conformance --ext .ts (clean after fixes)
pnpm build then pnpm exec vitest run (86 files, 1211 tests passed)
python3 yaml.safe_load on ci.yml + dependabot.yml (OK)
```
**Result:** Harness exits 0 with all 19 vectors matching and exits 1 on a forced mismatch. Conformance vitest test passes (3/3). Both root and conformance typechecks are clean. ESLint clean on the new dir. Full suite green: 86 test files / 1211 tests pass once dist is built (examples/* tests import @kya-os/mcp by name and require the built dist — a pre-existing requirement; a first run before `pnpm build` showed those 15 example files failing to resolve the package entry, all green after build). YAML valid.

**Deferred to CI:** Full CI matrix (ubuntu/macos/windows x Node 20/22) — verified locally on macOS + Node 22.3 only; CodeQL scan and the new Protocol Conformance Harness job as they run in GitHub Actions

## Review
Adversarial reviewer verdict: **pass** (tdd=True, build=True, security=True, solid/dry=True, scope=True).

> Governance note: branch-protection / secret-scanning toggles are delivered as a runbook+script (`scripts/governance/`) per request — not auto-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)