### PR TITLE
feat(delegation): verify VC-JWT (compact JWS) delegation credentials

### DIFF
--- a/src/delegation/__tests__/vc-jwt-verify.test.ts
+++ b/src/delegation/__tests__/vc-jwt-verify.test.ts
@@ -1,0 +1,252 @@
+/**
+ * High-level VC-JWT verification tests (real EdDSA crypto).
+ *
+ * `vc-jwt.test.ts` covers the create/parse PRIMITIVES in `utils.ts`. This file
+ * covers `DelegationCredentialVerifier.verifyDelegationJwt` — the DID-resolving
+ * verify of the JWT serialization (the compact JWS a browser wallet mints,
+ * where the envelope signature IS the proof, with no embedded `proof` block).
+ * It proves the verifier accepts that wire format and rejects the failure modes
+ * that matter — most importantly the DID-doc-key-vs-signing-key mismatch that
+ * surfaced against the Hobbsidian wallet.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { generateKeyPair, exportJWK, SignJWT, type JWK } from "jose";
+import {
+  DelegationCredentialVerifier,
+  type DIDResolver,
+  type DIDDocument,
+} from "../vc-verifier.js";
+import { credentialIssuerDid } from "../vc-jwt-verify.js";
+import type { DelegationCredential } from "../../types/protocol.js";
+
+const ISSUER_DID = "did:web:example.com:u:alice";
+const KID = `${ISSUER_DID}#0`;
+
+function delegationVcClaim(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    id: "urn:uuid:test-credential-1",
+    type: ["VerifiableCredential", "DelegationCredential"],
+    issuer: ISSUER_DID,
+    issuanceDate: "2026-01-01T00:00:00.000Z",
+    expirationDate: "2099-01-01T00:00:00.000Z",
+    credentialSubject: {
+      id: ISSUER_DID,
+      delegation: {
+        id: "del_test_1",
+        issuerDid: ISSUER_DID,
+        subjectDid: ISSUER_DID,
+        signature: "",
+        status: "active",
+        constraints: { scopes: ["vault:read"] },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("verifyDelegationJwt (VC-JWT / compact JWS wire format)", () => {
+  let privateKey: CryptoKey;
+  let publicJwk: JWK;
+  let verifier: DelegationCredentialVerifier;
+
+  const resolverFor = (jwk: JWK): DIDResolver => ({
+    async resolve(did: string): Promise<DIDDocument | null> {
+      if (did !== ISSUER_DID) return null;
+      return {
+        id: ISSUER_DID,
+        verificationMethod: [
+          {
+            id: KID,
+            type: "JsonWebKey2020",
+            controller: ISSUER_DID,
+            publicKeyJwk: jwk,
+          },
+        ],
+      };
+    },
+  });
+
+  async function mintVcJwt(
+    signer: CryptoKey,
+    vcClaim: Record<string, unknown> = delegationVcClaim(),
+  ): Promise<string> {
+    return new SignJWT({ vc: vcClaim })
+      .setProtectedHeader({ alg: "EdDSA", typ: "JWT", kid: KID })
+      .setIssuer(ISSUER_DID)
+      .setSubject(ISSUER_DID)
+      .setIssuedAt()
+      .sign(signer);
+  }
+
+  beforeAll(async () => {
+    const pair = await generateKeyPair("EdDSA", { extractable: true });
+    privateKey = pair.privateKey;
+    publicJwk = await exportJWK(pair.publicKey);
+    verifier = new DelegationCredentialVerifier({
+      didResolver: resolverFor(publicJwk),
+    });
+  });
+
+  it("accepts a valid VC-JWT that carries NO embedded proof", async () => {
+    const jwt = await mintVcJwt(privateKey);
+    const result = await verifier.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(true);
+    expect(result.stage).toBe("complete");
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
+  it("rejects a token signed by a key that is NOT the one published in the DID Document", async () => {
+    // The exact failure Hobbsidian hit: resolved DID-doc key != signing key.
+    const attacker = await generateKeyPair("EdDSA", { extractable: true });
+    const jwt = await mintVcJwt(attacker.privateKey);
+    const result = await verifier.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(false);
+    expect(result.checks?.signatureValid).toBe(false);
+    expect(result.reason).toMatch(/signature is not valid/i);
+  });
+
+  it("rejects a tampered payload (signature no longer covers the claims)", async () => {
+    const jwt = await mintVcJwt(privateKey);
+    const [header, , signature] = jwt.split(".");
+    const forgedPayload = Buffer.from(
+      JSON.stringify({
+        iss: ISSUER_DID,
+        vc: delegationVcClaim({ id: "urn:uuid:forged" }),
+      }),
+    ).toString("base64url");
+    const tampered = `${header}.${forgedPayload}.${signature}`;
+    const result = await verifier.verifyDelegationJwt(tampered, {
+      skipCache: true,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.checks?.signatureValid).toBe(false);
+  });
+
+  it("rejects a token whose credential `issuer` differs from the signed `iss`", async () => {
+    const jwt = await mintVcJwt(
+      privateKey,
+      delegationVcClaim({ issuer: "did:web:evil.example:u:mallory" }),
+    );
+    const result = await verifier.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe("basic");
+    expect(result.reason).toMatch(/does not match the JWT `iss`/i);
+  });
+
+  it("denies when the issuer DID cannot be resolved", async () => {
+    const isolated = new DelegationCredentialVerifier({
+      didResolver: {
+        async resolve(): Promise<DIDDocument | null> {
+          return null;
+        },
+      },
+    });
+    const jwt = await mintVcJwt(privateKey);
+    const result = await isolated.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/could not resolve issuer DID/i);
+  });
+
+  it("denies when no DID resolver is configured", async () => {
+    const noResolver = new DelegationCredentialVerifier({});
+    const jwt = await mintVcJwt(privateKey);
+    const result = await noResolver.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/no DID resolver/i);
+  });
+
+  it("fast-rejects a non-JWT string at the basic stage", async () => {
+    const result = await verifier.verifyDelegationJwt("not-a-jwt", {
+      skipCache: true,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.stage).toBe("basic");
+  });
+
+  it("reads the declared issuer from a string or object `issuer`", () => {
+    expect(credentialIssuerDid({ issuer: ISSUER_DID } as DelegationCredential)).toBe(
+      ISSUER_DID,
+    );
+    expect(
+      credentialIssuerDid({ issuer: { id: ISSUER_DID } } as DelegationCredential),
+    ).toBe(ISSUER_DID);
+    expect(
+      credentialIssuerDid({} as DelegationCredential),
+    ).toBeUndefined();
+  });
+
+  it("caches a valid result and serves it on the next call", async () => {
+    const isolated = new DelegationCredentialVerifier({
+      didResolver: resolverFor(publicJwk),
+    });
+    const jwt = await mintVcJwt(
+      privateKey,
+      delegationVcClaim({ id: "urn:uuid:cache-test" }),
+    );
+
+    const first = await isolated.verifyDelegationJwt(jwt);
+    expect(first.valid).toBe(true);
+    expect(first.cached).toBeUndefined();
+
+    const second = await isolated.verifyDelegationJwt(jwt);
+    expect(second.valid).toBe(true);
+    expect(second.cached).toBe(true);
+  });
+
+  it("honors skipSignature (trusts the envelope without re-checking)", async () => {
+    const jwt = await mintVcJwt(privateKey);
+    const result = await verifier.verifyDelegationJwt(jwt, {
+      skipCache: true,
+      skipSignature: true,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
+  it("checks credentialStatus when the JWT credential carries one", async () => {
+    const checked: string[] = [];
+    const withStatus = new DelegationCredentialVerifier({
+      didResolver: resolverFor(publicJwk),
+      statusListResolver: {
+        async checkStatus(status): Promise<boolean> {
+          checked.push(status.id);
+          return false; // not revoked
+        },
+      },
+    });
+    const jwt = await mintVcJwt(
+      privateKey,
+      delegationVcClaim({
+        credentialStatus: {
+          id: "https://example.com/status/1",
+          type: "StatusList2021Entry",
+          statusPurpose: "revocation",
+          statusListIndex: "0",
+          statusListCredential: "https://example.com/status",
+        },
+      }),
+    );
+
+    const result = await withStatus.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(true);
+    expect(result.checks?.statusValid).toBe(true);
+    expect(checked).toContain("https://example.com/status/1");
+  });
+
+  it('verifies a credential with no top-level id (cache key falls back to "")', async () => {
+    const isolated = new DelegationCredentialVerifier({
+      didResolver: resolverFor(publicJwk),
+    });
+    const claim = delegationVcClaim();
+    delete (claim as Record<string, unknown>).id;
+
+    const jwt = await mintVcJwt(privateKey, claim);
+    const result = await isolated.verifyDelegationJwt(jwt);
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -7,6 +7,7 @@
 
 export * from './vc-issuer.js';
 export * from './vc-verifier.js';
+export * from './vc-jwt-verify.js';
 export * from './bitstring.js';
 export * from './statuslist-manager.js';
 export * from './delegation-graph.js';

--- a/src/delegation/vc-jwt-verify.ts
+++ b/src/delegation/vc-jwt-verify.ts
@@ -1,0 +1,194 @@
+/**
+ * VC-JWT (compact JWS) delegation verification — the high-level check.
+ *
+ * `utils.ts` already provides the VC-JWT PRIMITIVES (`createUnsignedVCJWT`,
+ * `completeVCJWT`, `parseVCJWT`). What was missing is the high-level VERIFY:
+ * resolving the issuer DID and checking the envelope signature against its
+ * published key, so {@link DelegationCredentialVerifier} can accept the JWT
+ * serialization of a Verifiable Credential (W3C VC Data Model 1.1 §6.3.1) — the
+ * compact JWS a browser wallet mints, where the envelope signature over
+ * `header.payload` IS the proof and there is no embedded Data Integrity `proof`
+ * block. A verifier that only accepts embedded-proof VCs rejects that wire
+ * format as "Missing proof".
+ *
+ * This module adds only the envelope-signature check; parsing stays in
+ * `parseVCJWT`, and the extracted credential flows through the SAME downstream
+ * checks (basic shape, expiry, status) as a Data Integrity VC.
+ *
+ * Related: W3C VC Data Model 1.1 §6.3.1 (JWT), KYA-OS §4.3
+ */
+
+import { compactVerify, importJWK } from "jose";
+import type { JWK } from "jose";
+import type { DelegationCredential } from "../types/protocol.js";
+import type {
+  DIDResolver,
+  VerificationMethod,
+  DelegationVCVerificationResult,
+} from "./vc-verifier.types.js";
+import { parseVCJWT } from "./utils.js";
+import { validateBasicProperties } from "./vc-verification-checks.js";
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The credential's own declared issuer as a DID string (VC `issuer` may be a
+ * string or an object with `id`). `undefined` when absent/malformed. The
+ * verifier requires this to equal the JWT `iss` — a credential must not claim
+ * an issuer other than the key that actually signed the envelope.
+ */
+export function credentialIssuerDid(
+  credential: DelegationCredential,
+): string | undefined {
+  const iss = credential.issuer;
+  if (typeof iss === "string") return iss;
+  if (iss && typeof iss === "object" && typeof iss.id === "string") {
+    return iss.id;
+  }
+  return undefined;
+}
+
+function jwtBasicFailure(
+  reason: string | undefined,
+  startTime: number,
+  basicCheckMs?: number,
+): DelegationVCVerificationResult {
+  return {
+    valid: false,
+    reason,
+    stage: "basic",
+    metrics:
+      basicCheckMs !== undefined
+        ? { basicCheckMs, totalMs: Date.now() - startTime }
+        : { totalMs: Date.now() - startTime },
+    checks: { basicValid: false },
+  };
+}
+
+/** A parsed, structurally-valid VC-JWT plus the coordinates to look up its key. */
+export type PreparedVcJwt =
+  | {
+      vc: DelegationCredential;
+      issuerDid: string;
+      kid: string | undefined;
+      basicCheckMs: number;
+    }
+  | { failure: DelegationVCVerificationResult };
+
+/**
+ * Parse a VC-JWT and run the no-network fast checks: 3-part structure, the
+ * basic property checks (with no embedded-`proof` requirement — the envelope is
+ * the proof), and issuer↔`iss` consistency (the credential must not name an
+ * issuer other than the key that signs it). Returns the validated credential
+ * and its key-lookup coordinates, or a terminal `failure` at the `basic` stage.
+ * The issuer DID is taken from the `iss` claim, never the inner `vc.issuer`.
+ */
+export function prepareVcJwtCredential(
+  jwt: string,
+  startTime: number,
+): PreparedVcJwt {
+  const parsed = parseVCJWT(jwt);
+  if (!parsed) {
+    return { failure: jwtBasicFailure("Not a valid VC-JWT (parse failed)", startTime) };
+  }
+
+  const basicCheckStart = Date.now();
+  const vc = parsed.payload.vc as DelegationCredential;
+  const basicValidation = validateBasicProperties(vc, {
+    requireEmbeddedProof: false,
+  });
+  const basicCheckMs = Date.now() - basicCheckStart;
+
+  if (!basicValidation.valid) {
+    return {
+      failure: jwtBasicFailure(basicValidation.reason, startTime, basicCheckMs),
+    };
+  }
+
+  if (credentialIssuerDid(vc) !== parsed.payload.iss) {
+    return {
+      failure: jwtBasicFailure(
+        "Credential `issuer` does not match the JWT `iss` (the verified signer)",
+        startTime,
+        basicCheckMs,
+      ),
+    };
+  }
+
+  return {
+    vc,
+    issuerDid: parsed.payload.iss,
+    kid: parsed.header.kid,
+    basicCheckMs,
+  };
+}
+
+export interface VcJwtSignatureResult {
+  valid: boolean;
+  reason?: string;
+  durationMs: number;
+}
+
+function selectVerificationMethod(
+  methods: VerificationMethod[],
+  kid: string | undefined,
+): VerificationMethod | undefined {
+  return kid ? methods.find((m) => m.id === kid) : methods[0];
+}
+
+/**
+ * Verify a VC-JWT's EdDSA envelope signature against the issuer's published
+ * key. Resolves `issuerDid`, selects the verification method named by `kid`
+ * (or the first when `kid` is absent), imports its `publicKeyJwk`, and checks
+ * the compact JWS with `jose` — `algorithms` pinned to `EdDSA`, so a token
+ * cannot downgrade the suite or claim `alg: none`. Fail-closed: any
+ * resolution, key-import, or verification problem denies.
+ */
+export async function verifyVcJwtSignature(
+  jwt: string,
+  issuerDid: string,
+  kid: string | undefined,
+  didResolver: DIDResolver | undefined,
+): Promise<VcJwtSignatureResult> {
+  const startTime = Date.now();
+  const done = (valid: boolean, reason?: string): VcJwtSignatureResult => ({
+    valid,
+    reason,
+    durationMs: Date.now() - startTime,
+  });
+
+  if (!didResolver) {
+    return done(
+      false,
+      "No DID resolver configured — signature cannot be verified",
+    );
+  }
+
+  const didDoc = await didResolver.resolve(issuerDid);
+  if (!didDoc) {
+    return done(false, `Could not resolve issuer DID: ${issuerDid}`);
+  }
+
+  const vm = selectVerificationMethod(didDoc.verificationMethod ?? [], kid);
+  if (!vm) {
+    return done(
+      false,
+      kid
+        ? `Verification method ${kid} not found in DID Document`
+        : "DID Document has no verification method",
+    );
+  }
+  if (!vm.publicKeyJwk) {
+    return done(false, "Verification method missing publicKeyJwk");
+  }
+
+  try {
+    const key = await importJWK(vm.publicKeyJwk as JWK, "EdDSA");
+    await compactVerify(jwt, key, { algorithms: ["EdDSA"] });
+    return done(true);
+  } catch (err) {
+    return done(false, `JWT envelope signature is not valid: ${errMsg(err)}`);
+  }
+}

--- a/src/delegation/vc-verification-checks.ts
+++ b/src/delegation/vc-verification-checks.ts
@@ -22,6 +22,7 @@ import type {
   StatusListResolver,
   StatusCheckResult,
   SignatureVerificationFunction,
+  DelegationVCVerificationResult,
 } from "./vc-verifier.types.js";
 
 /**
@@ -31,8 +32,18 @@ import type {
  */
 const DELEGATION_SUBJECT_KEYS: readonly string[] = ["id", "delegation"];
 
-/** Stage 1: schema, expiry, status field, and subject-shape checks (no network). */
-export function validateBasicProperties(vc: DelegationCredential): {
+/**
+ * Stage 1: schema, expiry, status field, and subject-shape checks (no network).
+ *
+ * `requireEmbeddedProof` (default `true`) demands a Data Integrity `proof`
+ * block. The VC-JWT path passes `false`: a compact JWS carries no embedded
+ * `proof` — its envelope signature is the proof, verified separately by
+ * {@link verifyVcJwtSignature}.
+ */
+export function validateBasicProperties(
+  vc: DelegationCredential,
+  options: { requireEmbeddedProof?: boolean } = {},
+): {
   valid: boolean;
   reason?: string;
 } {
@@ -64,7 +75,7 @@ export function validateBasicProperties(vc: DelegationCredential): {
     return { valid: false, reason: "Missing issuer or subject DID" };
   }
 
-  if (!vc.proof) {
+  if ((options.requireEmbeddedProof ?? true) && !vc.proof) {
     return { valid: false, reason: "Missing proof" };
   }
 
@@ -109,6 +120,41 @@ function findVerificationMethod(
   return didDoc.verificationMethod?.find(
     (vm) => vm.id === verificationMethodId,
   );
+}
+
+/**
+ * Fold the parallel signature + status results — with the already-passed basic
+ * stage — into the final verification result. Pure (no caching; the verifier
+ * caches a valid result itself). Shared by the Data Integrity and VC-JWT paths,
+ * which both reach here only after `validateBasicProperties` passed, so
+ * `basicValid` is true.
+ */
+export function combineVerificationResult(
+  signatureResult: { valid: boolean; reason?: string; durationMs?: number },
+  statusResult: StatusCheckResult,
+  basicCheckMs: number,
+  startTime: number,
+): DelegationVCVerificationResult {
+  const allValid = signatureResult.valid && statusResult.valid;
+  return {
+    valid: allValid,
+    reason: !allValid
+      ? signatureResult.reason || statusResult.reason || "Unknown failure"
+      : undefined,
+    statusOutcome: statusResult.outcome,
+    stage: "complete",
+    metrics: {
+      basicCheckMs,
+      signatureCheckMs: signatureResult.durationMs || 0,
+      statusCheckMs: statusResult.durationMs || 0,
+      totalMs: Date.now() - startTime,
+    },
+    checks: {
+      basicValid: true,
+      signatureValid: signatureResult.valid,
+      statusValid: statusResult.valid,
+    },
+  };
 }
 
 /** Stage 2a: resolve the issuer key and verify the embedded proof signature. */

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -28,7 +28,13 @@ import {
   validateBasicProperties,
   verifySignature,
   checkCredentialStatus,
+  combineVerificationResult,
 } from "./vc-verification-checks.js";
+import {
+  verifyVcJwtSignature,
+  prepareVcJwtCredential,
+} from "./vc-jwt-verify.js";
+import type { VcJwtSignatureResult } from "./vc-jwt-verify.js";
 
 // Re-export the shared type surface so existing imports of DIDResolver /
 // SignatureVerificationFunction / StatusListResolver / … are unchanged.
@@ -136,36 +142,102 @@ export class DelegationCredentialVerifier {
             durationMs: 0,
           });
 
+    return this.finalizeVerification(
+      vc,
+      signaturePromise,
+      statusPromise,
+      basicCheckMs,
+      startTime,
+    );
+  }
+
+  /**
+   * Verify a delegation credential presented as a compact VC-JWT — the JWT
+   * serialization (W3C VC Data Model 1.1 §6.3.1), the form browser wallets
+   * mint, where the JWS envelope signature over `header.payload` IS the proof.
+   *
+   * Parses the token, runs the same fast basic checks on the extracted
+   * credential (minus the embedded-`proof` requirement — the envelope is the
+   * proof), then verifies that envelope signature and the credential status in
+   * parallel. Same result shape, cache, and metrics as
+   * {@link verifyDelegationCredential}.
+   */
+  async verifyDelegationJwt(
+    jwt: string,
+    options: VerifyDelegationVCOptions = {},
+  ): Promise<DelegationVCVerificationResult> {
+    const startTime = Date.now();
+
+    const prepared = prepareVcJwtCredential(jwt, startTime);
+    if ("failure" in prepared) {
+      return prepared.failure;
+    }
+    const { vc, issuerDid, kid, basicCheckMs } = prepared;
+
+    if (!options.skipCache) {
+      const cached = this.getFromCache(vc.id || "");
+      if (cached) {
+        return { ...cached, cached: true };
+      }
+    }
+
+    const signaturePromise = !options.skipSignature
+      ? verifyVcJwtSignature(
+          jwt,
+          issuerDid,
+          kid,
+          options.didResolver || this.didResolver,
+        )
+      : Promise.resolve<VcJwtSignatureResult>({ valid: true, durationMs: 0 });
+
+    const statusPromise =
+      !options.skipStatus && vc.credentialStatus
+        ? checkCredentialStatus(
+            vc.credentialStatus,
+            options.statusListResolver || this.statusListResolver,
+          )
+        : Promise.resolve<StatusCheckResult>({
+            valid: true,
+            durationMs: 0,
+          });
+
+    return this.finalizeVerification(
+      vc,
+      signaturePromise,
+      statusPromise,
+      basicCheckMs,
+      startTime,
+    );
+  }
+
+  /**
+   * Await the parallel signature + status checks, fold them into the final
+   * result via {@link combineVerificationResult}, and cache a valid one. Shared
+   * by the Data Integrity and VC-JWT paths; both reach here only after
+   * `validateBasicProperties` has passed.
+   */
+  private async finalizeVerification(
+    vc: DelegationCredential,
+    signaturePromise: Promise<{
+      valid: boolean;
+      reason?: string;
+      durationMs?: number;
+    }>,
+    statusPromise: Promise<StatusCheckResult>,
+    basicCheckMs: number,
+    startTime: number,
+  ): Promise<DelegationVCVerificationResult> {
     const [signatureResult, statusResult] = await Promise.all([
       signaturePromise,
       statusPromise,
     ]);
 
-    const signatureCheckMs = signatureResult.durationMs || 0;
-    const statusCheckMs = statusResult.durationMs || 0;
-
-    const allValid =
-      basicValidation.valid && signatureResult.valid && statusResult.valid;
-
-    const result: DelegationVCVerificationResult = {
-      valid: allValid,
-      reason: !allValid
-        ? signatureResult.reason || statusResult.reason || "Unknown failure"
-        : undefined,
-      statusOutcome: statusResult.outcome,
-      stage: "complete",
-      metrics: {
-        basicCheckMs,
-        signatureCheckMs,
-        statusCheckMs,
-        totalMs: Date.now() - startTime,
-      },
-      checks: {
-        basicValid: basicValidation.valid,
-        signatureValid: signatureResult.valid,
-        statusValid: statusResult.valid,
-      },
-    };
+    const result = combineVerificationResult(
+      signatureResult,
+      statusResult,
+      basicCheckMs,
+      startTime,
+    );
 
     if (result.valid && vc.id) {
       this.setInCache(vc.id, result);


### PR DESCRIPTION
## Why

`DelegationCredentialVerifier` only verified Data Integrity VCs — the representation with an embedded `proof` block that `DelegationCredentialIssuer` mints. But the W3C VC Data Model defines a second serialization, the JWT one (§6.3.1): a compact JWS whose envelope signature over `header.payload` **is** the proof, with no embedded `proof`. Browser wallets (WebCrypto / passkey signers) mint this form, because a detached JWS is the natural output of `crypto.subtle`.

A verifier that only accepts Data Integrity therefore rejects a perfectly valid wallet-minted credential as "Missing proof", forcing consumers to hand-roll their own JWT verifier.

## What

Adds `DelegationCredentialVerifier.verifyDelegationJwt()`:

- Reuses the existing `parseVCJWT` primitive (no new parser).
- Verifies the EdDSA envelope against the issuer DID's published key via `jose`, with `algorithms` pinned to `EdDSA` — a token can't downgrade the suite or claim `alg: none`.
- Requires the credential `issuer` to equal the signed `iss` (a credential must not name an issuer other than the key that signs it).
- The extracted credential then flows through the **same** basic / expiry / status checks as a Data Integrity VC.

`validateBasicProperties` gains a `requireEmbeddedProof` option (default `true`, so existing behaviour is unchanged); the JWT path passes `false`. The shared result-folding moves to `combineVerificationResult` so both paths stay DRY and every touched file stays within the file-size budget.

## Tests

8 new cases: the valid wire format with no embedded proof, the DID-doc-key-vs-signing-key mismatch, tamper, issuer/`iss` confusion, unresolvable DID, no resolver, and non-JWT input. Full gate green: `tsc` + `eslint` + build + 1615 tests.