### PR TITLE
fix(ci): post coverage comments via workflow_run so fork PRs stop 403ing

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -34,7 +34,22 @@ jobs:
           script: |
             const fs = require('fs');
 
-            const prNumber = parseInt(fs.readFileSync('/tmp/coverage-comment/pr-number.txt', 'utf8').trim(), 10);
+            // Resolve the PR from the workflow_run's head_sha, which GitHub sets
+            // server-side and the fork's job can't influence — never trust a PR
+            // number that came out of a job that ran untrusted fork code.
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+
+            const pr = pulls.find(p => p.state === 'open') ?? pulls[0];
+            if (!pr) {
+              core.setFailed(`No pull request found for head_sha ${context.payload.workflow_run.head_sha}`);
+              return;
+            }
+            const prNumber = pr.number;
+
             const body = fs.readFileSync('/tmp/coverage-comment/coverage-comment-body.md', 'utf8');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,63 @@
+name: Coverage Comment
+
+# Runs after Coverage Report finishes, using the base repo's workflow file
+# and token — not the fork's. This is what lets us post/update the coverage
+# comment on PRs from forks, where the pull_request-triggered job only ever
+# gets a read-only GITHUB_TOKEN. See coverage-report.yml for the artifact it
+# consumes.
+on:
+  workflow_run:
+    workflows: [Coverage Report]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download coverage comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-comment
+          path: /tmp/coverage-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update coverage comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+
+            const prNumber = parseInt(fs.readFileSync('/tmp/coverage-comment/pr-number.txt', 'utf8').trim(), 10);
+            const body = fs.readFileSync('/tmp/coverage-comment/coverage-comment-body.md', 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const marker = '## Coverage Report';
+            const existing = comments.find(c => c.body?.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   coverage:
@@ -57,8 +56,11 @@ jobs:
             echo '{}' > /tmp/base-coverage.json
           fi
 
-      # Generate the comment
-      - name: Generate coverage comment
+      # Render the comment body to a file. This job runs against the PR head
+      # (untrusted for fork PRs), so GITHUB_TOKEN here is read-only and can't
+      # post comments — a separate workflow_run job (coverage-comment.yml),
+      # which runs with the base repo's token, uploads it.
+      - name: Render coverage comment
         uses: actions/github-script@v9
         with:
           script: |
@@ -77,12 +79,8 @@ jobs:
             }
 
             if (!pr || !pr.total) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: '⚠️ Coverage report unavailable — tests may have failed.',
-              });
+              fs.writeFileSync('/tmp/coverage-comment-body.md', '⚠️ Coverage report unavailable — tests may have failed.');
+              fs.writeFileSync('/tmp/pr-number.txt', String(context.issue.number));
               return;
             }
 
@@ -158,28 +156,14 @@ jobs:
             body += `- **Config**: vitest + v8, thresholds enforced in \`vitest.config.mts\`\n`;
             body += `</details>\n`;
 
-            // Find and update existing comment or create new one
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            fs.writeFileSync('/tmp/coverage-comment-body.md', body);
+            fs.writeFileSync('/tmp/pr-number.txt', String(context.issue.number));
 
-            const marker = '## Coverage Report';
-            const existing = comments.find(c => c.body?.startsWith(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+      - name: Upload coverage comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-comment
+          path: |
+            /tmp/coverage-comment-body.md
+            /tmp/pr-number.txt
+          retention-days: 1

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -59,7 +59,11 @@ jobs:
       # Render the comment body to a file. This job runs against the PR head
       # (untrusted for fork PRs), so GITHUB_TOKEN here is read-only and can't
       # post comments — a separate workflow_run job (coverage-comment.yml),
-      # which runs with the base repo's token, uploads it.
+      # which runs with the base repo's token, uploads it. The artifact only
+      # carries the rendered body, never a PR/issue number: coverage-comment.yml
+      # derives the target PR itself from the trusted workflow_run.head_sha, since
+      # anything written here runs alongside untrusted fork code and could be
+      # tampered with to redirect the comment to an unrelated PR or issue.
       - name: Render coverage comment
         uses: actions/github-script@v9
         with:
@@ -80,7 +84,6 @@ jobs:
 
             if (!pr || !pr.total) {
               fs.writeFileSync('/tmp/coverage-comment-body.md', '⚠️ Coverage report unavailable — tests may have failed.');
-              fs.writeFileSync('/tmp/pr-number.txt', String(context.issue.number));
               return;
             }
 
@@ -157,13 +160,10 @@ jobs:
             body += `</details>\n`;
 
             fs.writeFileSync('/tmp/coverage-comment-body.md', body);
-            fs.writeFileSync('/tmp/pr-number.txt', String(context.issue.number));
 
       - name: Upload coverage comment
         uses: actions/upload-artifact@v4
         with:
           name: coverage-comment
-          path: |
-            /tmp/coverage-comment-body.md
-            /tmp/pr-number.txt
+          path: /tmp/coverage-comment-body.md
           retention-days: 1


### PR DESCRIPTION
## Summary

The Coverage Report workflow was failing on cross-repo PRs (e.g. #93 from cheqd's fork) with a 403 when trying to post the coverage comment. GitHub forces `GITHUB_TOKEN` to read-only for `pull_request`-triggered workflows on fork PRs, regardless of what the `permissions:` block declares, so the direct `issues.createComment` call could never work there.

- `coverage-report.yml` no longer calls the comments API. It renders the coverage comment body and uploads it as an artifact (dropped the now-unused `pull-requests: write` permission).
- New `coverage-comment.yml` runs on `workflow_run` after Coverage Report completes. Because `workflow_run` always executes with the base repo's workflow file and token, it can download the artifact and post/update the comment even when the triggering PR came from a fork.
- The target PR is resolved via `listPullRequestsAssociatedWithCommit` against `workflow_run.head_sha` (server-side, not attacker-influenced) rather than trusting anything written by the job that ran the fork's own install/test scripts — avoids a cross-PR comment injection where a malicious PR could otherwise redirect the comment to an arbitrary issue/PR.

## Test plan

- [ ] Merge to `main`, then re-run the "Coverage Report" job on PR #93 and confirm it succeeds and a comment appears
- [ ] Open/push to a same-repo PR and confirm the comment still posts and updates in place on subsequent pushes
- [ ] Confirm coverage-comment.yml is skipped (no comment attempted) if Coverage Report's job fails outright