### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-22
+
 ### Added
 
 - **Verifiable auditability protocol and `@kya-os/mcp/audit`.** Adds strict,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: identity, delegation, proofs, sessions, and verifiable audit trails",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Minor release cutting everything merged since 1.10.1: the verifiable auditability protocol and `@kya-os/mcp/audit` (recorder, checkpoints, observation, evidence lifecycle, replay bundles, `kya-audit` CLI), the provider contract kit, MCP audit instrumentation, full RFC 8785 canonicalization with cross-language conformance coverage, plus the dev-side vitest 4 toolchain and the ratcheted coverage gate.

The changelog's `[Unreleased]` section is retitled to `[1.11.0] - 2026-07-22`; the entries themselves were already written when the features merged.

After merge: tag `v1.11.0` and `npm publish`. Note the repo has no `v1.10.0`/`v1.10.1` tags on the remote (newest is `v1.9.0`) - worth backfilling `v1.10.1` at 6d880bb while tagging.
