### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-08
+
 ### Added
 
 - **`ProofGenerator` accepts a non-extractable signing key.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.8.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release 1.10.0.

**Added** — `ProofGenerator` and `withKyaOs` accept a non-extractable `CryptoKey` as the signing key (passkey-PRF / HSM / KMS), so per-request `org.kya-os/proof` proofs can be produced without the secret ever being materialized — realizing the signer-hook model SPEC §4.5 names. Additive and backward-compatible; the base64 string path is byte-for-byte unchanged. (PR #122.)

Minor bump per SemVer (backward-compatible new functionality). Full suite green (1631 passed / 1 skipped), typecheck + lint clean. Also syncs the tracked `package-lock.json` version, which was stale at 1.8.0.