### PR TITLE
chore(tsconfig): enable noUnusedLocals + noUnusedParameters

### DIFF
--- a/src/delegation/bitstring.ts
+++ b/src/delegation/bitstring.ts
@@ -40,7 +40,10 @@ export class BitstringManager {
   constructor(
     size: number,
     private compressor: CompressionFunction,
-    private decompressor: DecompressionFunction
+    // Accepted for signature symmetry with decode()/fromSetBits() and public
+    // back-compat, but the INSTANCE never decompresses: decode() inflates via
+    // the shared inflateStatusList() before construction, so no field is stored.
+    _decompressor: DecompressionFunction
   ) {
     this.size = size;
     const byteCount = Math.ceil(size / 8);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
## What

Enable `noUnusedLocals` and `noUnusedParameters` in `tsconfig.json`, and remove the one piece of dead code they surface.

## Why

Dead code (unused imports, locals, params) was only caught by the CI eslint step — `tsc` was silent on it because these flags were off. That splits dead-code detection out of the fast local typecheck loop, so it's easy to get a green `tsc --noEmit` locally and still fail CI lint.

Enabling the flags also catches a class of dead code **eslint structurally cannot**: `@typescript-eslint/no-unused-vars` targets imports/locals/args, but does **not** flag unused private class members or constructor parameter properties. `tsc`'s `noUnusedLocals` (`TS6138`) does — which is exactly how the finding below slipped past lint + CI.

## Blast radius: one finding

Enabling both flags surfaces exactly **one** error across the whole codebase:

```
src/delegation/bitstring.ts: Property 'decompressor' is declared but its value is never read (TS6138)
```

`BitstringManager` stored a constructor `decompressor` as a private field that nothing ever reads: `decode()` inflates the status list via the shared `inflateStatusList()` helper *before* constructing the manager, and `getBit`/`setBit` operate on the already-inflated `this.bits`. The field was a vestige from before the decode path was extracted.

**Fix, non-breaking:** `BitstringManager` is root-exported (`src/index.ts`), so the constructor is public API. Rather than change its arity (a semver-breaking change), the constructor still *accepts* the third argument but no longer stores it — the unused field is gone, the public signature is preserved, and `decode()`/`fromSetBits()` are unchanged. No version bump.

## Verification

Full local gate (all four CI steps):

- `tsc --noEmit` (with the new flags) — clean
- `npm run lint` — clean
- `npm run build` — clean
- tests — **1607 passed / 1 skipped**, conformance harness **PASS**

## Effect

Dead code — including the unused-private-member class eslint can't see — now fails the fast typecheck, closing the local false-green window.
