### PR TITLE
docs(spec): fix MCP extension id format and TAAWG name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to @kya-os/mcp
 
-Thank you for your interest in contributing to `@kya-os/mcp` — the reference implementation of the KYA-OS (Know Your Agent Operating System) protocol for Model Context Protocol servers, submitted to the [DIF Trust and Authorization for AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/agent-and-authorization.html). KYA-OS is the agent identity, authorization, and observability protocol; this package binds its primitives into MCP.
+Thank you for your interest in contributing to `@kya-os/mcp` — the reference implementation of the KYA-OS (Know Your Agent Operating System) protocol for Model Context Protocol servers, submitted to the [DIF Trusted AI Agents Working Group (TAAWG)](https://identity.foundation/working-groups/trusted-agents.html). KYA-OS is the agent identity, authorization, and observability protocol; this package binds its primitives into MCP.
 
 All contributions are welcome: bug fixes, protocol clarifications, new examples, test improvements, and documentation.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ Breaking changes to the specification require **explicit vote**:
 
 ## Relationship to DIF TAAWG
 
-This repository implements the KYA-OS specification, donated to the **Decentralized Identity Foundation (DIF) Trust and Authorization for AI Working Group (TAAWG)** and under review there for ratification as a DIF standard.
+This repository implements the KYA-OS specification, donated to the **Decentralized Identity Foundation (DIF) Trusted AI Agents Working Group (TAAWG)** and under review there for ratification as a DIF standard.
 
 - **Spec decisions** are made in the working group
 - **Implementation decisions** are made here

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@kya-os/mcp"><img src="https://img.shields.io/npm/v/@kya-os/mcp" alt="npm"></a>
   <a href="https://kya-os.org/mcp"><img src="https://img.shields.io/badge/spec-KYA--OS-blue" alt="spec"></a>
-  <a href="https://identity.foundation/working-groups/agent-and-authorization.html"><img src="https://img.shields.io/badge/DIF-TAAWG-purple" alt="DIF TAAWG"></a>
+  <a href="https://identity.foundation/working-groups/trusted-agents.html"><img src="https://img.shields.io/badge/DIF-TAAWG-purple" alt="DIF TAAWG"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/decentralized-identity/kya-os-mcp" alt="license"></a>
 </p>
 
@@ -432,7 +432,7 @@ publication, status-list backend hosting, and external registry changes.
 
 ## Links
 
-- [Spec](./SPEC.md) | [Card Profile](./SPEC-ENTITY-CARD.md) | [Changelog](./CHANGELOG.md) | [DIF TAAWG](https://identity.foundation/working-groups/agent-and-authorization.html) | [npm](https://www.npmjs.com/package/@kya-os/mcp)
+- [Spec](./SPEC.md) | [Card Profile](./SPEC-ENTITY-CARD.md) | [Changelog](./CHANGELOG.md) | [DIF TAAWG](https://identity.foundation/working-groups/trusted-agents.html) | [npm](https://www.npmjs.com/package/@kya-os/mcp)
 - [CONTRIBUTING.md](./CONTRIBUTING.md) | [CONFORMANCE.md](./CONFORMANCE.md) | [SECURITY.md](./SECURITY.md) | [GOVERNANCE.md](./GOVERNANCE.md)
 
 ## License

--- a/SPEC-ENTITY-CARD.md
+++ b/SPEC-ENTITY-CARD.md
@@ -40,8 +40,8 @@ BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as 
 
 Two sub-primitives in this specification are marked **[TAAWG-NORMATIVE]**: the entity **type
 axis** (§3) and the per-request holder-of-key **binding** `client_id → did:web → mandate-VC`
-(§7–§8). These are the two primitives KYA-OS seeks to ratify in the DIF Trust and Authorization
-for AI Agents Working Group (TAAWG); every other normative requirement in this document is shipped
+(§7–§8). These are the two primitives KYA-OS seeks to ratify in the DIF Trusted AI Agents
+Working Group (TAAWG); every other normative requirement in this document is shipped
 as the reference implementation (§15.6).
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -1015,7 +1015,7 @@ reverse-DNS extension id — and hence this key — can be re-pointed without a 
 change.
 
 > **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/proof`
-> (and the corresponding proposed MCP Extension id `org.kya-os.identity`; see
+> (and the corresponding proposed MCP Extension id `org.kya-os/delegation`; see
 > §15.2) are **proposed** and not yet ratified. They remain open for
 > working-group discussion and MAY change before this revision is finalized.
 > Because the key is configurable (above), pinning the final id later does not
@@ -1601,14 +1601,14 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
 - **JSON Schema 2020-12.** Tool `inputSchema`/`outputSchema` and KYA-OS schemas use
   JSON Schema 2020-12 (SEP-2106); see §6.2.
 - **Extensions Track intent (SEP-2133).** KYA-OS intends to register as an MCP
-  Extension under the proposed reverse-DNS extension id `org.kya-os.identity`,
+  Extension under the proposed reverse-DNS extension id `org.kya-os/delegation`,
   with an `ext-*` repository, independent versioning, and negotiation via the
   `extensions` capability map. Once registered, the canonical proof key (§7.6
   `proofMetaKey`) and capability advertisement (§10) will use that extension id;
   the key is configurable for this reason. KYA-OS targets the SEP-2133
   Standards-Track path.
 
-  > **Editorial note — open for discussion.** The extension id `org.kya-os.identity`
+  > **Editorial note — open for discussion.** The extension id `org.kya-os/delegation`
   > and the proof key `org.kya-os/proof` (§7.6) are **proposed** and not yet
   > ratified; both remain open for working-group discussion and MAY change before
   > this revision is finalized.

--- a/SPEC.md
+++ b/SPEC.md
@@ -23,7 +23,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Status
 
-**Stable 1.0.0** — Donated to DIF TAAWG (Decentralized Identity Foundation, Trust and Authorization for AI Agents Working Group). Under review for ratification as a DIF standard. The wire format is stable: any future change that breaks compatibility with this version will require a major version bump.
+**Stable 1.0.0** — Donated to DIF TAAWG (Decentralized Identity Foundation, Trusted AI Agents Working Group). Under review for ratification as a DIF standard. The wire format is stable: any future change that breaks compatibility with this version will require a major version bump.
 
 ---
 


### PR DESCRIPTION
Two small documentation fixes ahead of the extensions work. No normative changes.

**Extension id.** SEP-2133 requires extension ids of the form `{vendor-prefix}/{extension-name}`, so the dot-form `org.kya-os.identity` in the SPEC editorial notes was never a valid id. While fixing the separator, the name narrows to `org.kya-os/delegation`: it matches what the extension actually ships (delegation credentials and per-request proofs).