### PR TITLE
docs(readme): expand the Entity Card row with the CIMD on-ramp and discovery rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Also available: [outbound-delegation](./examples/outbound-delegation/) (gateway 
 | Capability | How it works |
 |-----------|-------------|
 | **Cryptographic identity** | Ed25519 (EdDSA) and P-256 (ES256, FIPS-eligible) key pairs, `did:key` / `did:web` resolution, optional `did:cheqd` resolver support |
-| **Entity Card** | Typed, DID-anchored identity: fluent `card()` builder, `withKyaOsCard` discovery projections, `requireProof` per-request holder-of-key guard |
+| **Entity Card** | Typed, DID-anchored identity: fluent `card()` builder, `requireProof` per-request holder-of-key guard, CIMD OAuth on-ramp (`client_id` ⇄ `did:web`, MCP's default client auth), and `withKyaOsCard` projections that embed into MCP `server.json` / Server Cards (draft SEP-2127), A2A AgentCards, and NANDA AgentFacts |
 | **Signed proofs** | Detached JWS over JCS-canonicalized request/response hashes |
 | **Delegation credentials** | W3C Verifiable Credentials with scope constraints, rooted at a Responsible Party |
 | **Revocation** | StatusList2021 bitstring with cascading revocation |


### PR DESCRIPTION
One-line README follow-up to the 1.9.0 Entity Card release.

The "What's under the hood" row for the Entity Card now names the two most standards-relevant pieces that were missing:

- the CIMD OAuth on-ramp (`client_id` ⇄ `did:web`) — this targets MCP's default client-auth mechanism (draft-ietf-oauth-client-id-metadata-document, MCP default since 2025-11-25), so it is the strongest interop claim we can make;
- the discovery projections, worded as "embed into" MCP `server.json` / Server Cards, A2A AgentCards, and NANDA AgentFacts — deliberately not "compliant with": the card is carried in `server.json` `_meta` per the reverse-DNS extension rules rather than implementing the server-card schema, and the AgentFacts projection populates/enriches an AgentFacts document rather than emitting a standalone one. SEP-2127 is marked draft since it has not landed in an MCP release.