### PR TITLE
feat(proof): accept a non-extractable CryptoKey as the signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- **`ProofGenerator` accepts a non-extractable signing key.**
+  `ProofAgentIdentity.privateKey` and `KyaOsIdentityConfig.privateKey` now
+  accept a `CryptoKey` handle in addition to a base64 private-key string. A
+  non-extractable WebCrypto key (e.g. a passkey-PRF-derived or HSM/KMS-fronted
+  key) can now produce `org.kya-os/proof` proofs without the secret ever being
+  materialized by the caller — realizing the signer-hook model the spec already
+  describes (§4.5) — end-to-end through `withKyaOs`. Both key forms yield an
+  equally valid, verifier-accepted proof. Backward-compatible: existing string
+  keys are unaffected (the string path is byte-for-byte unchanged); the only
+  source-level impact is that external code which reads `.privateKey` expecting
+  a `string` now sees a `string | CryptoKey` union.
+
 ## [1.9.0] - 2026-07-07
 
 Entity Card (`@kya-os/mcp/card`) — a typed, DID-anchored, per-request

--- a/src/middleware/with-kya-os.config-types.ts
+++ b/src/middleware/with-kya-os.config-types.ts
@@ -21,7 +21,14 @@ import type { DelegationCredential } from "../types/protocol.js";
 export interface KyaOsIdentityConfig {
   did: string;
   kid: string;
-  privateKey: string;
+  /**
+   * The Ed25519 signing key: a base64 raw private key, or a `CryptoKey` handle
+   * — including a non-extractable one (passkey-PRF- or HSM/KMS-fronted). The key
+   * is used only to sign per-request proofs (via {@link ProofGenerator}), so a
+   * handle lets a deployment keep secret key material inside its trust boundary
+   * end-to-end, per SPEC §4.5. See {@link ProofAgentIdentity.privateKey}.
+   */
+  privateKey: string | CryptoKey;
   publicKey: string;
   agentName?: string;
 }

--- a/src/proof/__tests__/signer-non-extractable-key.test.ts
+++ b/src/proof/__tests__/signer-non-extractable-key.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Non-extractable signing keys for ProofGenerator.
+ *
+ * `ProofAgentIdentity.privateKey` accepts a `CryptoKey` handle — including a
+ * NON-EXTRACTABLE WebCrypto key (passkey-PRF-derived, HSM/KMS-fronted) — as an
+ * alternative to a base64 private-key string, so secret key material never has
+ * to leave the caller's trust boundary to produce a proof. This realizes the
+ * signer model the spec already names:
+ *   §4.5  "Implementations that generate or hold agent secret keys … are
+ *          non-conformant."
+ *   §     "Signing MAY be delegated to a KMS/HSM-backed signer hook. Local
+ *          Ed25519 helpers MUST keep key material inside the caller's trust
+ *          boundary and send only signatures."
+ *
+ * Proven here with real crypto:
+ *   1. a non-extractable Ed25519 key genuinely can't be exported to the base64
+ *      string the string path requires (so it was previously unusable);
+ *   2. `ProofGenerator` signs with that non-extractable key and the UNMODIFIED
+ *      `ProofVerifier` accepts the proof; and
+ *   3. the string and CryptoKey forms of the SAME key are interchangeable —
+ *      both produce proofs the verifier accepts — so the change is
+ *      backward-compatible; and
+ *   4. the kid↔key binding still constrains the new path: a CryptoKey that
+ *      doesn't correspond to the declared kid yields a proof the verifier
+ *      rejects (a stolen/mismatched handle can't mint an accepted proof).
+ *
+ * jose owns the JWS signing-input construction, so canonicalization stays
+ * inside the library; the caller only ever supplies a key handle.
+ */
+import { describe, it, expect } from "vitest";
+import { exportJWK } from "jose";
+import { ProofGenerator } from "../generator.js";
+import { ProofVerifier } from "../verifier.js";
+import type { SessionContext } from "../../types/protocol.js";
+import type {
+  ProofAgentIdentity,
+  ToolRequest,
+} from "../generator.js";
+import { NodeCryptoProvider } from "../../__tests__/utils/node-crypto-provider.js";
+import { SystemClockProvider } from "../../providers/system-clock.js";
+import { MemoryNonceCacheProvider } from "../../providers/memory.js";
+
+const DID = "did:key:z6MkSignerHookExample";
+const KID = `${DID}#${DID.slice("did:key:".length)}`;
+const REQUEST: ToolRequest = { method: "vault/read", params: { fileId: "f1" } };
+
+/** Ed25519 PKCS#8 DER prefixes the 32-byte seed with a 16-byte header. */
+const PKCS8_HEADER_LEN = 16;
+
+function makeSession(nonce: string): SessionContext {
+  return {
+    sessionId: "sess_signer_hook",
+    audience: "verifier.example.com",
+    nonce,
+    timestamp: Math.floor(Date.now() / 1000),
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    ttlMinutes: 10,
+    identityState: "anonymous",
+  };
+}
+
+/** A fresh proof verifier wired with in-memory providers. */
+function buildVerifier(cryptoProvider: NodeCryptoProvider): ProofVerifier {
+  return new ProofVerifier({
+    cryptoProvider,
+    clockProvider: new SystemClockProvider(),
+    nonceCacheProvider: new MemoryNonceCacheProvider(),
+    fetchProvider: { fetch: async () => new Response(null) } as never,
+  });
+}
+
+/** Generate a proof for `identity`, then verify it against `publicJwk`. */
+async function generateAndVerify(
+  identity: ProofAgentIdentity,
+  publicJwk: Record<string, unknown>,
+  nonce: string
+): Promise<boolean> {
+  const cryptoProvider = new NodeCryptoProvider();
+  const proof = await new ProofGenerator(identity, cryptoProvider).generateProof(
+    REQUEST,
+    undefined,
+    makeSession(nonce),
+    { scopeId: "vault:read" }
+  );
+  const result = await buildVerifier(cryptoProvider).verifyProof(
+    proof,
+    publicJwk as never,
+    { request: REQUEST }
+  );
+  return result.valid;
+}
+
+describe("ProofGenerator — non-extractable / CryptoKey signing keys", () => {
+  it("a non-extractable Ed25519 private key cannot be exported to a string", async () => {
+    const { privateKey } = (await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      /* extractable */ false,
+      ["sign", "verify"]
+    )) as CryptoKeyPair;
+
+    expect(privateKey.extractable).toBe(false);
+    // The string path does importPKCS8(identity.privateKey). There is no such
+    // string to give it — export is refused — so this key was previously unusable.
+    await expect(crypto.subtle.exportKey("pkcs8", privateKey)).rejects.toThrow();
+  });
+
+  it("signs with a non-extractable CryptoKey; the unmodified verifier accepts the proof", async () => {
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      false,
+      ["sign", "verify"]
+    )) as CryptoKeyPair;
+    expect(privateKey.extractable).toBe(false);
+
+    // The public half is always exportable — it's what a verifier resolves from
+    // the DID document. Tag it with the kid the verifier matches on.
+    const publicJwk = { ...(await exportJWK(publicKey)), kid: KID };
+
+    const identity: ProofAgentIdentity = {
+      did: DID,
+      kid: KID,
+      privateKey, // a non-extractable CryptoKey, not a base64 string
+      publicKey: "", // unused on the generation path
+    };
+
+    expect(await generateAndVerify(identity, publicJwk, "nonce-crypto-key")).toBe(
+      true
+    );
+  });
+
+  it("the string and CryptoKey forms of the SAME key are interchangeable (backward-compatible)", async () => {
+    // One key, two forms. Generate it extractable so we can express it both as
+    // the base64 seed (the historical string path) and as a CryptoKey handle.
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      true,
+      ["sign", "verify"]
+    )) as CryptoKeyPair;
+    const pkcs8 = new Uint8Array(
+      await crypto.subtle.exportKey("pkcs8", privateKey)
+    );
+    // The base64 seed is exactly what NodeCryptoProvider.generateKeyPair emits.
+    const seedB64 = Buffer.from(pkcs8.subarray(PKCS8_HEADER_LEN)).toString(
+      "base64"
+    );
+    const publicJwk = { ...(await exportJWK(publicKey)), kid: KID };
+
+    const base = { did: DID, kid: KID, publicKey: "" };
+    const viaString: ProofAgentIdentity = { ...base, privateKey: seedB64 };
+    const viaCryptoKey: ProofAgentIdentity = { ...base, privateKey };
+
+    // Both forms of the same key produce proofs the same verifier accepts.
+    expect(await generateAndVerify(viaString, publicJwk, "nonce-string")).toBe(
+      true
+    );
+    expect(
+      await generateAndVerify(viaCryptoKey, publicJwk, "nonce-handle")
+    ).toBe(true);
+  });
+
+  it("rejects a proof whose CryptoKey doesn't match the declared kid (binding holds)", async () => {
+    // The device signs with its own non-extractable key...
+    const { privateKey } = (await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      false,
+      ["sign", "verify"]
+    )) as CryptoKeyPair;
+    // ...but the verifier resolves a DIFFERENT public key for that kid (i.e. the
+    // handle doesn't correspond to the identity it claims).
+    const { publicKey: otherPublic } = (await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      true,
+      ["sign", "verify"]
+    )) as CryptoKeyPair;
+    const mismatchedJwk = { ...(await exportJWK(otherPublic)), kid: KID };
+
+    const identity: ProofAgentIdentity = {
+      did: DID,
+      kid: KID,
+      privateKey,
+      publicKey: "",
+    };
+    // The new CryptoKey path doesn't self-verify at generation (same trust model
+    // as the string path); the mismatch is caught — fail-closed — at the verifier.
+    expect(
+      await generateAndVerify(identity, mismatchedJwk, "nonce-mismatch")
+    ).toBe(false);
+  });
+});

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -46,7 +46,16 @@ export const LEGACY_PROOF_META_KEY = 'proof';
 export interface ProofAgentIdentity {
   did: string;
   kid: string;
-  privateKey: string;
+  /**
+   * The Ed25519 signing key. Either the base64-encoded raw private key (the
+   * historical form), or a `CryptoKey` handle — including a **non-extractable**
+   * WebCrypto key (e.g. a passkey-PRF-derived or HSM/KMS-fronted key). Passing a
+   * handle keeps secret key material inside the caller's trust boundary and
+   * hands the library only a signer, per SPEC §4.5 ("implementations that …
+   * hold agent secret keys … are non-conformant") and the KMS/HSM signer-hook
+   * guidance. Either form produces an equally valid, verifier-accepted proof.
+   */
+  privateKey: string | CryptoKey;
   publicKey: string;
 }
 
@@ -177,10 +186,26 @@ export class ProofGenerator {
     );
   }
 
+  /**
+   * Resolve the identity's signing key into the form jose signs with. A base64
+   * string is imported as a PKCS#8 key (the historical path); a `CryptoKey`
+   * handle — including a non-extractable one (passkey-PRF- or HSM/KMS-fronted)
+   * — is used as-is. Either way the caller never has to materialize secret key
+   * bytes for the library, per SPEC §4.5.
+   */
+  private async resolveSigningKey(): Promise<CryptoKey> {
+    const key = this.identity.privateKey;
+    return typeof key === 'string'
+      ? importPKCS8(this.formatPrivateKeyAsPEM(key), 'EdDSA')
+      : key;
+  }
+
   private async generateJWS(meta: ProofMeta): Promise<string> {
     try {
-      const privateKeyPem = this.formatPrivateKeyAsPEM(this.identity.privateKey);
-      const privateKey = await importPKCS8(privateKeyPem, 'EdDSA');
+      // jose's CompactSign owns the JWS signing-input construction, so
+      // canonicalization stays inside the library and the signing input is the
+      // same regardless of how the signing key was supplied.
+      const privateKey = await this.resolveSigningKey();
 
       const payload = {
         aud: meta.audience,


### PR DESCRIPTION
## What

`ProofAgentIdentity.privateKey` (and `KyaOsIdentityConfig.privateKey`) now accept a `CryptoKey` handle in addition to a base64 private-key string. `generateJWS` resolves the key via a small `resolveSigningKey()`: a string is imported with `importPKCS8` (the historical path, byte-for-byte unchanged); a `CryptoKey` is used as-is. jose's `CompactSign` accepts either and owns the JWS signing-input construction, so canonicalization stays inside the library.

## Why

Today the proof generator requires the private key as a base64 string it can `importPKCS8`. That excludes exactly the strongest key custody — a **non-extractable** WebCrypto key (passkey-PRF-derived), or an HSM/KMS-fronted key — none of which can hand over raw key bytes.

The spec already points the other way:

> §4.5 — "Implementations that generate or hold agent secret keys … are non-conformant."
> "Signing MAY be delegated to a KMS/HSM-backed signer hook. Local Ed25519 helpers MUST keep key material inside the caller's trust boundary and send only signatures."

So this brings the reference generator into line with the signer model the spec names: a caller can now produce `org.kya-os/proof` proofs without ever materializing the secret. It's reachable end-to-end through `withKyaOs` (the config field only ever flows into `ProofGenerator`).

## Compatibility & scope

- **Backward-compatible.** The string path is byte-for-byte unchanged; existing callers are unaffected. The only source-level impact: external code that reads `.privateKey` as a `string` now sees a `string | CryptoKey` union (there are no such readers in-repo).
- **On the wire, nothing changes** — the proof format is identical; a `CryptoKey`-signed proof verifies through the unmodified `ProofVerifier`.
- **Deliberately minimal scope:** `CryptoKey` only (the cross-runtime web-standard handle). Node `KeyObject` — which jose's `CompactSign` also accepts — and a fully-opaque `sign(bytes)` callback for remote signers are natural follow-ups, left out here to keep the change small and wire-invariant.

## Tests

`src/proof/__tests__/signer-non-extractable-key.test.ts`, real crypto:

1. a non-extractable Ed25519 key genuinely can't be exported to the string the old path needs (so it was previously unusable);
2. `ProofGenerator` signs with that non-extractable key and the **unmodified** `ProofVerifier` accepts the proof;
3. the string and `CryptoKey` forms of the **same** key are interchangeable (both verify) — the backward-compat guarantee; and
4. a `CryptoKey` that doesn't match the declared `kid` yields a proof the verifier **rejects** — fail-closed, the kid↔key binding is preserved on the new path.

Full suite green (1631 passed / 1 skipped), typecheck + lint clean.
