### PR TITLE
chore(release): 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-07-08
+
 ### Fixed
 
 - **Cloudflare Worker / workerd bundle compatibility.** `safe-fetch-transports`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: delegation, proof, and session primitives",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Patch release. Fixes Cloudflare Worker / workerd bundle compatibility — safe-fetch lazy-loads `node:dns`/`node:https` so the Entity Card / VC-JWT verification path no longer requires node built-ins at bundle time (PR #124). Backward-compatible; SSRF policy unchanged. Full suite green (1640), typecheck + lint clean. Also bumps the tracked package-lock.json.