### PR TITLE
feat: entity-card design refinements — unfused-cnf diagnostic + DPoP relationship

### DIFF
--- a/SPEC-ENTITY-CARD.md
+++ b/SPEC-ENTITY-CARD.md
@@ -554,6 +554,13 @@ is a downgrade attempt and MUST fail closed (`cnf_required_by_token`, §11.2, §
 threads L1 token possession (§7) to L3 per-request proof-of-possession: **a stolen bearer token is
 inert without live possession of the DID key.**
 
+Where a proof DOES carry a `cnf` but the verifier is given no token `cnf.jkt` to fuse it against, the
+degradation to L3-minus is legitimate but easy to cause by misconfiguration (a verifier that simply
+never extracted the token's `cnf`). A verifier SHOULD therefore emit a **non-fatal** diagnostic —
+`cnf_present_but_token_unfused` — in that case. It does not affect validity (the proof is a sound
+L3-minus proof) and is distinct from the fail-closed `reasons`; its only purpose is to let an
+integrator who intended L3 observe the downgrade rather than have it pass silently.
+
 ### 8.7 Bindings summary
 
 | Binding | Defends against |
@@ -563,6 +570,45 @@ inert without live possession of the DID key.**
 | `nonce` + `created`/`expires` → NOW | replay (§12.2) |
 | `kid` → a DID verification method (and `kid.split('#')[0] === did`) | forged principal (§11.2, §12.1) |
 | `cnf.jkt` fusion | session-carry / stolen bearer token (§12.4) |
+
+### 8.8 Relationship to RFC 9449 (DPoP)
+
+`org.kya-os/proof@1` is a per-request proof-of-possession mechanism and it deliberately overlaps with
+DPoP [RFC9449]: both bind a fresh, short-lived proof to every request, both carry a nonce and a
+validity window, and both express the sender-constraint as an RFC 7638 [RFC7638] `cnf.jkt` thumbprint.
+This profile does **not** aim to replace DPoP. Where an authorization server issues DPoP-sender-
+constrained tokens, the two **compose** (see *Composition* below). This section records the specific
+points where the binding differs, and why, so that the mechanisms are not conflated.
+
+- **Request binding.** DPoP binds the HTTP method and target URI (`htm`/`htu`). An MCP tool call is a
+  JSON-RPC message, and under the Streamable HTTP transport such calls are typically `POST`ed to a
+  single `/mcp` endpoint — so `htm`/`htu` are identical across every call and distinguish no
+  operation; under the stdio transport there is no HTTP envelope to bind at all. The profile therefore
+  binds the JSON-RPC operation directly — `requestHash = SHA-256( RFC 8785 JCS({ method, params }) )`
+  (§8.3) — which is the invariant that actually identifies the request across both transports.
+- **Carrier.** DPoP travels as an HTTP header. This proof travels in the request's `_meta` (§8.2),
+  in-band with the JSON-RPC message, so it is transport-agnostic — the same proof verifies over stdio
+  and over Streamable HTTP. For deployments that terminate at an HTTP edge, §8.5 defines an OPTIONAL
+  RFC 9421 [RFC9421] HTTP Message Signature sibling over the same covered claims, so a
+  message-signature-aware intermediary can additionally check the proof at that layer.
+- **Key-to-principal anchoring.** A DPoP proof carries its public key inline (the JWT header `jwk`),
+  and the sender-constraint is that the token was issued bound to that key. This proof additionally
+  requires the signing key to be a verification method published by the caller's DID document
+  (`kid.split('#')[0] === did` plus RFC 7638 thumbprint membership, §8.4, §11.2), so possession is
+  bound not only to a token but to a discoverable, accountable **principal** (the Entity's Card DID) —
+  the identity axis DPoP does not itself address.
+- **Audience.** The proof binds a recipient `audience` DID (§8.4) — the intended recipient Entity —
+  closing relay / confused-deputy at the level of a principal's identity, which DPoP's `htu` (a URI)
+  does not express.
+- **Composition (§7.5, §8.6).** Where the authorization server does issue a DPoP-sender-constrained
+  access token, its `cnf.jkt` is fused with the proof's `cnf.jkt` and the resolved DID key to reach
+  **L3**: one key threads token possession and per-request possession. DPoP then operates at the token
+  layer and this proof at the per-request JSON-RPC layer — complementary, not competing. Absent an AS
+  `cnf`, the proof degrades to L3-minus (§8.6); it never requires DPoP and never conflicts with it.
+
+For a conventional HTTP resource server, DPoP remains the appropriate mechanism. This profile targets
+the MCP/JSON-RPC transport and the DID-anchored, typed-identity model, and reuses DPoP's
+sender-constraint semantics wherever they are present.
 
 ---
 

--- a/src/card/__tests__/middleware.test.ts
+++ b/src/card/__tests__/middleware.test.ts
@@ -86,7 +86,14 @@ describe('requireProof — the per-request holder-of-key guard', () => {
     const { signer, publicJwk } = await keypair();
     const guard = requireProof(deps(publicJwk));
     const result = await guard(REQ, await mintMeta(signer));
-    expect(result).toEqual({ ok: true, did: signer.did, level: 'L3-minus' });
+    // The proof carried a cnf but no token cnf was wired, so the guard surfaces the non-fatal
+    // unfused-cnf warning (TM-1) alongside the valid L3-minus result — it does not fail the guard.
+    expect(result).toEqual({
+      ok: true,
+      did: signer.did,
+      level: 'L3-minus',
+      warnings: ['cnf_present_but_token_unfused'],
+    });
   });
 
   it('derives L3 when the token cnf fuses with the proof key', async () => {

--- a/src/card/__tests__/proof.test.ts
+++ b/src/card/__tests__/proof.test.ts
@@ -61,7 +61,16 @@ describe('verifyCardProof — happy path', () => {
   it('verifies a valid proof and derives L3-minus without a token cnf', async () => {
     const { signer, publicJwk } = await keypair();
     const res = await verifyCardProof(await mint(signer), REQ, deps(publicJwk));
-    expect(res).toEqual({ ok: true, reasons: [], level: 'L3-minus', did: DID });
+    // The proof carries a cnf but no token cnf was wired to fuse it against, so it degrades to a
+    // valid L3-minus proof AND surfaces a NON-FATAL warning (TM-1) so the downgrade is observable.
+    // ok / reasons / level are unaffected — the warning does not fail the proof closed.
+    expect(res).toEqual({
+      ok: true,
+      reasons: [],
+      level: 'L3-minus',
+      did: DID,
+      warnings: ['cnf_present_but_token_unfused'],
+    });
   });
 
   it('accepts the proof when resolveDidKeys confirms the signing key is published by the DID', async () => {
@@ -77,6 +86,18 @@ describe('verifyCardProof — cnf.jkt fusion (RFC 7638 / 9449)', () => {
     const res = await verifyCardProof(await mint(signer), REQ, deps(publicJwk, { tokenCnfJkt: signer.jkt }));
     expect(res.ok).toBe(true);
     expect(res.level).toBe('L3');
+    // When the cnf actually fuses to L3 there is nothing unfused to warn about.
+    expect(res.warnings).toBeUndefined();
+  });
+
+  it('emits NO unfused-cnf warning when the proof itself carried no cnf', async () => {
+    const { signer, publicJwk } = await keypair();
+    const noCnf: ProofSigner = { did: signer.did, kid: signer.kid, sign: signer.sign };
+    const res = await verifyCardProof(await mint(noCnf), REQ, deps(publicJwk));
+    // No cnf presented → the L3-minus degradation is expected, not a misconfiguration, so no warning.
+    expect(res.ok).toBe(true);
+    expect(res.level).toBe('L3-minus');
+    expect(res.warnings).toBeUndefined();
   });
 
   it('rejects a token cnf.jkt that does not fuse with the proof', async () => {

--- a/src/card/__tests__/vectors.test.ts
+++ b/src/card/__tests__/vectors.test.ts
@@ -119,7 +119,15 @@ describe('conformance vector: card-proof.json (org.kya-os/proof@1)', () => {
 
   it('verifyCardProof recomputes every binding → ok, L3-minus without a token cnf', async () => {
     const res = await verifyCardProof(proof, request, proofDeps());
-    expect(res).toEqual({ ok: true, reasons: [], level: 'L3-minus', did: proof.did });
+    // The vector proof carries a cnf; with no token cnf wired it degrades to L3-minus and surfaces
+    // the non-fatal unfused-cnf warning (TM-1). The pass/fail conformance outcome is unaffected.
+    expect(res).toEqual({
+      ok: true,
+      reasons: [],
+      level: 'L3-minus',
+      did: proof.did,
+      warnings: ['cnf_present_but_token_unfused'],
+    });
   });
 
   it('verifyCardProof fuses the token cnf.jkt → L3', async () => {

--- a/src/card/middleware.ts
+++ b/src/card/middleware.ts
@@ -138,7 +138,7 @@ export interface ProofGateError {
 
 /** The guard verdict: a pass carries the accountable principal + assurance; a fail is 401-shaped. */
 export type ProofGateResult =
-  | { ok: true; did: string; level: ProofAssurance }
+  | { ok: true; did: string; level: ProofAssurance; warnings?: string[] }
   | { ok: false; status: 401; error: ProofGateError };
 
 /**
@@ -184,7 +184,12 @@ export function requireProof(deps: VerifyProofDeps, opts: RequireProofOptions = 
       const message = `proof assurance ${level} is below the required ${opts.minLevel}`;
       return fail('proof_level_insufficient', message, ['proof_level_insufficient']);
     }
-    return { ok: true, did: result.did, level };
+    return {
+      ok: true,
+      did: result.did,
+      level,
+      ...(result.warnings ? { warnings: result.warnings } : {}),
+    };
   };
 }
 

--- a/src/card/proof/types.ts
+++ b/src/card/proof/types.ts
@@ -235,4 +235,12 @@ export interface ProofVerifyResult {
   /** Present only when `ok`: the derived assurance and the accountable principal DID. */
   level?: ProofAssurance;
   did?: string;
+  /**
+   * Non-fatal diagnostics. Unlike `reasons`, these do NOT affect `ok` — the proof is valid — but
+   * flag a configuration state a caller should be able to observe. Currently:
+   * `cnf_present_but_token_unfused` — the proof carried a sender-constraint (`cnf`) that could not be
+   * fused because the verifier was given no token `cnf.jkt` (`tokenCnfJkt`), so assurance is L3-minus,
+   * not L3. Surfaced so an integrator who intended L3 sees the downgrade instead of it passing silently.
+   */
+  warnings?: string[];
 }

--- a/src/card/proof/verify.ts
+++ b/src/card/proof/verify.ts
@@ -68,11 +68,15 @@ export async function verifyCardProof(
   await consumeNonce(meta, deps, reasons);
   if (key && algOk && !(await verifyDetachedJws(meta, key))) reasons.push('invalid_signature');
 
+  const warnings: string[] = [];
   let level: ProofAssurance = 'L3-minus';
-  if (key) level = await checkCnfFusion(meta, key, deps, reasons);
+  if (key) level = await checkCnfFusion(meta, key, deps, reasons, warnings);
 
   const ok = reasons.length === 0;
-  return ok ? { ok, reasons, level, did: meta.did } : { ok, reasons };
+  const withWarnings = warnings.length > 0 ? { warnings } : {};
+  return ok
+    ? { ok, reasons, level, did: meta.did, ...withWarnings }
+    : { ok, reasons, ...withWarnings };
 }
 
 /** Resolve the signing key for `kid`; fail-closed (records `key_unresolvable`) on throw. */
@@ -206,6 +210,7 @@ async function checkCnfFusion(
   key: ProofPublicJwk,
   deps: VerifyProofDeps,
   reasons: string[],
+  warnings: string[],
 ): Promise<ProofAssurance> {
   let keyJkt: string;
   try {
@@ -216,7 +221,15 @@ async function checkCnfFusion(
     return 'L3-minus';
   }
   if (meta.cnf && meta.cnf.jkt !== keyJkt) reasons.push('cnf_key_mismatch');
-  if (deps.tokenCnfJkt === undefined) return 'L3-minus';
+  if (deps.tokenCnfJkt === undefined) {
+    // No token cnf.jkt was supplied, so there is nothing to fuse against and assurance is L3-minus.
+    // If the client nonetheless PRESENTED a sender-constraint (`cnf`), the proof was capable of L3 —
+    // it degraded only because `tokenCnfJkt` was not wired. That is a valid L3-minus proof, not a
+    // failure, so it is a warning (not a reason): it lets an integrator who intended L3 notice the
+    // silent downgrade rather than assume token-theft resistance they are not actually getting.
+    if (meta.cnf) warnings.push('cnf_present_but_token_unfused');
+    return 'L3-minus';
+  }
   if (!meta.cnf) {
     reasons.push('cnf_required_by_token');
     return 'L3-minus';


### PR DESCRIPTION
## What

Two self-contained refinements from the entity-card design audit. No behaviour of a *valid* proof changes; nothing is failed closed that wasn't before.

### 1. `feat(proof)` — surface a non-fatal warning when a presented `cnf` is left unfused (audit finding **TM-1**)

`verifyCardProof` returned `L3-minus` **silently** when a proof carried a `cnf` sender-constraint but the verifier was handed no token `cnf.jkt` to fuse it against. That degradation is legitimate, but it's also exactly what a misconfiguration looks like — an integrator who intended L3 (stolen-token resistance) but forgot to wire `tokenCnfJkt` gets L3-minus with zero signal.

- Adds a `warnings` channel to `ProofVerifyResult`, **distinct from the fail-closed `reasons`** so `ok` and `level` are unaffected — the proof is still a sound L3-minus proof.
- Emits `cnf_present_but_token_unfused` in exactly that case, and surfaces it through the `requireProof` guard.
- Effect: the L3→L3-minus downgrade is now observable instead of silent.

### 2. `docs(spec)` — §8.6 diagnostic note + §8.8 "Relationship to RFC 9449 (DPoP)"

- §8.6 documents the new non-fatal warning alongside the degradation.
- **§8.8 (new)** addresses the most-raised question in the design review — *"why not just DPoP?"* It acknowledges the deliberate overlap up front, then records the specific, transport- and identity-model-motivated reasons the bindings differ (request binding over JSON-RPC vs `htm`/`htu`; the in-band `_meta` carrier vs an HTTP header; DID-verification-method key anchoring vs an inline `jwk`; a recipient `audience` DID), and states plainly that the profile **composes with** DPoP — fusing the token `cnf.jkt` to reach L3 — rather than replacing it. For a conventional HTTP resource server, it notes DPoP remains the appropriate mechanism.

## Not included

- **No `schema.kya-os.org` / published-schema changes.** `warnings` lives on the verifier *result* (`ProofVerifyResult`), not on any wire object — the Card, Delegation, and `detached-proof` JSON schemas are untouched, and no `schemas/*.json` file changed.
- **No conformance-vector or cross-language (`verify.py`) changes.** The harness compares pass/fail, which is unchanged; conformance stays 33/33.
- **Non-breaking**, additive only — no version bump implied.

## Verification

Full four-step gate locally (matching CI):

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — clean
- tests — **1608 passed / 1 skipped**; conformance harness **PASS (33/33)**
