### PR TITLE
docs: point site links at kya-os.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <a href="https://kya-os.ai">
+  <a href="https://kya-os.org">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://kya-os.ai/mcp/images/logo-mark_white.svg">
-      <img alt="" src="https://kya-os.ai/mcp/images/logo-mark_black.svg" width="64">
+      <source media="(prefers-color-scheme: dark)" srcset="https://kya-os.org/mcp/images/logo-mark_white.svg">
+      <img alt="" src="https://kya-os.org/mcp/images/logo-mark_black.svg" width="64">
     </picture>
   </a>
 </p>
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@kya-os/mcp"><img src="https://img.shields.io/npm/v/@kya-os/mcp" alt="npm"></a>
-  <a href="https://kya-os.ai/mcp"><img src="https://img.shields.io/badge/spec-KYA--OS-blue" alt="spec"></a>
+  <a href="https://kya-os.org/mcp"><img src="https://img.shields.io/badge/spec-KYA--OS-blue" alt="spec"></a>
   <a href="https://identity.foundation/working-groups/agent-and-authorization.html"><img src="https://img.shields.io/badge/DIF-TAAWG-purple" alt="DIF TAAWG"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/decentralized-identity/kya-os-mcp" alt="license"></a>
 </p>

--- a/examples/outbound-delegation/README.md
+++ b/examples/outbound-delegation/README.md
@@ -111,4 +111,4 @@ const response = await fetch(targetUrl, {
 ## Related Spec
 
 - KYA-OS §7 — Outbound Delegation Propagation
-- [kya-os.ai/mcp](https://kya-os.ai/mcp)
+- [kya-os.org/mcp](https://kya-os.org/mcp)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@
  * KYA-OS Canonical Error Codes
  *
  * Single source of truth for all wire-format error codes.
- * Aligned with the error catalog at kya-os.ai/mcp.
+ * Aligned with the error catalog at kya-os.org/mcp.
  *
  * Naming convention: snake_case, no protocol prefix.
  * Follows OAuth 2.0 / Stripe conventions for readability and portability.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Delegation, proof, and session for Model Context Protocol Identity.
  * This package is a DIF TAAWG protocol reference implementation.
  *
- * Related Spec: https://kya-os.ai/mcp
+ * Related Spec: https://kya-os.org/mcp
  *
  * ## Error handling strategy
  *


### PR DESCRIPTION
The project site lives on kya-os.org (the same domain family as the DIF-registered schema.kya-os.org host), so this points the remaining site links there: the README logo link and both logo image sources, the spec badge, the outbound-delegation example's reference link, and two source-comment pointers in src/errors.ts and src/index.ts. All four changed URL targets were checked and return 200 on kya-os.org.

Two classes of kya-os.ai references are deliberately left alone. The live reference deployment hosts (demo-mcp.kya-os.ai and poc.kya-os.ai, from the live-probe workflow and the README deployment section) are running infrastructure whose did:web identity is the domain itself; changing those strings without moving the deployment would break the daily probe and the documented DID. And historical changelog entries keep their original wording.