### PR TITLE
fix(safe-fetch): lazy-load node:dns/node:https for workerd bundle compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cloudflare Worker / workerd bundle compatibility.** `safe-fetch-transports`
+  statically imported `node:dns/promises` and `node:https` at the module top
+  level, so anything that builds a `SafeFetch` — including the Entity Card /
+  VC-JWT verification path (card resolution + status-list revocation) — required
+  those node built-ins at bundle time and broke workerd builds. They now load
+  **lazily** (only when a node code path actually runs), so the module bundles
+  cleanly for workerd / browser. `selectDefaultTransport` transparently falls
+  back to `fetchTransport` where `node:https` is absent. The SSRF policy
+  (resolve-and-pin, private-range denial, redirect + size + timeout guards) is
+  unchanged; a Worker injects its own DNS seam (or uses trusted origins +
+  `fetchTransport`) to avoid `node:dns` at runtime.
+
 ## [1.10.0] - 2026-07-08
 
 ### Added

--- a/src/utils/__tests__/safe-fetch-workerd.test.ts
+++ b/src/utils/__tests__/safe-fetch-workerd.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Workerd/Cloudflare-Worker bundle safety for the SSRF-hardened fetch.
+ *
+ * `@kya-os/mcp` is imported into Cloudflare Workers to run the VC-JWT / Entity
+ * Card verification path (card resolution + status-list revocation), which
+ * builds a `SafeFetch`. `@kya-os/mcp@1.10.0` broke those Worker bundles at build
+ * time: `safe-fetch-transports.ts` STATICALLY imported `node:dns/promises` and
+ * `node:https` at the module top level, so importing anything that transitively
+ * loads it required node built-ins that workerd doesn't provide.
+ *
+ * These tests pin the fix: the module must load node built-ins LAZILY (only when
+ * a node code path actually runs), and a Worker-shaped configuration (injected
+ * DNS seam + `fetchTransport`, or trusted origins) must complete a request
+ * WITHOUT ever touching node:dns. The SSRF policy is unchanged — that stays
+ * covered by `safe-fetch.test.ts`.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect, vi } from "vitest";
+import {
+  createSafeFetch,
+  defaultLookup,
+  fetchTransport,
+  selectDefaultTransport,
+} from "../safe-fetch.js";
+import type { DnsAddress, RawResponse, TransportInit } from "../safe-fetch.js";
+
+const TRANSPORTS_SRC = fileURLToPath(
+  new URL("../safe-fetch-transports.ts", import.meta.url),
+);
+
+const transportInit = (over: Partial<TransportInit> = {}): TransportInit => ({
+  signal: new AbortController().signal,
+  hostname: "example.com",
+  pinnedAddress: "93.184.216.34",
+  family: 4,
+  maxBytes: 1_048_576,
+  ...over,
+});
+
+describe("workerd bundle safety — no static node built-in imports", () => {
+  it("safe-fetch-transports.ts has no top-level runtime `node:` import", () => {
+    const src = readFileSync(TRANSPORTS_SRC, "utf8");
+    // Top-level runtime imports only (ignore `import type`, which is erased and
+    // never reaches the bundle). A match here means the module would require a
+    // node built-in at load time — the exact break for workerd/browser bundles.
+    const offending = src
+      .split("\n")
+      .filter((line) => /^\s*import\s+(?!type\b)[^;]*from\s+['"]node:/.test(line));
+    expect(offending).toEqual([]);
+  });
+});
+
+describe("worker runtime path — a request completes without node:dns", () => {
+  it("uses the INJECTED dns seam (never node:dns) for a non-trusted origin", async () => {
+    // A Worker injects its own DNS seam (e.g. DNS-over-HTTPS) and fetchTransport.
+    // If the library reached for node:dns instead, this custom seam wouldn't run.
+    const workerLookup = vi.fn(
+      async (): Promise<DnsAddress[]> => [{ address: "93.184.216.34", family: 4 }],
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ card: true }), { status: 200 }));
+    try {
+      const safeFetch = createSafeFetch({
+        lookup: workerLookup,
+        transport: fetchTransport,
+      });
+      const res = await safeFetch("https://example.com/card.json");
+      expect(workerLookup).toHaveBeenCalledWith("example.com");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ card: true });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("selectDefaultTransport returns a SafeFetchTransport function", () => {
+    expect(typeof selectDefaultTransport()).toBe("function");
+  });
+
+  it("auto-selects fetchTransport when node:https can't load (workerd)", async () => {
+    // Simulate a runtime without node:https: the lazy loader's import rejects,
+    // so the default transport must transparently fall back to global fetch.
+    vi.resetModules();
+    vi.doMock("node:https", () => {
+      throw new Error("node:https is not available in workerd");
+    });
+    try {
+      const { selectDefaultTransport: freshSelect } = await import(
+        "../safe-fetch-transports.js"
+      );
+      const transport = freshSelect();
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("ok", { status: 200 }));
+      try {
+        const raw: RawResponse = await transport(
+          "https://example.com/x",
+          transportInit(),
+        );
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(raw.status).toBe(200);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    } finally {
+      vi.doUnmock("node:https");
+      vi.resetModules();
+    }
+  });
+
+  it("nodeHttpsTransport throws a clear error when node:https can't load", async () => {
+    // The exported node transport, invoked directly in a runtime without
+    // node:https, fails loudly rather than silently mis-fetching.
+    vi.resetModules();
+    vi.doMock("node:https", () => {
+      throw new Error("node:https is not available in workerd");
+    });
+    try {
+      const { nodeHttpsTransport } = await import("../safe-fetch-transports.js");
+      await expect(
+        nodeHttpsTransport("https://example.com/x", transportInit()),
+      ).rejects.toThrow(/node:https is unavailable/);
+    } finally {
+      vi.doUnmock("node:https");
+      vi.resetModules();
+    }
+  });
+});
+
+describe("buildPinnedLookup — pins both node:https lookup call-shapes to the validated IP", () => {
+  it("returns an ARRAY for the { all: true } shape (Node ≥20 autoSelectFamily)", async () => {
+    const { buildPinnedLookup } = await import("../safe-fetch-transports.js");
+    const lookup = buildPinnedLookup("93.184.216.34", 4);
+    const result = await new Promise<unknown>((resolve) => {
+      // @ts-expect-error exercising the { all: true } overload the runtime uses
+      lookup("example.com", { all: true }, (_e: unknown, addrs: unknown) => resolve(addrs));
+    });
+    expect(result).toEqual([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  it("returns the SCALAR 3-arg form otherwise", async () => {
+    const { buildPinnedLookup } = await import("../safe-fetch-transports.js");
+    const lookup = buildPinnedLookup("2606:2800:220:1::", 6);
+    const result = await new Promise<[unknown, unknown]>((resolve) => {
+      // @ts-expect-error exercising the scalar overload
+      lookup("example.com", {}, (_e: unknown, address: unknown, family: unknown) =>
+        resolve([address, family]),
+      );
+    });
+    expect(result).toEqual(["2606:2800:220:1::", 6]);
+  });
+});
+
+describe("defaultLookup — lazy node:dns", () => {
+  it("resolves a hostname to at least one address (lazy-loads node:dns)", async () => {
+    const addresses = await defaultLookup("localhost");
+    expect(addresses.length).toBeGreaterThan(0);
+    for (const a of addresses) {
+      expect(typeof a.address).toBe("string");
+      expect([4, 6]).toContain(a.family);
+    }
+  });
+
+  it("throws a guiding error when node:dns can't load (workerd)", async () => {
+    vi.resetModules();
+    vi.doMock("node:dns/promises", () => {
+      throw new Error("node:dns is not available in workerd");
+    });
+    try {
+      const { defaultLookup: freshLookup } = await import(
+        "../safe-fetch-transports.js"
+      );
+      await expect(freshLookup("example.com")).rejects.toThrow(
+        /inject a `lookup` seam/,
+      );
+    } finally {
+      vi.doUnmock("node:dns/promises");
+      vi.resetModules();
+    }
+  });
+});

--- a/src/utils/safe-fetch-transports.ts
+++ b/src/utils/safe-fetch-transports.ts
@@ -10,14 +10,54 @@
  * `./ip-classifier`; the seam vocabulary lives in `./safe-fetch-types`. No crypto here.
  */
 
-import { lookup as nodeDnsLookup } from 'node:dns/promises';
-import { request as httpsRequest } from 'node:https';
 import type { IncomingMessage } from 'node:http';
 import type { LookupFunction } from 'node:net';
 import type { DnsLookup, RawResponse, SafeFetchTransport } from './safe-fetch-types.js';
 
+/*
+ * Node built-ins are loaded LAZILY (never at the module top level), so this
+ * module — and everything that builds a `SafeFetch`, incl. the Entity Card /
+ * VC-JWT verification path — bundles cleanly for workerd / browser, where
+ * `node:dns` and `node:https` don't exist. A static `import 'node:dns/promises'`
+ * here broke Cloudflare Worker builds at bundle time (@kya-os/mcp 1.10.0). The
+ * built-ins now load only when a node code path actually runs; a Worker that
+ * injects its own `lookup` / `transport` (or uses `fetchTransport` + trusted
+ * origins) never triggers them. Type-only imports above are erased at compile
+ * time, so they never reach the bundle.
+ */
+
+type NodeDnsLookup = (typeof import('node:dns/promises'))['lookup'];
+let dnsLookupPromise: Promise<NodeDnsLookup> | undefined;
+/**
+ * Lazily load (and cache) `node:dns/promises`' `lookup`. Where `node:dns` is absent (workerd),
+ * fail with a guiding error rather than a cryptic module-resolution reject: a Worker should inject
+ * its own `lookup` seam (e.g. DNS-over-HTTPS) or use trusted origins + `fetchTransport`.
+ */
+function loadNodeDnsLookup(): Promise<NodeDnsLookup> {
+  return (dnsLookupPromise ??= import('node:dns/promises').then(
+    (m) => m.lookup,
+    (cause) => {
+      throw new Error(
+        'safe-fetch: node:dns is unavailable in this runtime — inject a `lookup` seam (e.g. DNS-over-HTTPS) or use trusted origins with fetchTransport',
+        { cause },
+      );
+    },
+  ));
+}
+
+type NodeHttps = typeof import('node:https');
+let nodeHttpsPromise: Promise<NodeHttps | null> | undefined;
+/** Lazily load (and cache) `node:https`; resolves to `null` where it's absent (workerd). */
+function loadNodeHttps(): Promise<NodeHttps | null> {
+  return (nodeHttpsPromise ??= import('node:https').then(
+    (m) => m,
+    () => null,
+  ));
+}
+
 /** Default DNS seam — resolve every address (`all: true`) for full SSRF screening. */
 export const defaultLookup: DnsLookup = async (hostname) => {
+  const nodeDnsLookup = await loadNodeDnsLookup();
   const resolved = await nodeDnsLookup(hostname, { all: true, verbatim: true });
   return resolved.map((entry) => ({ address: entry.address, family: entry.family }));
 };
@@ -68,24 +108,37 @@ async function readCapped(response: Response, maxBytes: number): Promise<RawResp
   };
 }
 
+/**
+ * Build the custom `node:https` lookup that pins the connection to the pre-validated IP for BOTH
+ * call-shapes (closing the DNS-rebinding TOCTOU window). Node ≥20 defaults to
+ * `autoSelectFamily=true`, which invokes a custom lookup with `{ all: true }` and expects an ARRAY
+ * of `{ address, family }`; a scalar 3-arg callback yields "Invalid IP address: undefined" and
+ * breaks every real request. Honour the array form when `all` is asked, the scalar form otherwise.
+ * Exported for direct unit testing (the request wiring around it is integration-only — no TLS in
+ * the unit suite). Not re-exported from the package barrels; the public surface is unchanged.
+ */
+export function buildPinnedLookup(pinnedAddress: string, family: 4 | 6): LookupFunction {
+  return (_hostname, options, cb) => {
+    if (typeof options === 'object' && options?.all) {
+      (cb as unknown as (e: null, a: Array<{ address: string; family: number }>) => void)(null, [
+        { address: pinnedAddress, family },
+      ]);
+    } else {
+      cb(null, pinnedAddress, family);
+    }
+  };
+}
+
 /** Default transport — node:https pinned to the validated IP, TLS SNI preserved, body-capped. */
-export const nodeHttpsTransport: SafeFetchTransport = (url, init) =>
-  new Promise<RawResponse>((resolve, reject) => {
-    // Return the pinned IP for BOTH lookup call-shapes. Node ≥20 defaults to
-    // `autoSelectFamily=true`, which invokes a custom lookup with `{ all: true }` and expects an
-    // ARRAY of `{ address, family }`; a scalar 3-arg callback yields "Invalid IP address:
-    // undefined" and breaks every real request. Honour the array form when `all` is asked,
-    // the scalar form otherwise.
+export const nodeHttpsTransport: SafeFetchTransport = async (url, init) => {
+  const https = await loadNodeHttps();
+  if (!https) {
+    throw new Error('safe-fetch: node:https is unavailable in this runtime; pass transport: fetchTransport');
+  }
+  const httpsRequest = https.request;
+  return new Promise<RawResponse>((resolve, reject) => {
     const family = init.family === 6 ? 6 : 4;
-    const pinnedLookup: LookupFunction = (_hostname, options, cb) => {
-      if (typeof options === 'object' && options?.all) {
-        (cb as unknown as (e: null, a: Array<{ address: string; family: number }>) => void)(null, [
-          { address: init.pinnedAddress, family },
-        ]);
-      } else {
-        cb(null, init.pinnedAddress, family);
-      }
-    };
+    const pinnedLookup = buildPinnedLookup(init.pinnedAddress, family);
     const req = httpsRequest(
       url,
       { method: 'GET', servername: init.hostname, signal: init.signal, lookup: pinnedLookup },
@@ -108,6 +161,7 @@ export const nodeHttpsTransport: SafeFetchTransport = (url, init) =>
     req.on('error', reject);
     req.end();
   });
+};
 
 /** Project a node:http IncomingMessage + buffered chunks into the RawResponse shape. */
 function toRawResponse(res: IncomingMessage, chunks: Buffer[]): RawResponse {
@@ -125,9 +179,14 @@ function toRawResponse(res: IncomingMessage, chunks: Buffer[]): RawResponse {
 
 /**
  * Pick the default transport: the `node:https` pinned transport when it is available, else the
- * fetch-based transport. This only covers ABSENCE of `node:https`; a runtime where the pinned
- * path is present-but-broken (e.g. Vercel Node serverless) must pass `transport: fetchTransport`.
+ * fetch-based transport. The `node:https` check is deferred to request time (it lazy-loads), so a
+ * runtime without `node:https` (workerd) transparently gets `fetchTransport`. This only covers
+ * ABSENCE of `node:https`; a runtime where the pinned path is present-but-broken (e.g. the Vercel
+ * Node serverless runtime) must still pass `transport: fetchTransport` explicitly.
  */
 export function selectDefaultTransport(): SafeFetchTransport {
-  return typeof httpsRequest === 'function' ? nodeHttpsTransport : fetchTransport;
+  return async (url, init) => {
+    const https = await loadNodeHttps();
+    return https ? nodeHttpsTransport(url, init) : fetchTransport(url, init);
+  };
 }


### PR DESCRIPTION
## Problem

`@kya-os/mcp@1.10.0` isn't cleanly Cloudflare-Worker / workerd compatible. `src/utils/safe-fetch-transports.ts` **statically** imported `node:dns/promises` and `node:https` at the module top level. Anything that builds a `SafeFetch` — including the Entity Card / VC-JWT verification path (card resolution + status-list revocation) that Workers use — transitively loads that module, so the node built-ins are required at **bundle time** and break the Worker build. (`node:dns` isn't a Worker capability at all, so externalizing it just moves the break to runtime — a startup crash when the module evaluates its static import.)

## Fix

Load the node built-ins **lazily** (cached dynamic `import()` at call time), never at module top level — the same pattern `src/card/revocation.ts` already uses for `node:zlib`. The module now loads with no node built-in requirement, so it bundles cleanly for workerd/browser; the built-ins load only when a node code path actually runs.

- `defaultLookup` — lazy `node:dns`; fails with a **guiding** error where it's absent (inject a `lookup` seam, e.g. DNS-over-HTTPS, or use trusted origins + `fetchTransport`).
- `nodeHttpsTransport` — lazy `node:https`; throws clearly when absent.
- `selectDefaultTransport` — defers the `node:https` check to request time and transparently falls back to `fetchTransport` when it's absent (so a Worker that passes no transport still works).
- Extracted `buildPinnedLookup` (the DNS-rebinding-TOCTOU pinned lookup) as a testable unit.

A Worker uses this by injecting its own `lookup`/`transport`, or `allowOrigins` + `fetchTransport` — none of which touch `node:dns` at runtime.

## Security — unchanged

This changes only **when** node built-ins load, not the SSRF policy. Resolve-and-pin, private-range denial (`isBlockedAddress`), split-horizon rebinding rejection, and the redirect/size/timeout guards all live in `safe-fetch.ts` and are untouched. **All 72 existing safe-fetch policy tests pass.**

## Tests / coverage (TDD)

New `safe-fetch-workerd.test.ts` (9 tests), written test-first:
- **Invariant**: `safe-fetch-transports.ts` has no top-level runtime `node:` import (regression guard for workerd-bundleability).
- Worker runtime path uses the injected DNS seam, never `node:dns`.
- `selectDefaultTransport` falls back to `fetchTransport` when `node:https` can't load; `defaultLookup` throws the guiding error when `node:dns` can't load; `nodeHttpsTransport` throws when absent.
- `buildPinnedLookup` pins both call-shapes (`{ all: true }` array + scalar).

`safe-fetch-transports.ts` coverage **49.5 → 65.2% stmts / 80 → 91.7% funcs**. The remaining uncovered block is the `node:https.request` socket wiring, which stays integration-only — matching the existing suite's deliberate no-TLS-in-unit-tests choice. Full repo suite green (**1640 passed**), typecheck + lint clean.

## Scope note

`node:crypto` (in the opt-in `NodeCryptoProvider`) is a separate matter: it's broadly available in workerd under `nodejs_compat`, and Workers use `WebCryptoProvider`, so it isn't the reported break and is out of scope here. The card/proof/delegation source pulls **no** node built-ins after this change.
