### PR TITLE
feat(extension): negotiate org.kya-os/decentralized-authority per SPEC-MCP-EXTENSION

### DIFF
--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -1,6 +1,6 @@
 # KYA-OS MCP Extension Binding
 
-**`org.kya-os/delegation`: agent delegation and per-request proof as an MCP 2026-07-28 extension**
+**`org.kya-os/decentralized-authority`: agent delegation and per-request proof as an MCP 2026-07-28 extension**
 
 Version: 1.0.0-draft
 Status: Draft (extension id proposed, pending DIF TAAWG ratification)
@@ -13,7 +13,7 @@ Binds: the KYA-OS Protocol Specification ([SPEC.md](./SPEC.md)) and the Entity C
 ## Abstract
 
 This document specifies how the KYA-OS protocol operates as an optional, strictly additive extension to the Model Context Protocol, using the Extensions framework introduced in the MCP `2026-07-28` specification (SEP-2133).
-The extension is identified as `org.kya-os/delegation` and is negotiated through the standard `extensions` member of `ClientCapabilities` and `ServerCapabilities`.
+The extension is identified as `org.kya-os/decentralized-authority` and is negotiated through the standard `extensions` member of `ClientCapabilities` and `ServerCapabilities`.
 It adds no tools, no JSON-RPC methods, no handshake, and no session semantics.
 Its entire wire surface is: one capability entry, the reverse-DNS `_meta` keys already registered by the underlying specifications, the `KYA-OS-*` outbound HTTP headers, and the Entity Card discovery projections.
 Everything normative about identity, delegation, proofs, and verification is defined in [SPEC.md](./SPEC.md) and [SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md); this document defines only the MCP binding and is intentionally thin.
@@ -33,13 +33,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 The extension identifier is:
 
 ```
-org.kya-os/delegation
+org.kya-os/decentralized-authority
 ```
 
 The vendor prefix `org.kya-os` is the reverse-DNS form of `kya-os.org`, which the KYA-OS project controls.
 The identifier follows the SEP-2133 `{vendor-prefix}/{extension-name}` form.
+The name states the extension's distinguishing property: the authority it conveys (identity, delegation chains, per-request proofs, and their audit trail) verifies locally from signed artifacts, with no round trip to a central authorization service (§13.2).
 
-> **Editorial note - open for discussion.** The extension id `org.kya-os/delegation` is **proposed** and not yet ratified by the DIF Trusted AI Agents Working Group (TAAWG); it remains open for working-group discussion and MAY change before this revision is finalized (see SPEC.md §7.6 and §15.2).
+> **Editorial note - open for discussion.** The extension id `org.kya-os/decentralized-authority` is **proposed** and not yet ratified by the DIF Trusted AI Agents Working Group (TAAWG); it remains open for working-group discussion and MAY change before this revision is finalized (see SPEC.md §7.6 and §15.2).
 
 ### 1.2 Versioning
 
@@ -60,7 +61,7 @@ Re-keying of the `_meta` registry entries (§2.2) would be specified by a succes
 
 | Surface | Mechanism | Defined in |
 |---|---|---|
-| Capability negotiation | `capabilities.extensions["org.kya-os/delegation"]` settings object | §3 (this document) |
+| Capability negotiation | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3 (this document) |
 | Request proof | `_meta["org.kya-os/proof@1"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
 | Response proof / audit | `_meta["org.kya-os/proof"]` detached response proof | SPEC.md §7 |
 | Consent step-up | signed `needs_authorization` challenge | SPEC.md §9 |
@@ -105,7 +106,7 @@ A client that supports this extension declares it inside that object's `extensio
       "io.modelcontextprotocol/protocolVersion": "2026-07-28",
       "io.modelcontextprotocol/clientCapabilities": {
         "extensions": {
-          "org.kya-os/delegation": {
+          "org.kya-os/decentralized-authority": {
             "version": "1.0.0",
             "proofProfiles": ["org.kya-os/proof@1"],
             "didMethods": ["did:key", "did:web"]
@@ -126,7 +127,7 @@ A server declares the extension in the `capabilities.extensions` member of its `
   "supportedVersions": ["2026-07-28"],
   "capabilities": {
     "extensions": {
-      "org.kya-os/delegation": {
+      "org.kya-os/decentralized-authority": {
         "version": "1.0.0",
         "proofProfiles": ["org.kya-os/proof@1"],
         "didMethods": ["did:key", "did:web"],
@@ -164,7 +165,7 @@ A **server** declaration asserts: the server verifies proofs under the listed pr
 
 ### 3.4 Discovery before first call
 
-A client MAY call `server/discover` before any other request to learn whether a server speaks, and whether it requires, `org.kya-os/delegation`, and attach proofs from the first real request onward.
+A client MAY call `server/discover` before any other request to learn whether a server speaks, and whether it requires, `org.kya-os/decentralized-authority`, and attach proofs from the first real request onward.
 The `/.well-known/mcp` document (SPEC.md §10) and the Entity Card projections (SPEC-ENTITY-CARD §6) advertise the same facts out of band; `server/discover` is the in-protocol source of truth under `2026-07-28`.
 
 ---
@@ -181,7 +182,7 @@ When the server does not require the extension:
 
 ### 4.2 Required mode (`required: true`)
 
-When the server requires the extension, a request whose `_meta["io.modelcontextprotocol/clientCapabilities"]` does **not** declare `org.kya-os/delegation` MUST be rejected with the core MCP error:
+When the server requires the extension, a request whose `_meta["io.modelcontextprotocol/clientCapabilities"]` does **not** declare `org.kya-os/decentralized-authority` MUST be rejected with the core MCP error:
 
 ```json
 {
@@ -189,10 +190,10 @@ When the server requires the extension, a request whose `_meta["io.modelcontextp
   "id": 7,
   "error": {
     "code": -32021,
-    "message": "Missing required client capability: org.kya-os/delegation",
+    "message": "Missing required client capability: org.kya-os/decentralized-authority",
     "data": {
       "reason": "extension_not_declared",
-      "extension": "org.kya-os/delegation"
+      "extension": "org.kya-os/decentralized-authority"
     }
   }
 }
@@ -379,7 +380,7 @@ That question is this extension's entire scope, and it composes with, rather tha
 
 An honest comparison against composing DPoP (proof-of-possession), Workload Identity Federation (workload identity), and RFC 8693 token exchange (delegation-ish nesting):
 
-| Capability | DPoP + WIF + RFC 8693 | `org.kya-os/delegation` | Honest call |
+| Capability | DPoP + WIF + RFC 8693 | `org.kya-os/decentralized-authority` | Honest call |
 |---|---|---|---|
 | Per-request proof-of-possession | Yes (HTTP-bound `htm`/`htu`) | Yes (JSON-RPC-bound `requestHash`) | Tie on mechanism; this profile binds the operation, DPoP binds the HTTP envelope; they compose via `cnf.jkt` (SPEC-ENTITY-CARD §8.6, §8.8). |
 | Workload/client identity | Yes, mature IdP federation | Yes (DID + Entity Card) | OAuth rails win on enterprise IdP maturity and reviewer familiarity. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1015,7 +1015,7 @@ reverse-DNS extension id — and hence this key — can be re-pointed without a 
 change.
 
 > **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/proof`
-> (and the corresponding proposed MCP Extension id `org.kya-os/delegation`; see
+> (and the corresponding proposed MCP Extension id `org.kya-os/decentralized-authority`; see
 > §15.2) are **proposed** and not yet ratified. They remain open for
 > working-group discussion and MAY change before this revision is finalized.
 > Because the key is configurable (above), pinning the final id later does not
@@ -1601,14 +1601,14 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
 - **JSON Schema 2020-12.** Tool `inputSchema`/`outputSchema` and KYA-OS schemas use
   JSON Schema 2020-12 (SEP-2106); see §6.2.
 - **Extensions Track intent (SEP-2133).** KYA-OS intends to register as an MCP
-  Extension under the proposed reverse-DNS extension id `org.kya-os/delegation`,
+  Extension under the proposed reverse-DNS extension id `org.kya-os/decentralized-authority`,
   with an `ext-*` repository, independent versioning, and negotiation via the
   `extensions` capability map. Once registered, the canonical proof key (§7.6
   `proofMetaKey`) and capability advertisement (§10) will use that extension id;
   the key is configurable for this reason. KYA-OS targets the SEP-2133
   Standards-Track path.
 
-  > **Editorial note — open for discussion.** The extension id `org.kya-os/delegation`
+  > **Editorial note — open for discussion.** The extension id `org.kya-os/decentralized-authority`
   > and the proof key `org.kya-os/proof` (§7.6) are **proposed** and not yet
   > ratified; both remain open for working-group discussion and MAY change before
   > this revision is finalized.

--- a/conformance/__tests__/conformance.test.ts
+++ b/conformance/__tests__/conformance.test.ts
@@ -22,6 +22,7 @@ const REQUIRED_CATEGORIES: VectorCategory[] = [
   'card-proof',
   'entity-card',
   'audit-integrity',
+  'negotiation',
 ];
 
 describe('KYA-OS conformance — reference implementation', () => {

--- a/conformance/loader.ts
+++ b/conformance/loader.ts
@@ -26,6 +26,7 @@ const VALID_CATEGORIES: readonly VectorCategory[] = [
   'card-proof',
   'entity-card',
   'audit-integrity',
+  'negotiation',
 ];
 
 function assertVectorFile(file: unknown, source: string): asserts file is VectorFile {

--- a/conformance/reference-adapter.ts
+++ b/conformance/reference-adapter.ts
@@ -16,6 +16,8 @@ import {
   createDidKeyResolver,
   createDidWebResolver,
   MemoryNonceCacheProvider,
+  parseExtensionSettings,
+  requireExtension,
   type DIDDocument,
   type CredentialStatus,
   type DelegationCredential,
@@ -48,9 +50,11 @@ import type {
   DelegationChainInput,
   DidResolutionInput,
   EntityCardInput,
+  NegotiationInput,
   SignedProofInput,
   StatusListInput,
 } from './types.js';
+import { isRecord } from '../src/utils/guards.js';
 import {
   CryptoProviderAuditHasher,
   digestAuditEvent,
@@ -341,6 +345,28 @@ export class ReferenceConformanceAdapter implements ConformanceAdapter {
         : fail('audit event canonicalization/digest, Merkle root, or proof rejected');
     } catch (error) {
       return fail(`verifyAuditIntegrity threw: ${asMessage(error)}`);
+    }
+  }
+
+  async evaluateNegotiation(input: NegotiationInput): Promise<AdapterResult> {
+    try {
+      const serverSettings = parseExtensionSettings(input.serverSettings);
+      if (serverSettings === undefined) {
+        return fail('vector serverSettings are not a valid settings object');
+      }
+      const guard = requireExtension(serverSettings);
+      const params = isRecord(input.request.params) ? input.request.params : undefined;
+      const verdict = guard({
+        meta: params?.['_meta'],
+        ...(input.initializeCapabilities !== undefined
+          ? { initializeCapabilities: input.initializeCapabilities }
+          : {}),
+      });
+      return verdict.ok
+        ? PASS
+        : fail(`rejected ${verdict.error.code} (${verdict.error.data.reason})`);
+    } catch (error) {
+      return fail(`evaluateNegotiation threw: ${asMessage(error)}`);
     }
   }
 }

--- a/conformance/runner.ts
+++ b/conformance/runner.ts
@@ -23,6 +23,7 @@ import type {
   DidResolutionInput,
   EntityCardInput,
   ExpectedOutcome,
+  NegotiationInput,
   SignedProofInput,
   StatusListInput,
 } from './types.js';
@@ -69,6 +70,8 @@ async function dispatch(
       return adapter.verifyEntityCard(vector.input as EntityCardInput);
     case 'audit-integrity':
       return adapter.verifyAuditIntegrity(vector.input as AuditIntegrityInput);
+    case 'negotiation':
+      return adapter.evaluateNegotiation(vector.input as NegotiationInput);
     default: {
       const exhaustive: never = vector.category;
       throw new Error(`Unknown vector category: ${String(exhaustive)}`);

--- a/conformance/types.ts
+++ b/conformance/types.ts
@@ -21,6 +21,8 @@
  * last two exercise the NEWER Entity Card layer — the stateless
  * `org.kya-os/proof@1` holder-of-key proof (`card-proof`) and the typed,
  * DID-anchored card (`entity-card`) — which is a distinct, orthogonal profile.
+ * `negotiation` exercises the MCP extension admission gate
+ * (`org.kya-os/delegation`, SPEC-MCP-EXTENSION.md §3-§5).
  */
 export type VectorCategory =
   | 'signed-proof'
@@ -30,7 +32,8 @@ export type VectorCategory =
   | 'did-web-resolution'
   | 'card-proof'
   | 'entity-card'
-  | 'audit-integrity';
+  | 'audit-integrity'
+  | 'negotiation';
 
 /** The outcome a conformant implementation MUST produce for a vector. */
 export type ExpectedOutcome = 'pass' | 'fail';
@@ -228,6 +231,23 @@ export interface AuditIntegrityInput {
 }
 
 /**
+ * Input for the MCP extension admission gate (`org.kya-os/delegation`,
+ * SPEC-MCP-EXTENSION.md §3-§5): given the server's declared settings and an
+ * inbound request, the implementation either ADMITS the request (`pass` - the
+ * extension is active, or an optional server gracefully degrades to core MCP)
+ * or REJECTS it (`fail` - `-32021` MissingRequiredClientCapability). A
+ * malformed client declaration MUST be treated as absent (fail closed).
+ */
+export interface NegotiationInput {
+  /** The server's `capabilities.extensions["org.kya-os/delegation"]` settings object. */
+  serverSettings: unknown;
+  /** The inbound JSON-RPC request; `params._meta` may carry the stateless declaration. */
+  request: { method: string; params?: unknown };
+  /** Initialize-era `ClientCapabilities` (2025-11-25 carriage), when the declaration rode initialize. */
+  initializeCapabilities?: unknown;
+}
+
+/**
  * The contract a third party implements to run the KYA-OS conformance vectors
  * against their own implementation.
  *
@@ -271,4 +291,11 @@ export interface ConformanceAdapter {
 
   /** Verify RFC 9162 audit root, inclusion, and consistency proof vectors. */
   verifyAuditIntegrity(input: AuditIntegrityInput): Promise<AdapterResult>;
+
+  /**
+   * Evaluate MCP extension negotiation: `pass` = the request is admitted
+   * (declared, or gracefully degraded on an optional server); `fail` = the
+   * server rejects it (`-32021`, required extension not declared).
+   */
+  evaluateNegotiation(input: NegotiationInput): Promise<AdapterResult>;
 }

--- a/conformance/types.ts
+++ b/conformance/types.ts
@@ -22,7 +22,7 @@
  * `org.kya-os/proof@1` holder-of-key proof (`card-proof`) and the typed,
  * DID-anchored card (`entity-card`) — which is a distinct, orthogonal profile.
  * `negotiation` exercises the MCP extension admission gate
- * (`org.kya-os/delegation`, SPEC-MCP-EXTENSION.md §3-§5).
+ * (`org.kya-os/decentralized-authority`, SPEC-MCP-EXTENSION.md §3-§5).
  */
 export type VectorCategory =
   | 'signed-proof'
@@ -231,7 +231,7 @@ export interface AuditIntegrityInput {
 }
 
 /**
- * Input for the MCP extension admission gate (`org.kya-os/delegation`,
+ * Input for the MCP extension admission gate (`org.kya-os/decentralized-authority`,
  * SPEC-MCP-EXTENSION.md §3-§5): given the server's declared settings and an
  * inbound request, the implementation either ADMITS the request (`pass` - the
  * extension is active, or an optional server gracefully degrades to core MCP)
@@ -239,7 +239,7 @@ export interface AuditIntegrityInput {
  * malformed client declaration MUST be treated as absent (fail closed).
  */
 export interface NegotiationInput {
-  /** The server's `capabilities.extensions["org.kya-os/delegation"]` settings object. */
+  /** The server's `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object. */
   serverSettings: unknown;
   /** The inbound JSON-RPC request; `params._meta` may carry the stateless declaration. */
   request: { method: string; params?: unknown };

--- a/conformance/vectors/negotiation.json
+++ b/conformance/vectors/negotiation.json
@@ -1,0 +1,157 @@
+{
+  "version": "1.0.0",
+  "category": "negotiation",
+  "vectors": [
+    {
+      "id": "negotiation/declared-optional",
+      "category": "negotiation",
+      "description": "Client declares org.kya-os/delegation in per-request _meta clientCapabilities; server does not require it",
+      "expected": "pass",
+      "reason": "A declared extension on an optional server is admitted with the extension active",
+      "input": {
+        "serverSettings": { "version": "1.0.0", "proofProfiles": ["org.kya-os/proof@1"] },
+        "request": {
+          "method": "tools/call",
+          "params": {
+            "name": "read_file",
+            "arguments": { "path": "/tmp/notes.txt" },
+            "_meta": {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": {
+                  "org.kya-os/delegation": {
+                    "version": "1.0.0",
+                    "proofProfiles": ["org.kya-os/proof@1"],
+                    "didMethods": ["did:key", "did:web"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "negotiation/absent-optional",
+      "category": "negotiation",
+      "description": "Client does not declare the extension; server does not require it",
+      "expected": "pass",
+      "reason": "Graceful degradation: an unaware client gets core MCP behavior on an optional server",
+      "input": {
+        "serverSettings": {},
+        "request": {
+          "method": "tools/call",
+          "params": { "name": "read_file", "arguments": { "path": "/tmp/notes.txt" } }
+        }
+      }
+    },
+    {
+      "id": "negotiation/absent-required",
+      "category": "negotiation",
+      "description": "Client does not declare the extension; server requires it",
+      "expected": "fail",
+      "reason": "A required-mode server MUST reject an undeclared client with -32021 (extension_not_declared)",
+      "input": {
+        "serverSettings": { "required": true },
+        "request": {
+          "method": "tools/call",
+          "params": {
+            "name": "read_file",
+            "arguments": { "path": "/tmp/notes.txt" },
+            "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+          }
+        }
+      }
+    },
+    {
+      "id": "negotiation/malformed-required",
+      "category": "negotiation",
+      "description": "Client declaration entry is present but malformed; server requires the extension",
+      "expected": "fail",
+      "reason": "A malformed settings object MUST be treated as absent (fail closed), so a required server rejects with -32021",
+      "input": {
+        "serverSettings": { "required": true },
+        "request": {
+          "method": "tools/call",
+          "params": {
+            "name": "read_file",
+            "arguments": { "path": "/tmp/notes.txt" },
+            "_meta": {
+              "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": {
+                  "org.kya-os/delegation": {
+                    "version": 1,
+                    "proofProfiles": "org.kya-os/proof@1"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "negotiation/legacy-initialize-required",
+      "category": "negotiation",
+      "description": "2025-11-25 peer declared the extension via initialize-era capabilities.extensions; server requires it",
+      "expected": "pass",
+      "reason": "The initialize-era carriage is a valid declaration when no per-request declaration is present",
+      "input": {
+        "serverSettings": { "required": true },
+        "request": {
+          "method": "tools/call",
+          "params": { "name": "read_file", "arguments": { "path": "/tmp/notes.txt" } }
+        },
+        "initializeCapabilities": {
+          "extensions": {
+            "org.kya-os/delegation": { "version": "1.0.0", "didMethods": ["did:web"] }
+          }
+        }
+      }
+    },
+    {
+      "id": "negotiation/empty-object-required",
+      "category": "negotiation",
+      "description": "Client declares the extension as an empty settings object; server requires it",
+      "expected": "pass",
+      "reason": "Per SEP-2133 an empty object means supported-with-default-configuration, which satisfies required mode",
+      "input": {
+        "serverSettings": { "required": true },
+        "request": {
+          "method": "tools/call",
+          "params": {
+            "name": "read_file",
+            "arguments": { "path": "/tmp/notes.txt" },
+            "_meta": {
+              "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": { "org.kya-os/delegation": {} }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "negotiation/malformed-optional",
+      "category": "negotiation",
+      "description": "Client declaration entry is malformed; server does not require the extension",
+      "expected": "pass",
+      "reason": "A malformed declaration degrades to core behavior on an optional server, never to a rejection",
+      "input": {
+        "serverSettings": {},
+        "request": {
+          "method": "tools/call",
+          "params": {
+            "name": "read_file",
+            "arguments": { "path": "/tmp/notes.txt" },
+            "_meta": {
+              "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": { "org.kya-os/delegation": ["not", "an", "object"] }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/vectors/negotiation.json
+++ b/conformance/vectors/negotiation.json
@@ -5,7 +5,7 @@
     {
       "id": "negotiation/declared-optional",
       "category": "negotiation",
-      "description": "Client declares org.kya-os/delegation in per-request _meta clientCapabilities; server does not require it",
+      "description": "Client declares org.kya-os/decentralized-authority in per-request _meta clientCapabilities; server does not require it",
       "expected": "pass",
       "reason": "A declared extension on an optional server is admitted with the extension active",
       "input": {
@@ -19,7 +19,7 @@
               "io.modelcontextprotocol/protocolVersion": "2026-07-28",
               "io.modelcontextprotocol/clientCapabilities": {
                 "extensions": {
-                  "org.kya-os/delegation": {
+                  "org.kya-os/decentralized-authority": {
                     "version": "1.0.0",
                     "proofProfiles": ["org.kya-os/proof@1"],
                     "didMethods": ["did:key", "did:web"]
@@ -79,7 +79,7 @@
             "_meta": {
               "io.modelcontextprotocol/clientCapabilities": {
                 "extensions": {
-                  "org.kya-os/delegation": {
+                  "org.kya-os/decentralized-authority": {
                     "version": 1,
                     "proofProfiles": "org.kya-os/proof@1"
                   }
@@ -104,7 +104,7 @@
         },
         "initializeCapabilities": {
           "extensions": {
-            "org.kya-os/delegation": { "version": "1.0.0", "didMethods": ["did:web"] }
+            "org.kya-os/decentralized-authority": { "version": "1.0.0", "didMethods": ["did:web"] }
           }
         }
       }
@@ -124,7 +124,7 @@
             "arguments": { "path": "/tmp/notes.txt" },
             "_meta": {
               "io.modelcontextprotocol/clientCapabilities": {
-                "extensions": { "org.kya-os/delegation": {} }
+                "extensions": { "org.kya-os/decentralized-authority": {} }
               }
             }
           }
@@ -146,7 +146,7 @@
             "arguments": { "path": "/tmp/notes.txt" },
             "_meta": {
               "io.modelcontextprotocol/clientCapabilities": {
-                "extensions": { "org.kya-os/delegation": ["not", "an", "object"] }
+                "extensions": { "org.kya-os/decentralized-authority": ["not", "an", "object"] }
               }
             }
           }

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,7 +13,7 @@ This directory contains JSON Schema definitions for the core KYA-OS (Model Conte
 | [detached-proof.json](./detached-proof.json) | Cryptographic proof for tool request/response |
 | [kya-os-card.schema.json](./kya-os-card.schema.json) | Typed KYA-OS Entity Card |
 | [well-known-mcpi.json](./well-known-mcpi.json) | Service discovery document |
-| [mcp-extension-settings.json](./mcp-extension-settings.json) | Negotiation settings for the `org.kya-os/delegation` MCP extension (SEP-2133) |
+| [mcp-extension-settings.json](./mcp-extension-settings.json) | Negotiation settings for the `org.kya-os/decentralized-authority` MCP extension (SEP-2133) |
 | [audit-event.schema.json](./audit-event.schema.json) | Strict, privacy-minimal producer audit event core |
 | [audit-entry.schema.json](./audit-entry.schema.json) | Recorder-assigned chained entry core |
 | [audit-receipt.schema.json](./audit-receipt.schema.json) | Signed append-receipt core |

--- a/schemas/mcp-extension-settings.json
+++ b/schemas/mcp-extension-settings.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.kya-os.org/v1/protocol/mcp-extension/settings/v1.0.0",
   "title": "KYA-OS MCP Extension Settings",
-  "description": "The settings object declared under capabilities.extensions[\"org.kya-os/delegation\"] in MCP ClientCapabilities and ServerCapabilities (SEP-2133). All members are optional; an empty object means the extension is supported with default configuration. Unknown members are ignored for forward compatibility. See SPEC-MCP-EXTENSION.md section 3.",
+  "description": "The settings object declared under capabilities.extensions[\"org.kya-os/decentralized-authority\"] in MCP ClientCapabilities and ServerCapabilities (SEP-2133). All members are optional; an empty object means the extension is supported with default configuration. Unknown members are ignored for forward compatibility. See SPEC-MCP-EXTENSION.md section 3.",
   "type": "object",
   "properties": {
     "version": {
@@ -29,7 +29,7 @@
     },
     "required": {
       "type": "boolean",
-      "description": "Server-side only: when true, the server rejects requests from clients that did not declare org.kya-os/delegation, using JSON-RPC error -32021 (MissingRequiredClientCapabilityError). Meaningless on a client declaration and ignored there. Defaults to false.",
+      "description": "Server-side only: when true, the server rejects requests from clients that did not declare org.kya-os/decentralized-authority, using JSON-RPC error -32021 (MissingRequiredClientCapabilityError). Meaningless on a client declaration and ignored there. Defaults to false.",
       "default": false
     }
   },

--- a/src/extension/__tests__/declaration.test.ts
+++ b/src/extension/__tests__/declaration.test.ts
@@ -103,7 +103,7 @@ describe('readExtensionDeclaration - precedence', () => {
 
 describe('readExtensionDeclaration - id override', () => {
   it('reads a declaration under an overridden extension id', () => {
-    const id = 'io.modelcontextprotocol/delegation';
+    const id = 'io.modelcontextprotocol/decentralized-authority';
     const declaration = readExtensionDeclaration({ meta: metaDeclaring({}, id), extensionId: id });
     expect(declaration).toEqual({ settings: {}, carriage: 'stateless' });
   });

--- a/src/extension/__tests__/declaration.test.ts
+++ b/src/extension/__tests__/declaration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Declaration reading across both carriage forms (SPEC-MCP-EXTENSION.md §3.1):
+ * the per-request stateless `_meta` carriage, the initialize-era carriage, the
+ * stateless-wins precedence, and the malformed-treated-as-absent rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readExtensionDeclaration } from '../declaration.js';
+import { KYA_OS_EXTENSION_ID, MCP_CLIENT_CAPABILITIES_META_KEY } from '../settings.js';
+
+/** A `params._meta` bag whose clientCapabilities declare the given extension entry. */
+function metaDeclaring(entry: unknown, id: string = KYA_OS_EXTENSION_ID): Record<string, unknown> {
+  return {
+    [MCP_CLIENT_CAPABILITIES_META_KEY]: { extensions: { [id]: entry } },
+  };
+}
+
+describe('readExtensionDeclaration - stateless carriage', () => {
+  it('reads a valid per-request declaration', () => {
+    const declaration = readExtensionDeclaration({
+      meta: metaDeclaring({ version: '1.0.0', didMethods: ['did:web'] }),
+    });
+    expect(declaration).toEqual({
+      settings: { version: '1.0.0', didMethods: ['did:web'] },
+      carriage: 'stateless',
+    });
+  });
+
+  it('treats an explicit empty-object entry as declared', () => {
+    const declaration = readExtensionDeclaration({ meta: metaDeclaring({}) });
+    expect(declaration).toEqual({ settings: {}, carriage: 'stateless' });
+  });
+
+  it('returns undefined when nothing declares the extension', () => {
+    expect(readExtensionDeclaration({})).toBeUndefined();
+    expect(readExtensionDeclaration({ meta: {} })).toBeUndefined();
+  });
+
+  it.each([
+    ['a non-record meta', 'not-a-record'],
+    ['a null meta', null],
+    ['an array meta', []],
+  ])('returns undefined for %s', (_label, meta) => {
+    expect(readExtensionDeclaration({ meta })).toBeUndefined();
+  });
+
+  it('returns undefined when clientCapabilities is not a record', () => {
+    const meta = { [MCP_CLIENT_CAPABILITIES_META_KEY]: 'capabilities' };
+    expect(readExtensionDeclaration({ meta })).toBeUndefined();
+  });
+
+  it('returns undefined when extensions is not a record', () => {
+    const meta = { [MCP_CLIENT_CAPABILITIES_META_KEY]: { extensions: ['x'] } };
+    expect(readExtensionDeclaration({ meta })).toBeUndefined();
+  });
+
+  it('ignores declarations of other extensions', () => {
+    const meta = metaDeclaring({}, 'io.modelcontextprotocol/tasks');
+    expect(readExtensionDeclaration({ meta })).toBeUndefined();
+  });
+
+  it('treats a malformed entry as absent (fail closed)', () => {
+    const meta = metaDeclaring({ proofProfiles: 'not-an-array' });
+    expect(readExtensionDeclaration({ meta })).toBeUndefined();
+  });
+});
+
+describe('readExtensionDeclaration - initialize-era carriage', () => {
+  it('reads the initialize-era declaration when no stateless entry exists', () => {
+    const declaration = readExtensionDeclaration({
+      meta: { [MCP_CLIENT_CAPABILITIES_META_KEY]: {} },
+      initializeCapabilities: { extensions: { [KYA_OS_EXTENSION_ID]: { required: false } } },
+    });
+    expect(declaration).toEqual({ settings: { required: false }, carriage: 'initialize' });
+  });
+
+  it('treats a malformed initialize-era entry as absent', () => {
+    const declaration = readExtensionDeclaration({
+      initializeCapabilities: { extensions: { [KYA_OS_EXTENSION_ID]: 42 } },
+    });
+    expect(declaration).toBeUndefined();
+  });
+});
+
+describe('readExtensionDeclaration - precedence', () => {
+  it('a present-but-malformed stateless entry is final: no initialize-era fallback', () => {
+    const declaration = readExtensionDeclaration({
+      meta: metaDeclaring({ version: 7 }),
+      initializeCapabilities: { extensions: { [KYA_OS_EXTENSION_ID]: {} } },
+    });
+    expect(declaration).toBeUndefined();
+  });
+
+  it('a valid stateless entry wins over a differing initialize-era one', () => {
+    const declaration = readExtensionDeclaration({
+      meta: metaDeclaring({ version: '2.0.0' }),
+      initializeCapabilities: { extensions: { [KYA_OS_EXTENSION_ID]: { version: '1.0.0' } } },
+    });
+    expect(declaration?.carriage).toBe('stateless');
+    expect(declaration?.settings.version).toBe('2.0.0');
+  });
+});
+
+describe('readExtensionDeclaration - id override', () => {
+  it('reads a declaration under an overridden extension id', () => {
+    const id = 'io.modelcontextprotocol/delegation';
+    const declaration = readExtensionDeclaration({ meta: metaDeclaring({}, id), extensionId: id });
+    expect(declaration).toEqual({ settings: {}, carriage: 'stateless' });
+  });
+});

--- a/src/extension/__tests__/gate.test.ts
+++ b/src/extension/__tests__/gate.test.ts
@@ -93,7 +93,7 @@ describe('requireExtension - required mode', () => {
   });
 
   it('names an overridden extension id in the rejection', () => {
-    const id = 'io.modelcontextprotocol/delegation';
+    const id = 'io.modelcontextprotocol/decentralized-authority';
     const overridden = requireExtension({ required: true }, { extensionId: id });
     const verdict = overridden({});
     expect(verdict.ok).toBe(false);

--- a/src/extension/__tests__/gate.test.ts
+++ b/src/extension/__tests__/gate.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The admission gate (SPEC-MCP-EXTENSION.md §4) and the JSON-RPC error surface
+ * (§5): required mode answers absence with core -32021 and the
+ * `extension_not_declared` reason; optional mode degrades to core behavior;
+ * proof-gate failures map their snake_case codes onto `error.data.reason`
+ * verbatim and never allocate from the MCP-reserved code range.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PROOF_PROFILE_ID } from '../../card/schema.js';
+import {
+  KYA_OS_DOMAIN_ERROR_CODE,
+  missingRequiredCapabilityError,
+  proofGateToJsonRpcError,
+  requireExtension,
+} from '../gate.js';
+import {
+  EXTENSION_NOT_DECLARED_REASON,
+  KYA_OS_EXTENSION_ID,
+  MCP_CLIENT_CAPABILITIES_META_KEY,
+  MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
+} from '../settings.js';
+
+function metaDeclaring(entry: unknown): Record<string, unknown> {
+  return {
+    [MCP_CLIENT_CAPABILITIES_META_KEY]: { extensions: { [KYA_OS_EXTENSION_ID]: entry } },
+  };
+}
+
+describe('requireExtension - optional mode (default)', () => {
+  const guard = requireExtension({});
+
+  it('admits a declared peer and reports the declaration', () => {
+    const verdict = guard({ meta: metaDeclaring({ version: '1.0.0' }) });
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.declaration?.carriage).toBe('stateless');
+      expect(verdict.declaration?.settings.version).toBe('1.0.0');
+    }
+  });
+
+  it('admits an undeclared peer as core traffic', () => {
+    const verdict = guard({});
+    expect(verdict).toEqual({ ok: true });
+  });
+
+  it('degrades a malformed declaration to core behavior, never a rejection', () => {
+    const verdict = guard({ meta: metaDeclaring('malformed') });
+    expect(verdict).toEqual({ ok: true });
+  });
+});
+
+describe('requireExtension - required mode', () => {
+  const guard = requireExtension({ required: true });
+
+  it('admits a declared peer', () => {
+    const verdict = guard({ meta: metaDeclaring({}) });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('admits an empty-object declaration (SEP-2133 default configuration)', () => {
+    const verdict = guard({ meta: metaDeclaring({}) });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('rejects an undeclared peer with the exact -32021 shape', () => {
+    const verdict = guard({});
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.error.code).toBe(MISSING_REQUIRED_CLIENT_CAPABILITY_CODE);
+      expect(verdict.error.message).toContain(KYA_OS_EXTENSION_ID);
+      expect(verdict.error.data.reason).toBe(EXTENSION_NOT_DECLARED_REASON);
+      expect(verdict.error.data.extension).toBe(KYA_OS_EXTENSION_ID);
+    }
+  });
+
+  it('rejects a stripped-to-malformed declaration exactly like an absent one', () => {
+    const verdict = guard({ meta: metaDeclaring({ didMethods: ['web'] }) });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.error.code).toBe(MISSING_REQUIRED_CLIENT_CAPABILITY_CODE);
+    }
+  });
+
+  it('accepts the initialize-era carriage', () => {
+    const verdict = guard({
+      initializeCapabilities: { extensions: { [KYA_OS_EXTENSION_ID]: {} } },
+    });
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.declaration?.carriage).toBe('initialize');
+    }
+  });
+
+  it('names an overridden extension id in the rejection', () => {
+    const id = 'io.modelcontextprotocol/delegation';
+    const overridden = requireExtension({ required: true }, { extensionId: id });
+    const verdict = overridden({});
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.error.data.extension).toBe(id);
+      expect(verdict.error.message).toContain(id);
+    }
+  });
+});
+
+describe('requireExtension - own-settings validation', () => {
+  it('throws on malformed server settings (programmer error, fail fast)', () => {
+    expect(() => requireExtension({ version: 'not-semver' })).toThrow(KYA_OS_EXTENSION_ID);
+  });
+});
+
+describe('missingRequiredCapabilityError', () => {
+  it('produces the canonical §4.2 error object', () => {
+    expect(missingRequiredCapabilityError()).toEqual({
+      code: -32021,
+      message: `Missing required client capability: ${KYA_OS_EXTENSION_ID}`,
+      data: { reason: EXTENSION_NOT_DECLARED_REASON, extension: KYA_OS_EXTENSION_ID },
+    });
+  });
+});
+
+describe('proofGateToJsonRpcError', () => {
+  const gateError = {
+    code: 'proof_missing',
+    message: 'no org.kya-os/proof@1 in _meta',
+    reasons: ['proof_missing'],
+  };
+
+  it('carries the snake_case code verbatim in error.data.reason', () => {
+    const error = proofGateToJsonRpcError(gateError);
+    expect(error.code).toBe(KYA_OS_DOMAIN_ERROR_CODE);
+    expect(error.message).toBe(gateError.message);
+    expect(error.data.reason).toBe('proof_missing');
+    expect(error.data.profile).toBe(PROOF_PROFILE_ID);
+    expect(error.data.reasons).toEqual(['proof_missing']);
+  });
+
+  it('omits empty diagnostics', () => {
+    const error = proofGateToJsonRpcError({ code: 'proof_invalid', message: 'nope', reasons: [] });
+    expect(error.data.reasons).toBeUndefined();
+  });
+
+  it('accepts an implementation-defined code override', () => {
+    expect(proofGateToJsonRpcError(gateError, { code: -32005 }).code).toBe(-32005);
+  });
+
+  it.each([-32020, -32021, -32099])(
+    'refuses the MCP-reserved code %d (SPEC-MCP-EXTENSION.md §5.1)',
+    (code) => {
+      expect(() => proofGateToJsonRpcError(gateError, { code })).toThrow('MCP-reserved');
+    },
+  );
+
+  it('allows codes outside the reserved range', () => {
+    expect(proofGateToJsonRpcError(gateError, { code: -32100 }).code).toBe(-32100);
+  });
+});

--- a/src/extension/__tests__/settings.test.ts
+++ b/src/extension/__tests__/settings.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Settings-object validation (SPEC-MCP-EXTENSION.md §3.2, mirrored by
+ * schemas/mcp-extension-settings.json): every member optional, `{}` legal,
+ * unknown members tolerated, malformed peer input parsed fail-closed to
+ * "not declared".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_EXTENSION_SETTINGS,
+  KYA_OS_EXTENSION_ID,
+  buildExtensionSettings,
+  buildExtensionsEntry,
+  parseExtensionSettings,
+  resolveExtensionSettings,
+} from '../settings.js';
+
+describe('parseExtensionSettings', () => {
+  it('accepts the empty object (SEP-2133: supported with default configuration)', () => {
+    expect(parseExtensionSettings({})).toEqual({});
+  });
+
+  it('accepts a fully-populated settings object', () => {
+    const settings = {
+      version: '1.0.0',
+      proofProfiles: ['org.kya-os/proof@1'],
+      didMethods: ['did:key', 'did:web'],
+      required: true,
+    };
+    expect(parseExtensionSettings(settings)).toEqual(settings);
+  });
+
+  it('tolerates and strips unknown members (forward compatibility)', () => {
+    const parsed = parseExtensionSettings({ version: '2.1.0', futureKnob: 'x' });
+    expect(parsed).toEqual({ version: '2.1.0' });
+  });
+
+  it('accepts a prerelease version string', () => {
+    expect(parseExtensionSettings({ version: '1.0.0-rc.1' })).toEqual({ version: '1.0.0-rc.1' });
+  });
+
+  it.each([null, undefined, [], 'settings', 42, true])(
+    'rejects a non-object value (%s)',
+    (value) => {
+      expect(parseExtensionSettings(value)).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ['a non-semver version', { version: 'v1' }],
+    ['a numeric version', { version: 1 }],
+    ['a string proofProfiles', { proofProfiles: 'org.kya-os/proof@1' }],
+    ['an empty proofProfiles array', { proofProfiles: [] }],
+    ['duplicate proofProfiles', { proofProfiles: ['p', 'p'] }],
+    ['an empty proofProfiles entry', { proofProfiles: [''] }],
+    ['a didMethods entry without the did: prefix', { didMethods: ['web'] }],
+    ['an uppercase didMethods entry', { didMethods: ['did:WEB'] }],
+    ['duplicate didMethods', { didMethods: ['did:web', 'did:web'] }],
+    ['a non-boolean required', { required: 'true' }],
+  ])('rejects %s', (_label, value) => {
+    expect(parseExtensionSettings(value)).toBeUndefined();
+  });
+
+  it('accepts an opt-in did method like did:cheqd', () => {
+    expect(parseExtensionSettings({ didMethods: ['did:cheqd'] })).toEqual({
+      didMethods: ['did:cheqd'],
+    });
+  });
+});
+
+describe('resolveExtensionSettings', () => {
+  it('resolves the empty declaration to the §3.2 defaults', () => {
+    expect(resolveExtensionSettings({})).toEqual(DEFAULT_EXTENSION_SETTINGS);
+  });
+
+  it('keeps declared members and defaults the rest', () => {
+    const resolved = resolveExtensionSettings({ required: true, didMethods: ['did:web'] });
+    expect(resolved.required).toBe(true);
+    expect(resolved.didMethods).toEqual(['did:web']);
+    expect(resolved.version).toBe(DEFAULT_EXTENSION_SETTINGS.version);
+    expect(resolved.proofProfiles).toEqual(DEFAULT_EXTENSION_SETTINGS.proofProfiles);
+  });
+
+  it('returns copies so callers cannot mutate the shared defaults', () => {
+    const resolved = resolveExtensionSettings({});
+    resolved.proofProfiles.push('mutated');
+    resolved.didMethods.push('did:mutated');
+    expect(DEFAULT_EXTENSION_SETTINGS.proofProfiles).toEqual(['org.kya-os/proof@1']);
+    expect(DEFAULT_EXTENSION_SETTINGS.didMethods).toEqual(['did:key', 'did:web']);
+  });
+});
+
+describe('buildExtensionSettings / buildExtensionsEntry', () => {
+  it('throws on malformed own settings (programmer error, not peer input)', () => {
+    expect(() => buildExtensionSettings({ version: 'nope' })).toThrow(KYA_OS_EXTENSION_ID);
+  });
+
+  it('builds the extensions-map fragment under the extension id', () => {
+    const entry = buildExtensionsEntry({ required: true });
+    expect(entry).toEqual({ [KYA_OS_EXTENSION_ID]: { required: true } });
+  });
+
+  it('supports an id override for graduation re-pointing', () => {
+    const entry = buildExtensionsEntry({}, 'io.modelcontextprotocol/delegation');
+    expect(Object.keys(entry)).toEqual(['io.modelcontextprotocol/delegation']);
+  });
+});

--- a/src/extension/__tests__/settings.test.ts
+++ b/src/extension/__tests__/settings.test.ts
@@ -101,7 +101,7 @@ describe('buildExtensionSettings / buildExtensionsEntry', () => {
   });
 
   it('supports an id override for graduation re-pointing', () => {
-    const entry = buildExtensionsEntry({}, 'io.modelcontextprotocol/delegation');
-    expect(Object.keys(entry)).toEqual(['io.modelcontextprotocol/delegation']);
+    const entry = buildExtensionsEntry({}, 'io.modelcontextprotocol/decentralized-authority');
+    expect(Object.keys(entry)).toEqual(['io.modelcontextprotocol/decentralized-authority']);
   });
 });

--- a/src/extension/declaration.ts
+++ b/src/extension/declaration.ts
@@ -1,0 +1,89 @@
+/**
+ * Reading a peer's `org.kya-os/delegation` declaration (SPEC-MCP-EXTENSION.md §3.1).
+ *
+ * Two carriage forms are normalized into one shape:
+ *
+ *   - stateless (2026-07-28): the request's
+ *     `params._meta["io.modelcontextprotocol/clientCapabilities"].extensions[id]`
+ *   - initialize-era (2025-11-25): `capabilities.extensions[id]` from the
+ *     initialize exchange, supplied by the host as `initializeCapabilities`
+ *
+ * Precedence: the per-request stateless entry, when PRESENT, is final - a
+ * malformed stateless entry is treated as no declaration (fail closed, §3.2)
+ * and the initialize-era entry is NOT consulted as a fallback, because the
+ * per-request carriage supersedes initialize-era state.
+ */
+
+import { isRecord } from '../utils/guards.js';
+import {
+  KYA_OS_EXTENSION_ID,
+  MCP_CLIENT_CAPABILITIES_META_KEY,
+  parseExtensionSettings,
+  type KyaOsExtensionSettings,
+} from './settings.js';
+
+/** Which carriage form a declaration arrived on. */
+export type DeclarationCarriage = 'stateless' | 'initialize';
+
+/** A normalized, validated peer declaration. */
+export interface ExtensionDeclaration {
+  settings: KyaOsExtensionSettings;
+  carriage: DeclarationCarriage;
+}
+
+/** Input to {@link readExtensionDeclaration}; both carriage sources are optional. */
+export interface ReadDeclarationInput {
+  /** The request's `params._meta` bag (stateless carriage). */
+  meta?: unknown;
+  /** Initialize-era `ClientCapabilities` (2025-11-25 carriage). */
+  initializeCapabilities?: unknown;
+  /** Extension id override (defaults to {@link KYA_OS_EXTENSION_ID}). */
+  extensionId?: string;
+}
+
+/**
+ * Read and validate the peer's declaration from either carriage.
+ * Returns `undefined` when the extension is not declared - including when the
+ * declared settings object is malformed (treated as absent, §3.2).
+ */
+export function readExtensionDeclaration(
+  input: ReadDeclarationInput,
+): ExtensionDeclaration | undefined {
+  const id = input.extensionId ?? KYA_OS_EXTENSION_ID;
+
+  const stateless = extensionsEntry(clientCapabilitiesFromMeta(input.meta), id);
+  if (stateless.present) {
+    const settings = parseExtensionSettings(stateless.value);
+    return settings === undefined ? undefined : { settings, carriage: 'stateless' };
+  }
+
+  const legacy = extensionsEntry(input.initializeCapabilities, id);
+  if (legacy.present) {
+    const settings = parseExtensionSettings(legacy.value);
+    return settings === undefined ? undefined : { settings, carriage: 'initialize' };
+  }
+
+  return undefined;
+}
+
+/** Pull `io.modelcontextprotocol/clientCapabilities` out of a `_meta` bag. */
+function clientCapabilitiesFromMeta(meta: unknown): unknown {
+  return isRecord(meta) ? meta[MCP_CLIENT_CAPABILITIES_META_KEY] : undefined;
+}
+
+/**
+ * Locate the extension's entry inside a capabilities object. Presence is
+ * detected with `hasOwnProperty` so an explicit empty-object declaration
+ * (`{ "org.kya-os/delegation": {} }` - legal per SEP-2133) is distinguishable
+ * from an absent one.
+ */
+function extensionsEntry(
+  capabilities: unknown,
+  id: string,
+): { present: boolean; value?: unknown } {
+  if (!isRecord(capabilities)) return { present: false };
+  const extensions = capabilities['extensions'];
+  if (!isRecord(extensions)) return { present: false };
+  if (!Object.prototype.hasOwnProperty.call(extensions, id)) return { present: false };
+  return { present: true, value: extensions[id] };
+}

--- a/src/extension/declaration.ts
+++ b/src/extension/declaration.ts
@@ -1,5 +1,5 @@
 /**
- * Reading a peer's `org.kya-os/delegation` declaration (SPEC-MCP-EXTENSION.md §3.1).
+ * Reading a peer's `org.kya-os/decentralized-authority` declaration (SPEC-MCP-EXTENSION.md §3.1).
  *
  * Two carriage forms are normalized into one shape:
  *
@@ -74,7 +74,7 @@ function clientCapabilitiesFromMeta(meta: unknown): unknown {
 /**
  * Locate the extension's entry inside a capabilities object. Presence is
  * detected with `hasOwnProperty` so an explicit empty-object declaration
- * (`{ "org.kya-os/delegation": {} }` - legal per SEP-2133) is distinguishable
+ * (`{ "org.kya-os/decentralized-authority": {} }` - legal per SEP-2133) is distinguishable
  * from an absent one.
  */
 function extensionsEntry(

--- a/src/extension/gate.ts
+++ b/src/extension/gate.ts
@@ -1,0 +1,140 @@
+/**
+ * The `org.kya-os/delegation` admission gate (SPEC-MCP-EXTENSION.md §4-§5).
+ *
+ * Mirrors the `requireProof` guard idiom (`src/card/middleware.ts`): the host
+ * builds a guard once from its server settings and runs it per request. Nothing
+ * in the default path changes for hosts that never install the gate - the
+ * extension is strictly opt-in.
+ *
+ *   - `required: false` (default): an undeclared peer gets core MCP behavior;
+ *     the gate always admits and merely reports the declaration when present.
+ *   - `required: true`: a request without a declaration is rejected with the
+ *     core MCP error `-32021` (`MissingRequiredClientCapabilityError`) carrying
+ *     `error.data = { reason: "extension_not_declared", extension: <id> }`.
+ *
+ * A stripped or malformed declaration is an ABSENT declaration (fail closed,
+ * §4.3) - never silent acceptance, never a guess.
+ */
+
+import { PROOF_PROFILE_ID } from '../card/schema.js';
+import {
+  readExtensionDeclaration,
+  type ExtensionDeclaration,
+} from './declaration.js';
+import {
+  EXTENSION_NOT_DECLARED_REASON,
+  KYA_OS_EXTENSION_ID,
+  MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
+  buildExtensionSettings,
+  resolveExtensionSettings,
+  type KyaOsExtensionSettings,
+} from './settings.js';
+
+/**
+ * Default implementation-defined JSON-RPC code for KYA-OS domain failures
+ * (SPEC-MCP-EXTENSION.md §5). The number is deliberately NOT the dispatch
+ * surface - clients dispatch on `error.data.reason` - and it stays inside the
+ * JSON-RPC implementation-defined range (`-32000..-32019`).
+ */
+export const KYA_OS_DOMAIN_ERROR_CODE = -32000;
+
+/** The MCP-reserved code range this extension MUST NOT allocate from (§5.1). */
+const MCP_RESERVED_MIN = -32099;
+const MCP_RESERVED_MAX = -32020;
+
+/** A JSON-RPC error object (the `error` member of a JSON-RPC response). */
+export interface JsonRpcErrorObject {
+  code: number;
+  message: string;
+  data: {
+    /** The snake_case KYA-OS reason code - the mandatory dispatch surface (§5.2). */
+    reason: string;
+    /** The extension id, on negotiation failures. */
+    extension?: string;
+    /** The proof profile, on proof-gate failures. */
+    profile?: string;
+    /** Fine-grained verification reasons (SPEC-ENTITY-CARD Appendix D.1), for diagnostics. */
+    reasons?: string[];
+  };
+}
+
+/** The gate verdict: admitted (with the declaration when one was made) or a JSON-RPC rejection. */
+export type ExtensionGateResult =
+  | { ok: true; declaration?: ExtensionDeclaration }
+  | { ok: false; error: JsonRpcErrorObject };
+
+/** Per-request admission guard built by {@link requireExtension}. */
+export type ExtensionGuard = (input: {
+  meta?: unknown;
+  initializeCapabilities?: unknown;
+}) => ExtensionGateResult;
+
+/**
+ * Build the admission guard from the server's own settings (validated here,
+ * throwing on malformed OWN settings - a programmer error, unlike peer input).
+ */
+export function requireExtension(
+  serverSettings: KyaOsExtensionSettings = {},
+  opts: { extensionId?: string } = {},
+): ExtensionGuard {
+  const settings = resolveExtensionSettings(buildExtensionSettings(serverSettings));
+  const extensionId = opts.extensionId ?? KYA_OS_EXTENSION_ID;
+  return (input) => {
+    const declaration = readExtensionDeclaration({ ...input, extensionId });
+    if (declaration !== undefined) {
+      return { ok: true, declaration };
+    }
+    if (!settings.required) {
+      return { ok: true };
+    }
+    return { ok: false, error: missingRequiredCapabilityError(extensionId) };
+  };
+}
+
+/** The `-32021` rejection for a required-but-undeclared extension (SPEC-MCP-EXTENSION.md §4.2). */
+export function missingRequiredCapabilityError(
+  extensionId: string = KYA_OS_EXTENSION_ID,
+): JsonRpcErrorObject {
+  return {
+    code: MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
+    message: `Missing required client capability: ${extensionId}`,
+    data: { reason: EXTENSION_NOT_DECLARED_REASON, extension: extensionId },
+  };
+}
+
+/** The 401-shaped proof-gate error shape (`requireProof`, `src/card/middleware.ts`), structurally. */
+export interface ProofGateErrorLike {
+  /** A snake_case gate code (`proof_missing` | `proof_invalid` | `proof_level_insufficient`). */
+  code: string;
+  message: string;
+  reasons?: string[];
+}
+
+/**
+ * Map a proof-gate rejection onto the JSON-RPC surface per SPEC-MCP-EXTENSION.md
+ * §5.2: the snake_case code rides `error.data.reason` VERBATIM, the numeric code
+ * stays implementation-defined, and codes inside the MCP-reserved range
+ * (`-32099..-32020`) are refused outright.
+ */
+export function proofGateToJsonRpcError(
+  gateError: ProofGateErrorLike,
+  opts: { code?: number; profile?: string } = {},
+): JsonRpcErrorObject {
+  if (opts.code !== undefined && opts.code >= MCP_RESERVED_MIN && opts.code <= MCP_RESERVED_MAX) {
+    throw new Error(
+      `JSON-RPC code ${opts.code} is inside the MCP-reserved range (${MCP_RESERVED_MIN}..${MCP_RESERVED_MAX}); ` +
+        'KYA-OS domain errors use implementation-defined codes (SPEC-MCP-EXTENSION.md §5.1)',
+    );
+  }
+  return {
+    code: opts.code ?? KYA_OS_DOMAIN_ERROR_CODE,
+    message: gateError.message,
+    data: {
+      reason: gateError.code,
+      profile: opts.profile ?? PROOF_PROFILE_ID,
+      ...(gateError.reasons && gateError.reasons.length > 0
+        ? { reasons: [...gateError.reasons] }
+        : {}),
+    },
+  };
+}

--- a/src/extension/gate.ts
+++ b/src/extension/gate.ts
@@ -1,5 +1,5 @@
 /**
- * The `org.kya-os/delegation` admission gate (SPEC-MCP-EXTENSION.md §4-§5).
+ * The `org.kya-os/decentralized-authority` admission gate (SPEC-MCP-EXTENSION.md §4-§5).
  *
  * Mirrors the `requireProof` guard idiom (`src/card/middleware.ts`): the host
  * builds a guard once from its server settings and runs it per request. Nothing

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,0 +1,43 @@
+/**
+ * KYA-OS MCP extension negotiation (`org.kya-os/delegation`).
+ *
+ * The MCP binding surface of SPEC-MCP-EXTENSION.md: the extension id and
+ * settings object (§1, §3), the declaration reader for both carriage forms
+ * (§3.1), the admission gate with core `-32021` required-mode enforcement
+ * (§4), and the JSON-RPC error mapping that keeps snake_case reason codes as
+ * the dispatch surface (§5). Strictly additive: nothing here runs unless the
+ * host opts in.
+ */
+
+export {
+  KYA_OS_EXTENSION_ID,
+  MCP_CLIENT_CAPABILITIES_META_KEY,
+  MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
+  EXTENSION_NOT_DECLARED_REASON,
+  ExtensionSettingsSchema,
+  DEFAULT_EXTENSION_SETTINGS,
+  parseExtensionSettings,
+  resolveExtensionSettings,
+  buildExtensionSettings,
+  buildExtensionsEntry,
+  type KyaOsExtensionSettings,
+  type ResolvedExtensionSettings,
+} from './settings.js';
+
+export {
+  readExtensionDeclaration,
+  type DeclarationCarriage,
+  type ExtensionDeclaration,
+  type ReadDeclarationInput,
+} from './declaration.js';
+
+export {
+  KYA_OS_DOMAIN_ERROR_CODE,
+  requireExtension,
+  missingRequiredCapabilityError,
+  proofGateToJsonRpcError,
+  type ExtensionGateResult,
+  type ExtensionGuard,
+  type JsonRpcErrorObject,
+  type ProofGateErrorLike,
+} from './gate.js';

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,5 +1,5 @@
 /**
- * KYA-OS MCP extension negotiation (`org.kya-os/delegation`).
+ * KYA-OS MCP extension negotiation (`org.kya-os/decentralized-authority`).
  *
  * The MCP binding surface of SPEC-MCP-EXTENSION.md: the extension id and
  * settings object (§1, §3), the declaration reader for both carriage forms

--- a/src/extension/settings.ts
+++ b/src/extension/settings.ts
@@ -2,7 +2,7 @@
  * KYA-OS MCP extension negotiation - identifiers and the settings object
  * (SPEC-MCP-EXTENSION.md §1, §3; wire schema: `schemas/mcp-extension-settings.json`).
  *
- * The extension is declared under `capabilities.extensions["org.kya-os/delegation"]`
+ * The extension is declared under `capabilities.extensions["org.kya-os/decentralized-authority"]`
  * as a small settings object. Per SEP-2133 an empty object means "supported, with
  * default configuration". Every identifier lives here as a single constant
  * (mirroring `KYA_OS_PROOF_META_KEY`), so a future re-pointing of the extension id
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { PROOF_PROFILE_ID } from '../card/schema.js';
 
 /** The proposed reverse-DNS MCP extension id (SPEC-MCP-EXTENSION.md §1.1). */
-export const KYA_OS_EXTENSION_ID = 'org.kya-os/delegation';
+export const KYA_OS_EXTENSION_ID = 'org.kya-os/decentralized-authority';
 
 /** The per-request `_meta` key carrying MCP `ClientCapabilities` (SEP-2575, stateless carriage). */
 export const MCP_CLIENT_CAPABILITIES_META_KEY = 'io.modelcontextprotocol/clientCapabilities';
@@ -110,7 +110,7 @@ export function buildExtensionSettings(
 }
 
 /**
- * Build the `extensions` map fragment - `{ "org.kya-os/delegation": settings }` -
+ * Build the `extensions` map fragment - `{ "org.kya-os/decentralized-authority": settings }` -
  * ready to merge into `ClientCapabilities.extensions` / `ServerCapabilities.extensions`
  * (or the per-request `_meta` carriage; SPEC-MCP-EXTENSION.md §3.1).
  */

--- a/src/extension/settings.ts
+++ b/src/extension/settings.ts
@@ -1,0 +1,122 @@
+/**
+ * KYA-OS MCP extension negotiation - identifiers and the settings object
+ * (SPEC-MCP-EXTENSION.md §1, §3; wire schema: `schemas/mcp-extension-settings.json`).
+ *
+ * The extension is declared under `capabilities.extensions["org.kya-os/delegation"]`
+ * as a small settings object. Per SEP-2133 an empty object means "supported, with
+ * default configuration". Every identifier lives here as a single constant
+ * (mirroring `KYA_OS_PROOF_META_KEY`), so a future re-pointing of the extension id
+ * (SEP-2133 graduation) is a constant change, never a call-site sweep.
+ */
+
+import { z } from 'zod';
+import { PROOF_PROFILE_ID } from '../card/schema.js';
+
+/** The proposed reverse-DNS MCP extension id (SPEC-MCP-EXTENSION.md §1.1). */
+export const KYA_OS_EXTENSION_ID = 'org.kya-os/delegation';
+
+/** The per-request `_meta` key carrying MCP `ClientCapabilities` (SEP-2575, stateless carriage). */
+export const MCP_CLIENT_CAPABILITIES_META_KEY = 'io.modelcontextprotocol/clientCapabilities';
+
+/** Core MCP `MissingRequiredClientCapabilityError` code (2026-07-28 error allocation policy). */
+export const MISSING_REQUIRED_CLIENT_CAPABILITY_CODE = -32021;
+
+/**
+ * The one reason code this extension defines itself (SPEC-MCP-EXTENSION.md §5.2):
+ * emitted only inside the `data` member of a core `-32021` error. Every other
+ * reason code is defined by SPEC-ENTITY-CARD Appendix D or SPEC.md Appendix A.
+ */
+export const EXTENSION_NOT_DECLARED_REASON = 'extension_not_declared';
+
+const SEMVER = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+const DID_METHOD = /^did:[a-z0-9]+$/;
+
+const unique = (values: readonly string[]): boolean => new Set(values).size === values.length;
+
+/**
+ * Zod mirror of `schemas/mcp-extension-settings.json`: every member OPTIONAL,
+ * unknown members tolerated (and stripped on parse) for forward compatibility.
+ * `required` is meaningful only on a server declaration and ignored client-side
+ * (SPEC-MCP-EXTENSION.md §3.2).
+ */
+export const ExtensionSettingsSchema = z.object({
+  version: z.string().regex(SEMVER, 'version must be a semver string').optional(),
+  proofProfiles: z
+    .array(z.string().min(1))
+    .min(1)
+    .refine(unique, 'proofProfiles must be unique')
+    .optional(),
+  didMethods: z
+    .array(z.string().regex(DID_METHOD, 'didMethods entries look like "did:web"'))
+    .min(1)
+    .refine(unique, 'didMethods must be unique')
+    .optional(),
+  required: z.boolean().optional(),
+});
+
+/** A declared (wire-shaped) settings object; all members optional, `{}` legal. */
+export type KyaOsExtensionSettings = z.infer<typeof ExtensionSettingsSchema>;
+
+/** Settings with every default applied (SPEC-MCP-EXTENSION.md §3.2 defaults column). */
+export interface ResolvedExtensionSettings {
+  version: string;
+  proofProfiles: string[];
+  didMethods: string[];
+  required: boolean;
+}
+
+/** The §3.2 defaults an empty declaration resolves to. */
+export const DEFAULT_EXTENSION_SETTINGS: ResolvedExtensionSettings = {
+  version: '1.0.0',
+  proofProfiles: [PROOF_PROFILE_ID],
+  didMethods: ['did:key', 'did:web'],
+  required: false,
+};
+
+/**
+ * Parse a PEER's settings value. A malformed value returns `undefined` - the
+ * declaration is treated as ABSENT (fail closed to non-declaration, never a
+ * guess at intent; SPEC-MCP-EXTENSION.md §3.2). `{}` parses successfully.
+ */
+export function parseExtensionSettings(value: unknown): KyaOsExtensionSettings | undefined {
+  const parsed = ExtensionSettingsSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Apply the §3.2 defaults to a declared settings object. */
+export function resolveExtensionSettings(
+  settings: KyaOsExtensionSettings = {},
+): ResolvedExtensionSettings {
+  return {
+    version: settings.version ?? DEFAULT_EXTENSION_SETTINGS.version,
+    proofProfiles: settings.proofProfiles ?? [...DEFAULT_EXTENSION_SETTINGS.proofProfiles],
+    didMethods: settings.didMethods ?? [...DEFAULT_EXTENSION_SETTINGS.didMethods],
+    required: settings.required ?? DEFAULT_EXTENSION_SETTINGS.required,
+  };
+}
+
+/**
+ * Validate OWN settings before putting them on the wire. Unlike a peer's input
+ * (parsed fail-closed), malformed own settings are a programmer error and throw.
+ */
+export function buildExtensionSettings(
+  settings: KyaOsExtensionSettings = {},
+): KyaOsExtensionSettings {
+  const parsed = ExtensionSettingsSchema.safeParse(settings);
+  if (!parsed.success) {
+    throw new Error(`invalid ${KYA_OS_EXTENSION_ID} settings: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+/**
+ * Build the `extensions` map fragment - `{ "org.kya-os/delegation": settings }` -
+ * ready to merge into `ClientCapabilities.extensions` / `ServerCapabilities.extensions`
+ * (or the per-request `_meta` carriage; SPEC-MCP-EXTENSION.md §3.1).
+ */
+export function buildExtensionsEntry(
+  settings: KyaOsExtensionSettings = {},
+  extensionId: string = KYA_OS_EXTENSION_ID,
+): Record<string, KyaOsExtensionSettings> {
+  return { [extensionId]: buildExtensionSettings(settings) };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,3 +370,31 @@ export {
   ED25519_SPKI_DER_HEADER_LENGTH,
   ED25519_KEY_SIZE,
 } from './utils/index.js';
+
+// MCP extension negotiation (org.kya-os/delegation - SPEC-MCP-EXTENSION.md)
+export {
+  KYA_OS_EXTENSION_ID,
+  MCP_CLIENT_CAPABILITIES_META_KEY,
+  MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
+  EXTENSION_NOT_DECLARED_REASON,
+  KYA_OS_DOMAIN_ERROR_CODE,
+  ExtensionSettingsSchema,
+  DEFAULT_EXTENSION_SETTINGS,
+  parseExtensionSettings,
+  resolveExtensionSettings,
+  buildExtensionSettings,
+  buildExtensionsEntry,
+  readExtensionDeclaration,
+  requireExtension,
+  missingRequiredCapabilityError,
+  proofGateToJsonRpcError,
+  type KyaOsExtensionSettings,
+  type ResolvedExtensionSettings,
+  type DeclarationCarriage,
+  type ExtensionDeclaration,
+  type ReadDeclarationInput,
+  type ExtensionGateResult,
+  type ExtensionGuard,
+  type JsonRpcErrorObject,
+  type ProofGateErrorLike,
+} from './extension/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,7 +371,7 @@ export {
   ED25519_KEY_SIZE,
 } from './utils/index.js';
 
-// MCP extension negotiation (org.kya-os/delegation - SPEC-MCP-EXTENSION.md)
+// MCP extension negotiation (org.kya-os/decentralized-authority - SPEC-MCP-EXTENSION.md)
 export {
   KYA_OS_EXTENSION_ID,
   MCP_CLIENT_CAPABILITIES_META_KEY,


### PR DESCRIPTION
Note: the extension id here is `org.kya-os/decentralized-authority`, the name the DIF TAAWG landed on in its 2026-07-28 session (Alan Karp's suggestion), superseding the `org.kya-os/delegation` working name this PR opened with. The rename commit flips the id across the spec documents, schema, module, and vectors in one pass; the editorial notes keep their proposed framing pending formal ratification.

Implements the negotiation surface of SPEC-MCP-EXTENSION.md (#141) in the package: a new opt-in `src/extension/` module plus a `negotiation` conformance category.

**The module** (all exported from the package root, nothing on the default path changes unless a host installs the gate):

- `KYA_OS_EXTENSION_ID` (`org.kya-os/decentralized-authority`) and the other identifiers as single constants, mirroring the `KYA_OS_PROOF_META_KEY` pattern so graduation re-pointing stays a constant change.
- `ExtensionSettingsSchema` / `parseExtensionSettings` / `buildExtensionSettings` / `buildExtensionsEntry`: a zod mirror of `schemas/mcp-extension-settings.json`. Peer input parses fail-closed (malformed = not declared, spec §3.2); own settings throw on error. `{}` is a legal declaration per SEP-2133.
- `readExtensionDeclaration`: normalizes both carriage forms - the per-request `_meta["io.modelcontextprotocol/clientCapabilities"].extensions` (2026-07-28) and the initialize-era `capabilities.extensions` (2025-11-25) - into one shape with a `carriage` tag.
- `requireExtension`: the admission guard, in the same idiom as `requireProof`. Optional servers admit undeclared peers as core traffic; `required: true` rejects with core `-32021` carrying `error.data { reason: "extension_not_declared", extension }` (spec §4.2).
- `proofGateToJsonRpcError`: maps proof-gate failures onto the JSON-RPC surface with the snake_case code verbatim in `error.data.reason`, an implementation-defined numeric code, and a hard refusal of anything in the MCP-reserved `-32020..-32099` range (spec §5).

**Decisions worth a look in review:**

1. **Stateless entry wins, and a malformed one is final.** When the per-request carriage contains an entry for our id but it is malformed, the declaration is treated as absent and the initialize-era entry is NOT consulted as a fallback - the per-request carriage supersedes initialize-era state, and falling back would partially honor a corrupted declaration.
2. **Presence via `hasOwnProperty`**, so an explicit `{ "org.kya-os/decentralized-authority": {} }` is distinguishable from no declaration.
3. **No middleware rewiring.** The gate is a standalone guard the host installs, exactly like the card proof gate; wiring it into `withKyaOs` defaults would have been a default-path behavior change this PR deliberately avoids.

**Vectors:** seven `negotiation` vectors covering declared/absent against optional and required servers, malformed-treated-as-absent on both modes, the initialize-era carriage, and the SEP-2133 empty-object declaration. The loader, runner, adapter contract, and the required-categories test learn the category; the Python cross-language verifier is untouched (its scope is card-proof, and the category is additive).

Validation: `typecheck` + `conformance:typecheck` + `lint` clean, 1923 tests passing, conformance runner 43/43.
