### PR TITLE
ci: probe the live reference deployment daily and link it from the README

### DIFF
--- a/.github/workflows/live-probe.yml
+++ b/.github/workflows/live-probe.yml
@@ -1,0 +1,73 @@
+name: Live deployment probe
+
+# Read-only daily check of the public reference deployment at
+# https://demo-mcp.kya-os.ai. The repo does not deploy or operate the server;
+# it independently verifies it, the same way any third party can. No secrets.
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    env:
+      BASE: https://demo-mcp.kya-os.ai
+      EXPECTED_DID: did:web:demo-mcp.kya-os.ai
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Check the published discovery surfaces
+        run: |
+          curl -sf "$BASE/health" > /dev/null
+          test "$(curl -sf "$BASE/.well-known/did.json" | jq -r .id)" = "$EXPECTED_DID"
+          test "$(curl -sf "$BASE/card.json" | jq -r .id)" = "$EXPECTED_DID"
+          test "$(curl -sf "$BASE/card.json" | jq -r .entityType)" = "mcp"
+          curl -sf "$BASE/provenance" | jq -e '.package == "@kya-os/mcp"' > /dev/null
+          curl -sf "$BASE/status-list" | jq -e '.encodedList | length > 0' > /dev/null
+
+      - name: Round-trip a live proof over MCP and verify it
+        run: |
+          SID=$(curl -s -D - -o /dev/null "$BASE/mcp" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"live-probe","version":"0"}}}' \
+            | grep -i '^mcp-session-id:' | tr -d '\r' | awk '{print $2}')
+          test -n "$SID"
+
+          curl -s "$BASE/mcp" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -H "mcp-session-id: $SID" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+
+          curl -s "$BASE/mcp" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -H "mcp-session-id: $SID" \
+            -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"vault_read","arguments":{"file":"q3-plan.md"}}}' \
+            | sed -n 's/^data: //p' \
+            | jq '.result._meta["org.kya-os/proof"]' > proof.json
+
+          jq -e .jws proof.json > /dev/null
+          # Resolves the signer DID over the public internet and checks the JWS.
+          npx tsx examples/verify-proof/verify.ts proof.json

--- a/README.md
+++ b/README.md
@@ -165,6 +165,28 @@ This starts all example servers and opens [MCP Inspector](https://github.com/mod
 
 Also available: [outbound-delegation](./examples/outbound-delegation/) (gateway pattern), [verify-proof](./examples/verify-proof/) (standalone verification), [statuslist](./examples/statuslist/) (revocation lifecycle), [cheqd-dlr](./examples/cheqd-dlr/) (operator DID linkage + DLR publishing).
 
+## Try it against the live server
+
+[![Live deployment probe](https://github.com/decentralized-identity/kya-os-mcp/actions/workflows/live-probe.yml/badge.svg)](https://github.com/decentralized-identity/kya-os-mcp/actions/workflows/live-probe.yml)
+
+A public reference deployment runs the latest published release, with the identity `did:web:demo-mcp.kya-os.ai`.
+Every surface is a plain HTTPS fetch, so no privileged access is needed to check any claim it makes.
+
+| Surface | URL |
+|---------|-----|
+| MCP endpoint (streamable-http) | `https://demo-mcp.kya-os.ai/mcp` |
+| DID document | [/.well-known/did.json](https://demo-mcp.kya-os.ai/.well-known/did.json) |
+| Entity Card | [/card.json](https://demo-mcp.kya-os.ai/card.json) |
+| Revocation status list | [/status-list](https://demo-mcp.kya-os.ai/status-list) |
+| Exactly what is running | [/provenance](https://demo-mcp.kya-os.ai/provenance) |
+
+Connect [MCP Inspector](https://github.com/modelcontextprotocol/inspector) to `https://demo-mcp.kya-os.ai/mcp`, call `vault_read`, and inspect the proof in `_meta`.
+Then verify that proof yourself with [examples/verify-proof](./examples/verify-proof/), which resolves the server's `did:web` over the public internet and checks the signature.
+A guided browser walkthrough of the same server (valid proof, tamper, replay, stolen key, live revocation, cross-language re-verification) runs at [poc.kya-os.ai](https://poc.kya-os.ai).
+
+The [daily probe](./.github/workflows/live-probe.yml) in CI performs those same read-only checks: it fetches the discovery surfaces, round-trips a real tool call over MCP, and verifies the returned proof against the publicly resolved DID.
+The server is operated by a maintainer on pinned releases; this repo does not deploy it, it independently verifies it.
+
 ---
 
 ## What's under the hood


### PR DESCRIPTION
There is now a public reference deployment of the package: https://demo-mcp.kya-os.ai, a streamable-http MCP server with a did:web identity, an entity card, and a bitstring status list, pinned to the latest published release. This PR links it from the README and adds a small scheduled workflow that checks it once a day.

The workflow is deliberately read-only and needs no secrets. It fetches the discovery surfaces (did.json, card.json, status-list, provenance), then round-trips a real tool call over MCP and verifies the returned _meta proof with the existing examples/verify-proof script, which resolves did:web:demo-mcp.kya-os.ai over the public internet and checks the JWS. If the deployment drifts or goes down, the badge goes red.

The repo does not deploy or operate the server, it only verifies it, the same way any third party can. Deployment configs and credentials live outside this repo on purpose, so nothing vendor-specific enters CI here. I ran the exact probe sequence locally against the live server before opening this and the proof verified.

There is also a guided browser walkthrough that drives the same server at https://poc.kya-os.ai, linked from the new README section.