### PR TITLE
submission: Decentralized Authority extension spec + SEP draft (for WG review)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -419,11 +419,13 @@ so it is reproducible against any implementation without re-signing.
 | `vectors/card-proof.json` | `org.kya-os/proof.v1` holder-of-key proof | valid signed proof, in-window, audience-bound | tampered body, tampered signature, wrong audience, expired, kid⇄did forgery |
 | `vectors/entity-card.json` | Entity Card `parseCard` + `verifyCard` | golden card per `entityType`, accountable agent | malformed (unknown field), broken accountability JOIN |
 | `vectors/audit-integrity.json` | Audit JCS + domain-separated hashing + RFC 9162 | fixed Unicode event, leaf/root, inclusion and consistency paths | mutated event/proof relationships are exercised by the audit unit suites |
+| `vectors/negotiation.json` | MCP extension admission gate (`org.kya-os/decentralized-authority`) | declared and malformed-degrades-to-core (optional server); empty-object and initialize-era declarations, `server/discover` exemption (required server) | absent against a required server (`-32021`), present-but-malformed against a required server (`-32602`, malformed_declaration) |
 
 The first five categories exercise the **legacy** session-bound primitives; the
 next two exercise the **Entity Card** layer (see the dedicated section below),
-and `audit-integrity` provides language-neutral bytes and hashes for the audit
-protocol.
+`audit-integrity` provides language-neutral bytes and hashes for the audit
+protocol, and `negotiation` exercises the MCP extension admission gate
+(`org.kya-os/decentralized-authority`, SPEC-MCP-EXTENSION.md §3-§5).
 
 A `fail` vector passes the suite only when the implementation correctly **rejects**
 it. The runner exits non-zero on any mismatch.

--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -8,12 +8,14 @@ Editors: KYA-OS Working Group
 Repository: https://github.com/decentralized-identity/kya-os-mcp
 Binds: the KYA-OS Protocol Specification ([SPEC.md](./SPEC.md)) and the Entity Card profile ([SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md)) to the Model Context Protocol Extensions framework (SEP-2133)
 
+> **Condensed edition.** A venue-shaped condensation of this binding is maintained at [submission/decentralized-authority.md](./submission/decentralized-authority.md) for MCP Extensions Track review. This document is authoritative on any conflict until an MCP extension repository adopts the binding, and changes to either document are mirrored in the same change set.
+
 ---
 
 ## Abstract
 
 This document specifies how the KYA-OS protocol operates as an optional, strictly additive extension to the Model Context Protocol, using the Extensions framework introduced in the MCP `2026-07-28` specification (SEP-2133).
-The extension is identified as `org.kya-os/decentralized-authority` and is negotiated through the standard `extensions` member of `ClientCapabilities` and `ServerCapabilities`.
+The extension is identified as `org.kya-os/decentralized-authority` and is declared through the standard `extensions` member of `ClientCapabilities` and `ServerCapabilities`.
 It adds no tools, no JSON-RPC methods, no handshake, and no session semantics.
 Its entire wire surface is: one capability entry, the reverse-DNS `_meta` keys already registered by the underlying specifications, the `KYA-OS-*` outbound HTTP headers, and the Entity Card discovery projections.
 Everything normative about identity, delegation, proofs, and verification is defined in [SPEC.md](./SPEC.md) and [SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md); this document defines only the MCP binding and is intentionally thin.
@@ -43,7 +45,7 @@ The identifier was settled in DIF TAAWG discussion (2026-07-28).
 
 ### 1.2 Versioning
 
-The extension version is carried in the negotiation settings object (§3.2) and versions independently of both the MCP specification and the underlying KYA-OS protocol version.
+The extension version is carried in the settings object (§3.2) and versions independently of both the MCP specification and the underlying KYA-OS protocol version.
 Per SEP-2133, a breaking change to this extension requires a **new extension identifier**; the `1.x` line of this document is therefore strictly additive.
 
 ### 1.3 Graduation
@@ -60,7 +62,7 @@ Re-keying of the `_meta` registry entries (§2.2) would be specified by a succes
 
 | Surface | Mechanism | Defined in |
 |---|---|---|
-| Capability negotiation | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3 (this document) |
+| Capability declaration | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3 (this document) |
 | Request proof | `_meta["org.kya-os/request-proof"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
 | Response proof / audit | `_meta["org.kya-os/response-proof"]` detached response proof | SPEC.md §7 |
 | Consent step-up | signed `needs_authorization` challenge | SPEC.md §9 |
@@ -69,7 +71,7 @@ Re-keying of the `_meta` registry entries (§2.2) would be specified by a succes
 | Discovery | Entity Card + projections; `/.well-known/mcp`; `server/discover` | SPEC-ENTITY-CARD §5-§6; SPEC.md §10; §3.4 (this document) |
 
 The extension defines **no tools** and **no new JSON-RPC methods**.
-The `_kyaos_handshake` tool and the KYA-OS session lifecycle (SPEC.md §5, §14) are **not part of this extension**; they are the legacy 1.x session profile, retained as an optional application-layer convenience outside the negotiated surface (see §11 and SPEC-ENTITY-CARD §15.5, Appendix D.4).
+The `_kyaos_handshake` tool and the KYA-OS session lifecycle (SPEC.md §5, §14) are **not part of this extension**; they are the legacy 1.x session profile, retained as an optional application-layer convenience outside the declared surface (see §11 and SPEC-ENTITY-CARD §15.5, Appendix D.4).
 
 ### 2.2 `_meta` keys
 
@@ -109,7 +111,10 @@ sequenceDiagram
 
 ---
 
-## 3. Capability Negotiation
+## 3. Capability Declaration and Selection
+
+Because the stateless MCP `2026-07-28` core has no `initialize` handshake round trip, this surface negotiates no session-wide agreement: the server **advertises** the proof profiles and DID methods it supports, the client **selects** from that set and **declares** its selection on every request, and the server **enforces** its own configured minimum on every request.
+The selection is a hint that identifies the client's active configuration; the enforcement is the security boundary.
 
 ### 3.1 Where the declaration travels
 
@@ -175,6 +180,7 @@ All members are OPTIONAL; per SEP-2133, an **empty object** (`{}`) means "suppor
 
 Unknown members MUST be ignored (forward compatibility).
 A peer that receives a settings object it cannot parse - a declaration that is present but malformed, as distinct from one that is absent - MUST NOT treat it as a valid declaration, and MUST NOT guess at intent. The declaration is an untrusted, intermediary-mutable, proof-excluded `_meta` member, so its handling is mode-dependent. In **optional mode** a malformed declaration degrades to non-declaration exactly like an absent one (core MCP behavior, §4); a corrupting intermediary therefore cannot turn an otherwise-valid request into a rejection when a mere strip would let it through. In **required mode**, where a non-declaring request is rejected regardless, the server MUST reject the request with JSON-RPC `-32602` (Invalid params) carrying `reason: "malformed_declaration"`, distinguishing a garbled declaration from a genuinely absent one (`-32021`, §4).
+An absent or stripped declaration is a distinct case: it is handled as a non-declaration, failing closed per the graceful-degradation contract (§4).
 
 ### 3.3 Meaning of a declaration
 
@@ -183,9 +189,15 @@ A declaring client SHOULD attach a proof to every request it wants authorized un
 
 A **server** declaration asserts: the server verifies proofs under the listed profiles per the fail-closed algorithm of SPEC-ENTITY-CARD §11, and (when `required` is `true`) enforces declaration as a precondition (§4).
 
+A client's declaration identifies the client's active configuration; it never sets the server's verification bar.
+A server MUST NOT weaken its verification requirements on the basis of a client's declaration.
+The declared `proofProfiles` and `didMethods` may only select among the profiles and methods the server already accepts; they can never move the server below its configured floor.
+Because the load-bearing artifact is the signed proof and not the declaration (§10 item 1), a declaration naming a weaker profile than the proof actually carries cannot make a server accept a proof it would otherwise reject: either the proof verifies under a profile the server accepts, or it fails closed.
+
 ### 3.4 Discovery before first call
 
 A client MAY call `server/discover` before any other request to learn whether a server speaks, and whether it requires, `org.kya-os/decentralized-authority`, and attach proofs from the first real request onward.
+Having learned the server's advertised `proofProfiles` and `didMethods`, a client SHOULD select from the intersection of its own and the server's advertised sets and declare that selection on each subsequent request.
 The `/.well-known/mcp` document (SPEC.md §10) and the Entity Card projections (SPEC-ENTITY-CARD §6) advertise the same facts out of band; `server/discover` is the in-protocol source of truth under `2026-07-28`.
 
 ---
@@ -236,6 +248,8 @@ The safety property is therefore fail-closed handling of absence, never silent a
 - optional mode degrades a missing or stripped declaration to core behavior (§4.1);
 - a missing or stripped **proof** on a gated call is rejected by the proof gate (`proof_missing`, §5.2), regardless of what the declaration said;
 - a stripped proof `cnf` in the presence of a token `cnf` fails closed (`cnf_required_by_token`, SPEC-ENTITY-CARD §8.6, §12.7).
+
+A declaration that is present but malformed is handled per §3.2: in optional mode it degrades to absence exactly like a stripped one, and in required mode it is rejected with `-32602` (`malformed_declaration`) rather than the `-32021` an absent declaration gets.
 
 Nothing security-relevant may ever be trusted from `_meta` without verifying the signed artifact it carries.
 
@@ -293,6 +307,7 @@ The MCP-specific deltas are only these:
 1. **Placement.** The proof object rides `_meta["org.kya-os/request-proof"]` inside `params` of the JSON-RPC request - the role-named carrier of the `org.kya-os/proof.v1` profile (SPEC-ENTITY-CARD §8.1; the legacy key and `prf` value `org.kya-os/proof@1` are accepted for one major version).
 2. **Request binding.** `requestHash` covers `{ method, params }` with `params._meta` removed (SPEC-ENTITY-CARD §8.3).
    Consequently an intermediary MAY add or rewrite `_meta` members (for example the required `io.modelcontextprotocol/*` keys) without invalidating the proof, and MUST NOT mutate `method` or any other part of `params` on a proof-bearing request, because any such mutation invalidates `requestHash`.
+   Because `_meta` is both intermediary-mutable and outside proof coverage, its contents are untrusted: a verifier derives no security decision from any `_meta` member except by verifying the signed proof that member carries.
 3. **Transport agnosticism.** The proof is in-band JSON-RPC and verifies identically over stdio and Streamable HTTP; the OPTIONAL RFC 9421 sibling (SPEC-ENTITY-CARD §8.5) serves HTTP-edge intermediaries.
 4. **Relationship to DPoP.** SPEC-ENTITY-CARD §8.8 governs; the two compose and are not alternatives.
 
@@ -310,9 +325,11 @@ A future MRTR profile (§7.3) would have to extend `responseHash` coverage to `r
 Authority is conveyed only by a verifiable delegation chain: the W3C VC model of SPEC.md §6, including the VC 2.0 + ZCAP-LD profile of SPEC.md §6.10, with the designation invariant (SPEC.md §6.4.1), revocation (SPEC.md §6.5-§6.6, SPEC-ENTITY-CARD §10.3), and the recomputed accountability joins (SPEC-ENTITY-CARD §10.2).
 A proof references its authority via `delegationRef`; declaring the extension conveys no authority by itself.
 
+Revocation status lists SHOULD be published per issuing authority - each delegation's status served from the issuer's own domain - rather than through a single centralized registry, preserving the no-central-authority property (§13.2).
+
 ### 7.2 Consent step-up
 
-The step-up flow is SPEC.md §9: a call lacking sufficient delegation returns a `needs_authorization` challenge whose content, including `authorizationUrl`, is bound by a signed response proof (`outcome: "needs_authorization"`, SPEC.md §7.4, §9.2).
+The step-up flow is SPEC.md §9: a call lacking sufficient permission returns a `needs_authorization` challenge whose content, including `authorizationUrl`, is bound by a signed response proof (`outcome: "needs_authorization"`, SPEC.md §7.4, §9.2).
 A client MUST verify the challenge proof and recompute `responseHash` over the received challenge before directing a user to `authorizationUrl` (SPEC.md §9.3), and MUST apply the RFC 9207 issuer validation of SPEC.md §9.4 on the authorization callback.
 This document binds the challenge carriage: a server delivers the SPEC.md §9.2 challenge object as the body of a `resultType: "complete"` result, so the proof's `responseHash` covers the challenge content (SPEC.md §7.3, §7.4) while the result's `resultType` member itself remains outside proof coverage (§6).
 
@@ -321,7 +338,7 @@ This document binds the challenge carriage: a server delivers the SPEC.md §9.2 
 MCP `2026-07-28` introduces the Multi Round-Trip Request pattern (SEP-2322): a server returns `resultType: "input_required"` with `inputRequests`, and the client retries the original request carrying `inputResponses`.
 The KYA-OS step-up flow is structurally the same shape: challenge out, user action, retry with `resumeToken` and a fresh delegation (SPEC.md §9.3).
 This revision carries the challenge as the body of a `resultType: "complete"` result (§7.2, this document's own binding decision; SPEC.md §9.2 defines the challenge object without a carriage statement) and does not profile it onto `input_required`, because the underlying specification defines the retry as a new request rather than an MRTR continuation.
-A future revision MAY define an MRTR profile of the consent flow; such a profile would be additive and negotiated through the settings object.
+A future revision MAY define an MRTR profile of the consent flow; such a profile would be additive and declared through the settings object.
 
 ---
 
@@ -363,6 +380,7 @@ Extension-specific considerations:
 4. **Replay containment scope.** Proof construction is stateless; verification is not (SPEC-ENTITY-CARD §8).
    Accept-once nonce enforcement is per nonce-store visibility scope: a verifier without a nonce seam MUST fail closed (`nonce_seam_missing`, SPEC-ENTITY-CARD §11.2 step 8), and multi-replica deployments MUST use an atomic, shared or replica-sticky nonce store (SPEC-ENTITY-CARD §12.2) if duplicate execution of a byte-identical request inside the 60-second window is unacceptable.
    The same bound applies to any stateless-verification scheme, including DPoP server-side `jti` tracking (RFC 9449).
+   Because every proof carries a freshness window of at most 60 seconds, observed nonces need be retained only for that window plus the verifier's maximum tolerated clock skew: a proof replayed after the window fails the freshness check independently of the nonce store, so nonce retention is bounded by the proof window, not by the delegation lifetime.
 5. **Verification cost and revocation freshness.** Warm-path verification is local CPU only (signature checks plus JCS hashing); cold paths add DID document and status-list fetches through SafeFetch.
    Revocation staleness is bounded by status-cache TTL, with short TTLs (60 seconds or less) recommended for high-privilege scopes (SPEC.md §6.5.2, §11.10); this is the same trade OAuth makes through token lifetime, relocated to a cache knob.
 
@@ -376,6 +394,8 @@ Extension-specific considerations:
 1. **Correlation.** A stable agent DID plus per-request signed proofs makes an agent's activity linkable across every server it touches, and non-repudiable indefinitely.
    That is the explicit goal of enterprise audit deployments and a real cost elsewhere.
    Implementations SHOULD support pairwise (per-audience) agent DIDs (SPEC.md §12.1, SPEC-ENTITY-CARD §13), and this extension does NOT require a globally stable DID for conformance.
+   Delegate keys SHOULD be one-off and short-lived (SPEC.md §6.9): a fresh key per delegation bounds replay and key-compromise exposure and reinforces pairwise-DID unlinkability.
+   Where an operator must revoke every delegation a principal holds in a single action (for example, offboarding a departing employee), it MAY instead bind that principal's delegations to one revocable key and revoke that key, accepting the reduced unlinkability a shared key implies.
 2. **Chain disclosure.** Delegation credentials identify delegating principals to every chain verifier.
    Issuers SHOULD prefer opaque, organization-resolvable subject identifiers over human-readable ones, and deployments SHOULD present chains pruned to the minimum depth that preserves the authority argument (see also per-delegation keys, SPEC.md §12.5).
 3. **Cards are claim-minimal.** Discovery projections carry no principal PII (SPEC-ENTITY-CARD §4.2, §13); optional fields are omitted, not nulled.
@@ -432,7 +452,7 @@ The deprecation of core Logging, alongside standardized trace-context `_meta`, m
 
 - [SPEC.md](./SPEC.md), the KYA-OS Protocol Specification, v1.0.0.
 - [SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md), the KYA-OS Entity Card profile, v1.1.
-- [`schemas/mcp-extension-settings.json`](./schemas/mcp-extension-settings.json), the negotiation settings schema.
+- [`schemas/mcp-extension-settings.json`](./schemas/mcp-extension-settings.json), the extension settings schema.
 - Model Context Protocol, specification revision `2026-07-28` (Release Candidate; verified against the `draft` revision, 2026-07-28). https://modelcontextprotocol.io/specification/draft, expected to publish as https://modelcontextprotocol.io/specification/2026-07-28
 - SEP-2133, *Extensions framework for MCP*. https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2133
 - **[RFC2119]** / **[RFC8174]** BCP 14 conformance keywords.

--- a/submission/0000-decentralized-authority.md
+++ b/submission/0000-decentralized-authority.md
@@ -1,0 +1,116 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# SEP-0000: Decentralized Authority Extension
+
+| | |
+|---|---|
+| **Title** | Decentralized Authority: agent identity, delegated authority, and per-request proof-of-possession as an MCP extension |
+| **Author** | Dylan Hobbs (@h0bb5) |
+| **Sponsor** | None (seeking sponsor) |
+| **Status** | proposal |
+| **Type** | Extensions Track |
+| **Extension id** | `org.kya-os/decentralized-authority` (see Rationale for the identifier-and-governance path on acceptance) |
+| **Created** | 2026-07-28 |
+| **PR** | 0000 (placeholder; file renamed to the PR number on filing) |
+| **Associated group** | To be secured before filing: an MCP-side interest group (candidate paths: the authorization-extensions orbit, or a new agent-identity IG formed per the SEP guidelines). External standards home: DIF Trusted AI Agents Working Group (TAAWG) |
+| **Extension maintainers** | Dylan Hobbs (@h0bb5); at least one additional maintainer from outside the KYA-OS project, to be named with the associated group |
+| **Filing gates** | This draft does not file until three gates close: the official-SDK reference module (design complete, fork branch pending), the associated group, and a sponsor |
+
+## Abstract
+
+MCP's `2026-07-28` authorization stack answers which *user* authorized which *client* (core OAuth) and how an *enterprise* governs a session (the Enterprise-Managed Authorization extension).
+No layer answers which *agent* is acting, under what verifiable delegated authority, with proof a third party can check later.
+This SEP proposes an Extensions Track extension, `org.kya-os/decentralized-authority`, that adds exactly that layer: agent identity as a W3C DID, authority as a Verifiable Credential delegation chain with per-hop attenuation and revocation, and a self-contained per-request holder-of-key proof carried in `_meta`.
+Every artifact verifies locally from signatures, with no round trip to a central authorization service; the default DID methods are `did:key` and `did:web`, and no distributed ledger is required or referenced.
+The extension is strictly additive: no tools, no new methods, no sessions, no use of the `Authorization` header.
+It is negotiated through the standard `extensions` capability map, degrades gracefully for unaware peers, and rejects undeclared clients in required mode using core `-32021`.
+The wire binding is one short document; the underlying protocol is specified externally as a DIF TAAWG work item, with the implementation evidence described in Reference Implementation.
+
+## Motivation
+
+Three demand signals, all inside this venue:
+
+1. `ext-auth` [issue #13](https://github.com/modelcontextprotocol/ext-auth/issues/13) asks how a downstream API can distinguish a request executed directly by a human from one executed by an autonomous agent acting on the user's behalf, today indistinguishable because the agent fully impersonates the user.
+2. In [Discussion #804](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/804), a gateway-based authorization proposal, a commenter proposes the composing alternative: agents carrying signed delegation chains that any server verifies locally, with the gateway issuing delegation proofs rather than terminating trust.
+   This extension specifies that alternative and composes with the gateway pattern rather than replacing it.
+3. The [project roadmap's](https://modelcontextprotocol.io/development/roadmap) Enterprise Readiness priority calls for "end-to-end visibility into what a client requested and what a server did" and proposals for "gateway and proxy patterns", noting "much of the output will likely land as extensions".
+   The non-repudiable per-request proof artifact is a direct mechanism for that audit-trail deliverable, and the outbound header registry is a direct mechanism for authorization propagation through gateways.
+
+The operator need behind these signals: organizations deploying fleets of agents need delegated authority that is attributable (which agent, on whose authority), auditable after the fact by parties who were not present, and revocable without redeploying the fleet, across organizational boundaries where no shared authorization server exists.
+The need is sharpest in regulated sectors such as healthcare, government, and financial services, where operators must evidence who authorized an action and what was done long after the session that did it has ended.
+Non-repudiable per-request proofs and self-contained delegation chains are mechanisms for exactly those obligations, proposed here as an optional extension rather than as operator-specific infrastructure.
+
+The `2026-07-28` revision hardened user-level OAuth, and `ext-auth` covers enterprise session governance and workload client credentials.
+None of these establish agent-level identity, delegation semantics beyond token passing, or per-request proof a third party can re-verify after the fact.
+This extension specifies that layer and composes with the existing ones: CIMD is its on-ramp, sender-constrained tokens fuse with its proofs via `cnf.jkt`, and EMA remains the enterprise session layer beside it.
+
+## Specification
+
+The complete wire binding is the accompanying extension specification ([`decentralized-authority.md`](./decentralized-authority.md), Apache-2.0), which defers normatively to the externally governed KYA-OS Protocol Specification and Entity Card profile.
+Summary of the entire surface:
+
+- **Negotiation**: a settings object (`version`, `proofProfiles`, `didMethods`, `required`) under `capabilities.extensions["org.kya-os/decentralized-authority"]`, carried per-request in `_meta["io.modelcontextprotocol/clientCapabilities"]` and in `server/discover` results; `{}` means supported with defaults.
+- **Required mode**: servers with `required: true` reject undeclared clients with core `-32021`, carrying the core schema's `requiredCapabilities` member plus `error.data.reason: "extension_not_declared"`; optional servers degrade to core behavior, and `server/discover` is never gated so discovery stays reachable.
+- **Request proof**: a self-contained holder-of-key proof under `_meta["org.kya-os/request-proof"]` (the role-named carrier of the `org.kya-os/proof.v1` profile), hash-bound to the request with `params._meta` excluded, audience-bound, nonce-fresh, 60-second lifetime, verified fail-closed.
+- **Authority**: W3C VC delegation chains with subset-only attenuation, continuity, depth caps, and status-list revocation; referenced from proofs, never asserted.
+- **Consent**: a signed challenge result whose proof binds the authorization URL against substitution.
+- **Gateway propagation**: the `KYA-OS-*` outbound header registry with authoritative-versus-advisory trust tiers, plus body-free routing on the core `Mcp-Method`/`Mcp-Name` headers.
+- **Errors**: no new numeric codes anywhere; snake_case reason codes ride `error.data.reason`.
+
+## Rationale
+
+**Why DID/VC rails rather than composing DPoP, Workload Identity Federation, and RFC 8693 token exchange.**
+Comparison, including rows where the OAuth stack is stronger:
+
+| Capability | DPoP + WIF + RFC 8693 | This extension |
+|---|---|---|
+| Per-request proof-of-possession | Yes, HTTP-bound (`htm`/`htu`) | Yes, bound to the JSON-RPC operation; composes with DPoP via `cnf.jkt` |
+| Transport coverage | HTTP-only; undefined over stdio | Identical over stdio and Streamable HTTP (MCP is dual-transport) |
+| Enterprise IdP maturity | Stronger | Conceded; a cost this proposal accepts |
+| Verification without an AS round trip | No; validity and exchange are AS-mediated | Yes; local, from public keys |
+| Cross-domain portability | Pairwise federation configuration per domain pair | The chain carries its own authority |
+| Delegation with per-hop narrowing | Standardized nesting (RFC 8693 `act`); attenuation is AS policy, not verifier-checkable | Subset-only attenuation enforced by any verifier |
+| Post-hoc third-party verifiability | Signed tokens verify while AS key history is retained; no self-contained grant chain | Chain and proof verify from the artifacts alone |
+| Revocation staleness | Token lifetime | Status-cache TTL; a knob, not a solution, for both |
+| Library ubiquity | Stronger | Conceded |
+
+SEP-1932 (DPoP) and SEP-1933 (Workload Identity Federation) are in flight in this venue and address the token and workload layers; this extension composes with both via the `cnf.jkt` sender-constraint (Entity Card §8.6, §8.8) and never competes for the `Authorization` header.
+Local verification and portable chains are the decentralization property the identifier names.
+
+**Design inputs.**
+The delegation model applies object-capability discipline rather than novel invention: authority flows only by explicit grant, every hop may only attenuate (subset-only actions, monotone caveats, narrowing validity; KYA-OS Spec §6.10), and an invocation must designate the specific resource it exercises (§6.4.1), the classic remedy to the confused deputy.
+The credential shape profiles W3C ZCAP-LD capabilities carried as Verifiable Credentials, with revocation-as-delegable-permission recorded as future work in the governing specification (§6.5.1), a pattern familiar from UCAN.
+The alternative authorization models in the table above were design inputs rather than foils: the `cnf.jkt` fusion exists precisely because RFC 9449's sender-constraint semantics were worth adopting wherever an authorization server supplies them.
+
+**Identifier and governance on acceptance.**
+As drafted, this is a vendor-prefixed extension whose normative core is externally governed, which SEP-2133 does not yet define a track for.
+The proposed resolution, stated head-on: the intended entry path is `experimental-ext-` incubation with the associated interest group; on graduation through this SEP, the MCP binding document transfers to extension-repository governance under an `io.modelcontextprotocol` identifier, with MCP core maintainers holding ultimate authority over the binding, while the underlying KYA-OS specifications remain externally governed, the way EMA's profiled token machinery remains at the IETF.
+The `org.kya-os/*` namespace then survives as the `_meta` key namespace of the underlying proof profile; core expects official extensions to define keys under `io.modelcontextprotocol/`, so whether those keys also re-point on graduation is an adoption-time decision the configurable `proofMetaKey` (KYA-OS Spec §7.6) leaves open.
+One distinction is owed precision: the underlying specifications are DIF TAAWG work items under ratification review, not yet ratified standards; the SEP's claims rest on the published documents and shipped implementations, not on that pending status.
+Stewardship is active rather than nominal: the TAAWG task force meets weekly, working-group review has already changed the specification (the proof-key separation and the exact request-hash canonicalization were external review findings, resolved in the 1.11.0 release), and the conformance suite gates every change in CI.
+The identifier was settled in DIF TAAWG discussion (2026-07-28); it was chosen because "authority" covers identity, delegation, proof, and audit together, where "delegation" alone did not.
+
+## Backward Compatibility
+
+Strictly additive.
+Unaware peers get core MCP end to end; discovery projections degrade to fetches, never failures; `2025-11-25` peers carry the declaration as an additive initialize-era member.
+No core behavior, method, or schema changes.
+
+## Reference Implementation
+
+- **[`@kya-os/mcp`](https://www.npmjs.com/package/@kya-os/mcp) (TypeScript, npm)**: proof generation and fail-closed verification, delegation-chain evaluation, and discovery emitters (published 1.11.0); the negotiation module and `-32021` admission guard are on the repository's `main` branch, shipping in the next release.
+- **[`kya-os-verify`](https://pypi.org/project/kya-os-verify/) 0.2.0 (Python, PyPI, beta)**: an independent, stdlib-only verify-side implementation, re-verifying the TypeScript-minted vectors in CI (cross-language JCS and Ed25519 parity, one-directional today).
+- **[Conformance vectors](https://github.com/decentralized-identity/kya-os-mcp/tree/main/conformance/vectors)**: a 44-vector machine-readable suite, including 8 negotiation vectors covering declared, absent, malformed, empty-object, initialize-era, and discovery-exemption cases against optional and required servers, with the [stdlib Python verifier](https://github.com/decentralized-identity/kya-os-mcp/blob/main/conformance/verify.py) as the second implementation for the proof and audit vector categories.
+- **Live deployment**: [poc.kya-os.ai](https://poc.kya-os.ai) (guided walkthrough) against [demo-mcp.kya-os.ai](https://demo-mcp.kya-os.ai/provenance), demonstrating the underlying protocol stack: DID-anchored identity, per-request proofs, live revocation, and tamper and replay rejection against the shipped verifier.
+- **Official SDK (the Extensions Track review gate)**: an opt-in, disabled-by-default module for the TypeScript SDK v2 line, designed against the v2.0.0 release at a pinned commit.
+  Every seam the module needs is a public v2 API (capability registration on both roles, `server/discover` passthrough, transport decoration for the admission gate, per-request `_meta` access, and `-32021` with a preserved `data` payload), so the module requires **zero SDK core changes**.
+  The accompanying design note ([`sdk-v2-module-design.md`](./sdk-v2-module-design.md)) specifies the API, gate placement, carriage normalization, and a 7-10 person-day estimate.
+  The fork-branch prototype is a filing gate: per SEP-2133 this SEP is pre-review until it exists, and it is sequenced before filing, not after.
+
+A conformance scenario and the SEP-2484 traceability file will be prepared from the existing vector suite during review.
+
+## Security Implications
+
+The extension's security analysis lives in the governing specifications and is summarized in the extension document's Security Considerations.
+The SEP-relevant points: capability declarations are unauthenticated `_meta` and are handled fail-closed (stripped equals absent, never accepted as authenticated); replay prevention is honestly scoped (stateless proof construction, stateful verification, with the same multi-replica bound DPoP's `jti` tracking carries); discovery fetches are mandatorily SSRF-hardened; and privacy is addressed with pairwise-DID support and a claim-minimal card, with no globally stable identifier required for conformance.
+The threat model is enumerated rather than asserted: the governing specifications carry per-threat tables with mitigations and named residual risks (KYA-OS Spec §11.1; Entity Card §12.10), the conformance suite's negative vectors are those attacks in executable form (tampered bodies and signatures, wrong audiences, expired windows, kid-to-did forgeries, absent replay seams, malformed and stripped declarations), and the public walkthrough demonstrates tamper, replay, stolen-key, and live-revocation handling against the shipped verifier.

--- a/submission/decentralized-authority.md
+++ b/submission/decentralized-authority.md
@@ -1,0 +1,231 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Decentralized Authority
+
+**An MCP extension for decentralized agent identity, delegated authority, and per-request proof-of-possession.**
+
+| | |
+|---|---|
+| **Extension id** | `org.kya-os/decentralized-authority` |
+| **Version** | 1.0.0-draft |
+| **Status** | Draft, prepared for MCP Extensions Track review |
+| **License** | Apache-2.0 (this document, per the SPDX grant above; the host repository is otherwise MIT) |
+| **Governing specifications** | [KYA-OS Protocol Specification](https://github.com/decentralized-identity/kya-os-mcp/blob/main/SPEC.md) and [Entity Card profile](https://github.com/decentralized-identity/kya-os-mcp/blob/main/SPEC-ENTITY-CARD.md), developed by the KYA-OS project, donated to and maintained as work items of the DIF Trusted AI Agents Working Group (TAAWG) |
+| **Reference implementations** | [`@kya-os/mcp`](https://www.npmjs.com/package/@kya-os/mcp) (TypeScript; 1.11.0 on npm, negotiation module on repository `main` pending the next release), [`kya-os-verify` 0.2.0, beta](https://pypi.org/project/kya-os-verify/) (Python, verify-side, cross-language parity) |
+
+## Abstract
+
+This extension lets an MCP server verify, on every request, which agent is calling, whether the authority it is exercising authorizes the request, and that the live caller currently controls the key bound to that identity.
+Identity is a W3C DID, authority is a W3C Verifiable Credential delegation chain with per-hop attenuation, and possession is a self-contained per-request proof carried in `_meta`.
+Everything verifies locally from signed artifacts: no round trip to a central authorization service is required, which is a property associated with the name.
+The default DID methods are `did:key` (raw public keys) and `did:web` (TLS and DNS); no distributed ledger is required or referenced by this extension.
+The extension adds no tools, no JSON-RPC methods, and no sessions; its wire surface is one capability entry, reverse-DNS `_meta` keys, the `KYA-OS-*` outbound HTTP headers for gateway propagation, and discovery documents.
+It composes with, and never replaces, MCP's OAuth-based authorization: it does not read or write the `Authorization` header.
+
+## Conformance Keywords
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals.
+
+## 1. Dependencies
+
+This document is a thin MCP binding.
+The identity model, delegation semantics, proof profile, verification algorithm, and their security analysis are defined normatively by the governing specifications listed above, referenced here by section.
+Implementers need those two documents; this one defines only what is MCP-specific.
+
+This document is the venue-shaped condensation of [SPEC-MCP-EXTENSION.md](../SPEC-MCP-EXTENSION.md), the full MCP binding maintained in the same repository.
+Until an MCP extension repository adopts this binding, SPEC-MCP-EXTENSION.md is authoritative on any conflict between the two; after adoption, the adopted text governs.
+Changes to either document are mirrored in the same change set.
+
+## 2. What the Extension Adds
+
+| Surface | Mechanism | Defined in |
+|---|---|---|
+| Capability declaration | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3, §4 |
+| Request proof | `_meta["org.kya-os/request-proof"]` per-request holder-of-key proof | Entity Card §8 |
+| Response proof | `_meta["org.kya-os/response-proof"]` detached response proof, including signed consent challenges | KYA-OS Spec §7, §9 |
+| Delegated authority | W3C VC delegation chains, referenced from proofs via `delegationRef` | KYA-OS Spec §6 |
+| Gateway propagation | `KYA-OS-*` outbound HTTP headers; body-free routing | KYA-OS Spec §8 |
+| Discovery | Entity Card and projections; `server/discover` | Entity Card §5-§6; §4, §9 |
+
+The extension defines **no tools and no new JSON-RPC methods**.
+Both proof keys are role-named; versions live inside the objects, never in keys (the request proof's format version rides its `prf` field). The response-proof object is shared with the KYA-OS 1.x profile, distinguished by its own fields (KYA-OS Spec §7.5-§7.6); prior keys stay read-accepted for one major version.
+The KYA-OS session machinery and `_kyaos_handshake` tool (KYA-OS Spec §5, §14), the legacy session-bound proof (Entity Card §15.5, Appendix D.4), and the legacy top-level `proof` result member are outside this extension.
+
+The full request cycle, including the consent step-up that issues a delegation credential:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (MCP client)
+    participant S as MCP Server (verifier)
+    participant AS as Authorization Service
+
+    Note over A: holds DID key + delegation credential
+    A->>S: request + _meta: capability declaration<br/>+ org.kya-os/request-proof (profile proof.v1)
+    Note over S: declared? (required mode: -32021 if not)<br/>verify fail-closed: kid⇄did, audience,<br/>requestHash, window, nonce, signature<br/>designated scope ∈ delegation
+    alt request authorized
+        S-->>A: result + org.kya-os/response-proof (signed receipt)
+    else insufficient permission
+        S-->>A: signed needs_authorization challenge<br/>(responseHash binds authorizationUrl)
+        A->>AS: user grants at authorizationUrl
+        AS-->>A: issues delegation credential
+        A->>S: retry with resumeToken + credential
+        S-->>A: result + org.kya-os/response-proof
+    end
+```
+
+## 3. Settings Object
+
+The settings object is declared under the extension id in the `extensions` capability map.
+Its schema is published at [`schemas/mcp-extension-settings.json`](https://github.com/decentralized-identity/kya-os-mcp/blob/main/schemas/mcp-extension-settings.json) (JSON Schema 2020-12).
+All members are OPTIONAL; an empty object means "supported, default configuration".
+
+| Member | Type | Default | Meaning |
+|---|---|---|---|
+| `version` | string (semver) | `"1.0.0"` | The extension-document version implemented. The default tracks the published document version this draft becomes. |
+| `proofProfiles` | string[] | `["org.kya-os/proof.v1"]` | Proof profiles minted (client) or verified (server). |
+| `didMethods` | string[] | `["did:key", "did:web"]` | DID methods used (client) or resolved (server). |
+| `required` | boolean | `false` | Server-side only: reject requests from clients that do not declare this extension (§5). Ignored on client declarations. |
+
+A peer receiving a declaration MUST ignore unknown members.
+A peer that receives a settings object it cannot parse — a declaration that is present but malformed, as distinct from one that is absent — MUST NOT treat it as a valid declaration, and MUST NOT guess at intent.
+Because the declaration is an untrusted, intermediary-mutable, proof-excluded `_meta` member, its handling is mode-dependent: in optional mode a malformed declaration degrades to non-declaration exactly like an absent one (core MCP behavior), so a corrupting intermediary cannot turn an otherwise-valid request into a rejection when a mere strip would let it through; in required mode, where a non-declaring request is rejected regardless, the server MUST reject it with `-32602` (Invalid params) carrying `reason: "malformed_declaration"`, distinguishing a garbled declaration from a genuinely absent one (`-32021`, §5).
+A declaration that is well-formed but omits members, or carries only unknown members, takes effect with each member at its default per the rule above.
+
+## 4. Capability Declaration and Selection
+
+The stateless MCP core (`2026-07-28`) has no handshake round trip, so this extension negotiates no session-wide agreement.
+Instead the server *advertises* what it supports, the client *selects* from that set and *declares* its selection on each request, and the server *enforces* its own configured minimum on each request.
+The selection is a hint; the enforcement is the security boundary.
+
+A client declares the extension inside `_meta["io.modelcontextprotocol/clientCapabilities"]` on each request; the per-request proof object of Entity Card §8.2 rides beside it under `_meta["org.kya-os/request-proof"]`:
+
+```json
+{
+  "io.modelcontextprotocol/clientCapabilities": {
+    "extensions": {
+      "org.kya-os/decentralized-authority": {
+        "proofProfiles": ["org.kya-os/proof.v1"],
+        "didMethods": ["did:key", "did:web"]
+      }
+    }
+  }
+}
+```
+
+A server advertises the extension in the `capabilities.extensions` member of its `server/discover` result (§9), listing the `proofProfiles` and `didMethods` it accepts.
+A client MAY pre-flight `server/discover` and choose a profile and DID method from the intersection of its own and the server's advertised sets; a client that declares a profile the server does not advertise MUST expect a proof-profile error rather than silent acceptance.
+For peers on the `2025-11-25` protocol, the same settings object travels in the initialize-era `capabilities.extensions` field, as an additive member that revision's schema does not define.
+When both carriage forms are present, the per-request declaration takes precedence only for identifying the client's active configuration; it never lowers the profiles or DID methods the server requires.
+
+A server MUST NOT weaken its verification requirements on the basis of a client's declaration.
+The declared `proofProfiles` and `didMethods` may only select among methods the server already accepts; they can never move the server below its configured floor.
+Because the load-bearing artifact is the signed proof and not the declaration, a declaration that names a weaker profile than the proof actually carries cannot make a server accept a proof it would otherwise reject: either the proof verifies under a profile the server accepts, or it fails closed.
+This closes the protocol-downgrade path that an unqualified precedence rule would leave open.
+
+A declaring client asserts that it can mint proofs under at least one listed profile and understands this extension's error surface.
+A declaring server asserts that it verifies the listed profiles per the fail-closed algorithm of Entity Card §11.
+
+## 5. Required Mode and Graceful Degradation
+
+When `required` is absent or `false`, a request from a non-declaring client MUST be processed as core MCP: no proof is demanded and no extension error is emitted.
+
+When `required` is `true`, a request whose client capabilities do not declare this extension MUST be rejected with the core MCP error `-32021` (`MissingRequiredClientCapabilityError`), carrying both the core schema's `requiredCapabilities` member and this extension's reason code:
+
+```json
+{
+  "code": -32021,
+  "message": "Missing required client capability: org.kya-os/decentralized-authority",
+  "data": {
+    "requiredCapabilities": { "extensions": { "org.kya-os/decentralized-authority": {} } },
+    "reason": "extension_not_declared",
+    "extension": "org.kya-os/decentralized-authority"
+  }
+}
+```
+
+Clients dispatch on `error.data.reason` (§6); where an SDK's typed error reconstruction surfaces only `requiredCapabilities`, membership of this extension's id in `requiredCapabilities.extensions` is the fallback discriminant.
+Required mode MUST NOT gate `server/discover`: the pre-flight discovery of §4 and §9 has to remain reachable by non-declaring clients, or a client could never learn the requirement it fails.
+Implementations SHOULD extend the same exemption to liveness pings from earlier protocol revisions.
+
+`_meta` is intermediary-mutable and excluded from proof coverage by design (§7), so a stripped declaration is handled exactly as an absent one: rejection in required mode, core behavior in optional mode, never accepted as authenticated (a present-but-malformed declaration is handled per §3, mode-dependently).
+The load-bearing artifacts are always the signed proof and credentials, never the declaration.
+
+## 6. Errors
+
+This extension allocates **no numeric JSON-RPC codes**.
+Implementations MUST NOT emit codes from the MCP-reserved `-32020` to `-32099` range for this extension's errors, other than core `-32021` exactly as specified in §5.
+The failure taxonomy rides `error.data`:
+
+```json
+{ "code": -31000, "message": "KYA-OS proof required",
+  "data": { "reason": "proof_missing", "profile": "org.kya-os/proof.v1" } }
+```
+
+Numeric codes for these errors are allocated outside the JSON-RPC reserved range (`-32768` to `-32000`), per the core allocation policy; the legacy `-32000` to `-32019` sub-range is not used.
+
+`error.data.reason` carries a snake_case code from the governing specifications verbatim (Entity Card Appendix D; KYA-OS Spec Appendix A).
+Client behavior MUST be keyed by `error.data.reason`; clients MUST NOT vary behavior on the implementation-defined numeric code.
+This document defines two reason codes of its own: `extension_not_declared` (inside a `-32021` error) and `malformed_declaration` (inside a `-32602` error, §3).
+
+## 7. Per-Request Proof
+
+The request proof is `org.kya-os/proof.v1`, defined in Entity Card §8 and verified in the exact fail-closed order of Entity Card §11.2.
+The MCP-specific bindings are:
+
+1. The proof object rides `_meta["org.kya-os/request-proof"]` inside the request's `params` - the role-named carrier of the `org.kya-os/proof.v1` profile (Entity Card §8.1; the legacy key and `prf` value `org.kya-os/proof@1` are accepted for one major version).
+2. Its `requestHash` covers `{ method, params }` with `params._meta` removed (Entity Card §8.3).
+   An intermediary can therefore add or rewrite `_meta` members, such as the required `io.modelcontextprotocol/*` keys, without invalidating the proof, and any mutation of covered request material invalidates the proof by construction.
+   Because `_meta` is both intermediary-mutable and outside proof coverage, its contents are untrusted: a verifier derives no security decision from any `_meta` member except by verifying the signed proof that member carries.
+3. The proof is in-band JSON-RPC and verifies identically over stdio and Streamable HTTP; an OPTIONAL RFC 9421 sibling signature (Entity Card §8.5) serves HTTP-edge intermediaries, and the profile's relationship to DPoP is specified in Entity Card §8.8 (the two compose).
+
+Response-side proofs (KYA-OS Spec §7) cover the response body only.
+Result members outside the body, including the `2026-07-28` `resultType` member, are outside `responseHash` coverage.
+
+## 8. Delegated Authority and Consent
+
+Declaring the extension conveys no authority.
+Authority is conveyed only by a verifiable delegation chain (KYA-OS Spec §6, including the VC 2.0 + ZCAP-LD profile of §6.10), referenced from proofs via `delegationRef`, with per-hop attenuation, the designation invariant, and revocation via W3C Status Lists.
+This is a capability system in the lineage of ZCAP-LD, UCAN, and SPKI/SDSI (References, Informative).
+Status lists SHOULD be published per issuing authority — each delegation's status served from the issuer's own domain — rather than through a single centralized registry, preserving the no-central-authority property the extension is named for.
+
+A call lacking sufficient permission returns the signed `needs_authorization` challenge of KYA-OS Spec §9, carried as the body of a `resultType: "complete"` result.
+The challenge's `responseHash` binds its content, including `authorizationUrl`; a client MUST verify the challenge proof before directing a user to that URL, and applies the RFC 9207 issuer validation required by KYA-OS Spec §9.4 on the authorization callback.
+When a server calls downstream services under a delegation, outbound propagation uses the `KYA-OS-*` header registry and the body-free routing of KYA-OS Spec §8; advisory headers are never authorization inputs there.
+
+## 9. Discovery
+
+Discovery is the Entity Card layer: the DID-anchored `card.json` (Entity Card §5) and its projections onto MCP `server.json` / `catalog.json` `_meta["org.kya-os/card"]`, A2A, and NANDA (Entity Card §6, with mandatory SSRF-hardened fetching per Entity Card §6.6), plus the CIMD on-ramp (Entity Card §7).
+The `server/discover` advertisement (§4) is the in-protocol surface: a client can learn whether a server speaks, and requires, this extension before the first tool call.
+This binding defines no well-known endpoint; server metadata at well-known paths is deferred to the MCP Server Card work.
+
+## 10. Security Considerations
+
+The threat models of KYA-OS Spec §11 and Entity Card §12 apply in full.
+Extension-specific notes:
+
+1. **Declaration stripping** degrades to §5's fail-closed handling; the declaration is never a trusted input.
+2. **`_meta` coexistence**: verifiers read only KYA-OS keys and never hash, trust, or reject on foreign `_meta` keys (KYA-OS Spec §7.6); handlers SHOULD NOT derive authorization decisions from unsigned `_meta` content.
+3. **Token non-interference**: this extension never reads or writes the `Authorization` header; OAuth remains the token layer and the core token-passthrough prohibition is untouched.
+4. **Replay scope**: proof construction is stateless, verification is not; a verifier without a nonce seam fails closed (`nonce_seam_missing`, per Entity Card §11.2), and multi-replica deployments use an atomic, shared or replica-sticky nonce store (Entity Card §12.2) when duplicate execution of a byte-identical request within the 60-second window is unacceptable, the same bound DPoP carries via server-side `jti` tracking.
+   Because every proof carries a freshness window of at most 60 seconds, observed nonces need be retained only for that window plus the verifier's maximum tolerated clock skew: a proof replayed after the window fails the freshness check independently of the nonce store, so nonce retention is bounded by the proof window, not by the delegation lifetime.
+5. **Cost profile**: warm-path verification is local CPU; cold paths fetch DID documents and status lists through SafeFetch, with revocation staleness bounded by status-cache TTL (short TTLs recommended for high-privilege scopes, KYA-OS Spec §6.5.2).
+
+## 11. Privacy Considerations
+
+A stable DID plus per-request signed proofs makes an agent's activity linkable and non-repudiable, which is the goal in audit deployments and a cost elsewhere.
+Implementations SHOULD support pairwise per-audience DIDs, and this extension does not require a globally stable DID for conformance.
+Delegate keys SHOULD be one-off and short-lived (KYA-OS Spec §6.9): a fresh key per delegation bounds both replay and key-compromise exposure and reinforces the pairwise-DID unlinkability above.
+Where an operator must be able to revoke every delegation a principal holds in a single action — offboarding a departing employee, for instance — it MAY instead bind that principal's delegations to one revocable key and revoke that key, accepting the reduced unlinkability a shared key implies.
+Delegation credentials disclose delegating principals to chain verifiers; issuers SHOULD use opaque organization-resolvable subject identifiers, and cards are claim-minimal by design, carrying no principal PII (Entity Card §4.2, §13).
+Verifiers SHOULD fetch whole status lists (herd privacy), and deployments should define proof-retention windows (KYA-OS Spec §12.4).
+
+## 12. Backward Compatibility
+
+The extension is strictly additive.
+A peer that ignores it gets core MCP behavior end to end; a stripped discovery projection degrades to a fetch of the canonical card, never a failure (Entity Card §6).
+The KYA-OS 1.x session profile and the prior response-proof keys (`org.kya-os/proof`, bare `proof`) remain governed by the KYA-OS Specification (§5, §7.6) outside this extension.
+
+## References
+
+**Normative**: KYA-OS Protocol Specification v1.0.0; KYA-OS Entity Card profile v1.1; `schemas/mcp-extension-settings.json`; MCP specification revision `2026-07-28`; SEP-2133; BCP 14.
+**Informative**: RFC 9449 (DPoP); RFC 9207; RFC 9421; W3C DID Core, VC Data Model 2.0, Bitstring Status List; MCP `ext-auth` extensions; related capability systems — W3C ZCAP-LD, UCAN, and SPKI/SDSI (RFC 2693).

--- a/submission/sdk-v2-module-design.md
+++ b/submission/sdk-v2-module-design.md
@@ -1,0 +1,218 @@
+# `org.kya-os/decentralized-authority` as an opt-in module for the MCP TypeScript SDK v2
+
+Scoping spike, design doc only.
+No implementation, no pushes, no PRs.
+Date: 2026-07-28.
+
+Sources: the SPEC-MCP-EXTENSION.md binding in the kya-os-mcp tree, its shipped reference logic (`src/extension/settings.ts`, `declaration.ts`, `gate.ts`, `conformance/vectors/negotiation.json`, on the repository `main` branch and shipping in the next release), and a fresh read of the official TypeScript SDK v2 described below.
+
+---
+
+## 1. Which SDK ref was read
+
+Clone: `github.com/modelcontextprotocol/typescript-sdk`, branch `main`, commit `cc4b41617ce3601b1290d67216ea0b194a3cd9ac` ("Version Packages (#2555)").
+This commit is the peeled target of every `@modelcontextprotocol/*@2.0.0` tag (`client@2.0.0`, `server@2.0.0`, `core@2.0.0`, `node@2.0.0`, `server-legacy@2.0.0`, `express@2.0.0`, `fastify@2.0.0`, `hono@2.0.0`, `codemod@2.0.0`).
+So the tree read is exactly the v2.0.0 release line.
+
+npm state at read time: v2 is a monorepo split into scoped packages.
+`@modelcontextprotocol/server` and `@modelcontextprotocol/client` went `2.0.0-beta.1` (2026-06-30) through `2.0.0-beta.5` (2026-07-21), then `2.0.0` published 2026-07-27T23:55Z and now carries dist-tag `latest`.
+The legacy monolith `@modelcontextprotocol/sdk` stays at `1.30.0` and is not the v2 line.
+File citations below are repo-relative paths in the typescript-sdk tree, all read at commit `cc4b416`.
+
+A structural note that shapes the whole design: v2 implements the MCP `2026-07-28` revision exactly as SPEC-MCP-EXTENSION.md assumes.
+Stateless core, per-request `_meta` envelope, mandatory `server/discover`, `-32021` as a first-class protocol error, and `extensions` maps on both capability shapes.
+There is no SDK "extensions framework" API beyond those generic surfaces, and that turns out to be enough.
+
+---
+
+## 2. Investigation answers
+
+### 2a. Client capabilities envelope and the `extensions` map
+
+Representation.
+`ClientCapabilities.extensions?: { [key: string]: JSONObject }` is in the spec types at `packages/core-internal/src/types/spec.types.2026-07-28.ts:771-781`, with the server twin at `:868-878`.
+The zod wire schemas admit it on the 2026-07-28 era (`packages/core-internal/src/wire/rev2026-07-28/buildSchemas.ts:276`, `:300`, `:647`, `:657`) and, importantly, also on the 2025-11-25 era (`packages/core-internal/src/wire/rev2025-11-25/buildSchemas.ts:408`, `:494`), which matches SPEC-MCP-EXTENSION §3.1's initialize-era carriage rule.
+
+Sending.
+On a modern-era connection the `Client` stamps the reserved envelope keys onto every outgoing request and notification via the protected seam `_outboundMetaEnvelope()` (`packages/client/src/client/client.ts:700-712`), which passes `clientCapabilities: this._capabilities` to the era codec.
+The codec builds the object with `CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities"` at `packages/core-internal/src/wire/rev2026-07-28/codec.ts:129-137`.
+`Protocol._envelopeOutbound` merges it under `params._meta` with user-supplied `_meta` keys spread last, so user keys win (`packages/core-internal/src/shared/protocol.ts:675-685`).
+The connect-time `server/discover` probe carries the same envelope (`packages/client/src/client/versionNegotiation.ts:372`).
+
+Contributing entries.
+Two public paths, no third: constructor option `ClientOptions.capabilities` (`client.ts:187`, stored at `:637`) and `client.registerCapabilities(caps)` (`client.ts:789-796`, before connect only).
+Both go through `mergeCapabilities` (`protocol.ts:1881-1896`), which merges one level deep, so `{ extensions: { "org.kya-os/decentralized-authority": {...} } }` merges into an existing `extensions` map without clobbering other extension ids.
+
+Is there a dedicated public extensions API (register/declare hooks)?
+No.
+There is no `registerExtension`-style hook anywhere in the v2 surface, and the docs tree has no extensions page (the only docs mention of extension methods is `docs/advanced/custom-methods.md`).
+The generic surfaces above are the API, and they are sufficient for declaration.
+
+### 2b. Server contribution to `server/discover` `capabilities.extensions`
+
+`ServerOptions.capabilities` seeds `Server._capabilities` (`packages/server/src/server/server.ts:319`); `server.registerCapabilities(caps)` (`server.ts:443-457`, public, before connect only) merges through the same `mergeCapabilities`.
+`McpServer` forwards its `ServerOptions` verbatim (`packages/server/src/server/mcp.ts:118`) and exposes the low-level instance as `public readonly server: Server` (`mcp.ts:70`), so both API levels can declare.
+
+The `server/discover` handler is installed by the serving entries (`installModernOnlyHandlers`, `server.ts:239-241`, called from `createMcpHandler.ts:772` and the stdio entry) or at construction when a modern revision is configured (`server.ts:345-347`).
+It answers with `capabilities: discoverAdvertisedCapabilities(this.getCapabilities())` (`_ondiscover`, `server.ts:932-940`), and `discoverAdvertisedCapabilities` is a shallow copy that passes `extensions` through untouched (`server.ts:1331-1332`).
+Conclusion: `registerCapabilities({ extensions: { [id]: settings } })` on the factory-fresh instance is all it takes; the declaration then appears in every `server/discover` result, including the discover probe instance `createMcpHandler` builds from the same factory (`createMcpHandler.ts:82-83`).
+
+### 2c. Server-side pre-handler interception and protocol-level errors
+
+There is no public protocol-level middleware.
+What v2 calls "middleware" is (i) client-side `fetch` wrapping (`docs/clients/middleware.md:6`) and (ii) HTTP framework adapters (`packages/middleware/{express,fastify,hono,node}`).
+The dispatch-adjacent hooks that do exist are all `protected` or internal:
+
+- `Protocol._wrapHandler` (`protocol.ts:1749-1754`), subclass-only wrapping of registered handlers.
+- `Protocol._shouldDropInbound` (`protocol.ts:650-652`), subclass-only drop consult.
+- The HTTP entry's pre-dispatch capability gate (`createMcpHandler.ts:700-703`) evaluates `requiredClientCapabilitiesForRequest` against `REQUIRED_CLIENT_CAPABILITIES_BY_METHOD`, but that table is a module-scoped constant that is empty today (`packages/core-internal/src/shared/clientCapabilityRequirements.ts:42`), not per-instance extensible.
+- `ServerOptions.requestState.verify` (`server.ts:191`) is a real public verify hook, but scoped to multi-round-trip request state, not general requests.
+
+The seam that IS public and sufficient: the `Transport` interface plus the fact that every serving entry connects the factory product through its public `connect` method.
+
+- `Transport` is a public exported type (`packages/core-internal/src/exports/public/index.ts:66`, re-exported by both `@modelcontextprotocol/server` (`packages/server/src/index.ts:109`) and `@modelcontextprotocol/client` (`packages/client/src/index.ts:117`)).
+- The modern HTTP path calls `await server.connect(transport)` on the factory product (`packages/server/src/server/invoke.ts:66`).
+- The legacy stateless path does the same (`createMcpHandler.ts:329`), and stdio does too (`packages/server/src/server/serveStdio.ts:531`).
+- `McpServer.connect` simply delegates (`mcp.ts:148-149`).
+
+So a factory wrapper can decorate the product's public `connect` to interpose a gate transport.
+The gate sees every inbound `JSONRPCRequest` as raw wire bytes, before the dispatch layer's lift mutates anything.
+That raw view matters twice over: dispatch lifts the reserved `_meta` envelope keys and the MRTR retry members out of `params` before handlers run (`liftWireOnlyMaterial`, `protocol.ts:211-251`), and spec-path handlers receive zod-parsed params (`protocol.ts:1701-1719`), so only the transport boundary can recompute the KYA-OS `requestHash` over the exact received `{ method, params }` minus `params._meta` (SPEC-ENTITY-CARD §8.3).
+To reject, the gate writes a `JSONRPCErrorResponse` directly via the inner transport's `send`, which is byte-for-byte what the dispatch layer's own `sendErrorResponse` does (`protocol.ts:953-960`).
+
+Handler-level context access also exists for anyone who prefers wrapping individual handlers: `ctx.mcpReq._meta` carries the non-reserved keys (the KYA-OS proof key survives the lift; `protocol.ts:1057`, contract at `:348-352`) and `ctx.mcpReq.envelope` carries the lifted reserved keys including the client capabilities declaration (`protocol.ts:1058`, type at `:355-363`).
+
+HTTP status for `-32021`.
+The per-request HTTP transport maps an error response with code `-32021` to HTTP `400` even when it is produced after the dispatch window opens, as a documented spec-mandated exception (`packages/server/src/server/perRequestTransport.ts:266-296`, special case at `:290`; status table `LADDER_ERROR_HTTP_STATUS` at `packages/core-internal/src/shared/inboundClassification.ts:383-390`; `httpStatusForErrorCode` at `:410-415`).
+So a gate-emitted or handler-thrown `-32021` gets the spec's `400` with zero extra work, and in-band `-31000` proof-gate errors correctly stay on HTTP `200`.
+
+### 2d. Client-side `_meta` read/write
+
+Per-request write, explicit: every request params type includes `_meta` (`RequestMetaSchema` is `z.looseObject`, `buildSchemas.ts:146`), `callTool(params, ...)` takes `CallToolRequest['params']` verbatim (`client.ts:2317`), and user `_meta` wins over the auto-envelope (`protocol.ts:672-684`).
+So `client.callTool({ name, arguments, _meta: { "org.kya-os/request-proof": proof } })` works today.
+
+Per-request write, transparent: decorate the client `Transport` the developer already constructs and passes to `client.connect(transport)`.
+`transport.send` sees the final outgoing `JSONRPCRequest` (envelope already merged), and since `requestHash` excludes `params._meta` by design, minting the proof there and injecting it under `_meta` is hash-safe by construction (SPEC-MCP-EXTENSION §6 item 2).
+`send` returns a promise, so async signing (including non-extractable `CryptoKey` signers) fits.
+A pleasant consequence: multi-round-trip auto-fulfilment retries (`client.ts:717-750`) re-enter `transport.send` as new wire requests, so each retry gets a fresh, correctly bound proof with no special handling, matching SPEC-MCP-EXTENSION §7.3's "retry is a new request" posture.
+
+Reading results: result schemas keep `_meta` (`_meta: z.optional(z.looseObject({}))`, `buildSchemas.ts:365`, `:375`), and the 2026 decode returns the body verbatim minus only the `resultType` discriminator (`rev2026-07-28/codec.ts:253-256`).
+Since KYA-OS `responseHash` excludes `_meta` and never covers `resultType` (SPEC-MCP-EXTENSION §6), response-proof verification can run either on the decoded result or, more robustly, on the raw response inside the same transport decorator before the SDK decodes it.
+
+Reading errors: an inbound error response becomes `ProtocolError.fromError(code, message, data)` (`protocol.ts:1213`).
+One sharp edge found: the `-32021` branch of `fromError` (`packages/core-internal/src/types/errors.ts:93-102`) reconstructs `MissingRequiredClientCapabilityError` from `data.requiredCapabilities` alone and drops sibling members at `:100`.
+If `data` carries `{ reason, extension }` without `requiredCapabilities`, exactly the SPEC-MCP-EXTENSION §4.2 shape, the branch does not match and the error falls through to the generic path (`errors.ts:105`) with `data` preserved verbatim.
+So the spec-exact error shape survives SDK client reconstruction intact, and clients can dispatch on `error.data.reason` as §5.2 requires.
+(The final core spec makes `data.requiredCapabilities` a MUST on `-32021`, so the module emits it alongside `reason`/`extension`. That routes stock SDK clients into the typed subclass, which drops the sibling members at `errors.ts:100` - so the client module reads the raw wire error at its transport decorator, before `fromError` runs, and the one-line upstream fix preserving extra data members is the named companion ask in the maintainer summary rather than an optional nicety.)
+
+### 2e. Protocol error modeling for `-32021` with a `data` payload
+
+`ProtocolError` is a public class with a `(code, message, data)` constructor (`errors.ts:19-54`), and `MissingRequiredClientCapabilityError` subclasses it with `ProtocolErrorCode.MissingRequiredClientCapability = -32021` (`errors.ts:207-226`; enum at `packages/core-internal/src/types/enums.ts:30`; spec constant `MISSING_REQUIRED_CLIENT_CAPABILITY = -32021` at `spec.types.2026-07-28.ts:449`; data interface at `types.ts:783`).
+All of it is public API re-exported by both role packages (`exports/public/index.ts:106-111`).
+A handler-thrown error keeps its integer `code` and its `data` verbatim on the wire (`protocol.ts:1141-1151`), and `encodeErrorCode` is identity for `-32021` on both eras (`rev2026-07-28/codec.ts:271`, `rev2025-11-25/codec.ts:141`).
+So an extension can emit `-32021` with `data: { reason: "extension_not_declared", extension: "org.kya-os/decentralized-authority" }` from a wrapped handler or mint the response directly at the transport gate; both produce the SPEC-MCP-EXTENSION §4.2 wire shape, and on HTTP both get status `400` (see 2c).
+
+---
+
+## 3. Minimal module design
+
+### 3.1 Shape and naming
+
+One new package, no SDK core changes: working name `@kya-os/mcp-sdk` (subpaths `/server` and `/client`), delivered for the SEP as a prototype branch of the official SDK adding `packages/extension-decentralized-authority` with identical code.
+The module is a thin binding: all extension logic in `@kya-os/mcp` (on `main`, shipping in the next release: `src/extension/settings.ts`: id, meta-key and code constants, settings schema, `buildExtensionsEntry`; `src/extension/declaration.ts`: `readExtensionDeclaration` with the stateless and initialize carriages; `src/extension/gate.ts`: `requireExtension`, `missingRequiredCapabilityError`, `proofGateToJsonRpcError`; verification primitives in `src/card/`) is imported, not duplicated.
+
+### 3.2 Public API sketch
+
+```ts
+// ---- server (wraps the factory; works for createMcpHandler, serveStdio, and hand-wired connect) ----
+import { withDecentralizedAuthority } from '@kya-os/mcp-sdk/server';
+
+const handler = createMcpHandler(
+    withDecentralizedAuthority(myFactory, {
+        settings: { version: '1.0.0', proofProfiles: ['org.kya-os/proof.v1'], didMethods: ['did:key', 'did:web'] },
+        required: true,                      // -32021 + { reason: 'extension_not_declared' } for undeclared clients
+        verifier,                            // proof verifier from @kya-os/mcp (fail-closed order, SPEC-ENTITY-CARD §11.2)
+        nonceStore,                          // shared across per-request instances (module default: in-memory, documented caveat)
+        gate: { exempt: ['server/discover', 'ping'] }   // discovery is never gated (SPEC-MCP-EXTENSION §4.2)
+    })
+);
+
+// ---- client (declare + transparently attach proofs) ----
+import { decentralizedAuthority } from '@kya-os/mcp-sdk/client';
+
+const da = decentralizedAuthority({ signer, delegationRef });    // signer may hold a non-extractable CryptoKey
+const client = new Client(info, { capabilities: da.capabilities });   // or da.register(client) pre-connect
+await client.connect(da.transport(new StreamableHTTPClientTransport(url)));
+```
+
+### 3.3 How each piece lands on the SDK surfaces found in §2
+
+Server declaration: the factory wrapper calls `product.server.registerCapabilities({ extensions: buildExtensionsEntry(settings) })` on every fresh instance, pre-connect (the entries call the factory per request, per connection, and per discover probe, so the advertisement is always present in `server/discover`).
+Server gate: the wrapper replaces the product's public `connect` with `t => originalConnect(gateTransport(t, opts))`.
+The gate transport delegates the `Transport` contract and intercepts inbound requests: it reads the declaration from `_meta["io.modelcontextprotocol/clientCapabilities"].extensions` (or, on a 2025-era `initialize`, from `params.capabilities.extensions`) via `readExtensionDeclaration`, answers required-mode absence with the §4.2 `-32021` error object written straight to `innerTransport.send` (HTTP 400 comes free, `perRequestTransport.ts:290`), runs the proof gate on gated methods over the raw `{ method, params }`, maps failures through `proofGateToJsonRpcError` (`-31000`, `data.reason` in `proof_missing | proof_invalid | proof_level_insufficient`), and forwards clean traffic to the protocol's `onmessage` untouched.
+Malformed declarations are treated as absent (fail closed, SPEC-MCP-EXTENSION §3.2), matching the `negotiation/malformed-*` vectors.
+
+Client declaration: `da.capabilities` / `da.register(client)` use the constructor option or `registerCapabilities`; the SDK then carries the declaration on every request automatically via `_outboundMetaEnvelope`, including the discover probe.
+Client proofs: `da.transport(t)` decorates `send` to mint `org.kya-os/proof.v1` over the final wire request (minus `_meta`) and inject it under `_meta`; it also verifies response proofs from `_meta["org.kya-os/response-proof"]` on the way back, before the SDK decode, and surfaces `needs_authorization` challenges per SPEC.md §9.
+
+Optional mode, unaware peers, and disabled-by-default all hold by construction: a server not wrapped and a client not decorated are byte-identical to stock v2, and a wrapped server with `required: false` passes undeclared traffic through untouched.
+
+### 3.4 Crypto and verification: peer dependency, not vendored
+
+Peer dependencies: `@modelcontextprotocol/server` / `@modelcontextprotocol/client` at `>=2.0.0 <3`, and `@kya-os/mcp` at the first minor carrying the extension module for settings/declaration/gate logic and the `src/card/` verification primitives (DID resolution, delegation chains, status lists, JCS hashing, jose 6).
+Vendoring is rejected: the verification stack is security-sensitive and already audited once, the conformance harness pins it, and duplicating it would fork the fail-closed order.
+The SDK core gains zero dependencies because the SDK core gains zero code.
+
+### 3.5 Diff to SDK core
+
+Zero core changes required.
+Every needed seam is public API at `cc4b416`: capability `extensions` maps on both roles, `registerCapabilities` on both roles, the auto-emitted client envelope, the `Transport` interface plus entry-side `connect(product)` dispatch, verbatim `code`/`data` pass-through for thrown protocol errors, and the `-32021` to HTTP 400 mapping.
+One named companion ask, not a blocker (the client module reads raw wire errors, §2d): one line in `ProtocolError.fromError` (`errors.ts:100`) to preserve extra `-32021` data members alongside `requiredCapabilities`, so stock SDK clients keep the extension dispatch code. One optional nicety: (2) a per-instance hook behind `REQUIRED_CLIENT_CAPABILITIES_BY_METHOD` (`clientCapabilityRequirements.ts:42`) so required-extension gating could ride the entry's own pre-dispatch rung instead of a transport decorator.
+If maintainers prefer the hook route for an official extensions story, that is the exact PR to name; the module works without it.
+
+---
+
+## 4. Effort estimate (person-days)
+
+Scenario A is the real one: the hooks exist (verified in §2).
+Scenario B is the counterfactual if the seams had been missing (no public `Transport` decoration path, no `registerCapabilities`), requiring an upstream hook PR first.
+
+| Work item | A: hooks exist (actual) | B: hooks missing (counterfactual) |
+|---|---|---|
+| Module (server wrapper, client wrapper, settings/declaration/gate binding over `@kya-os/mcp`) | 3-4 | 5-7 (includes writing the core hook PR itself) |
+| Tests (port the 8 `negotiation.json` vectors + proof-gate vectors against real `Client`/`Server` over `InMemoryTransport`, `createMcpHandler` HTTP-status assertions incl. the 400, stdio path, 2025-era initialize carriage) | 3-4 | 4-5 |
+| Docs (README, worked example, SEP prototype note for the maintainers) | 1-2 | 2 |
+| **Total** | **7-10** | **11-14 plus upstream review latency on the hook PR** |
+
+---
+
+## 5. Maintainer-facing summary (Discord-ready)
+
+> **Prototype: `org.kya-os/decentralized-authority` as an opt-in extension module on SDK v2, zero core changes.**
+>
+> We (DIF-hosted KYA-OS project) have an Extensions Track SEP in the works for `org.kya-os/decentralized-authority`: verifiable agent identity, delegation chains, and per-request holder-of-key proofs for MCP.
+> Per the extensions docs, an Extensions Track SEP needs a reference implementation in an official SDK before review, so we scoped exactly what that takes on `typescript-sdk@cc4b416` (the 2.0.0 line) and want to sanity-check the approach with you before building the prototype branch.
+>
+> The short version: **v2 already exposes everything we need, and the module touches no core code.**
+> Declaration rides the existing `capabilities.extensions` maps (client side auto-carried in the per-request `_meta` envelope, server side surfaced by `server/discover` via `registerCapabilities`).
+> The proof is one namespaced `_meta` key on requests.
+> Enforcement is a `Transport` decorator installed by wrapping the user's `McpServerFactory`, so `createMcpHandler`, `serveStdio`, and hand-wired `connect` all work unchanged; required mode answers undeclared clients with core `-32021` (`data.reason: "extension_not_declared"`), and your per-request transport already maps that to the spec's HTTP 400.
+> No new tools, no new methods, no new error codes, no new SDK dependencies.
+>
+> **Disabled by default, by construction**: nothing activates unless a developer explicitly wraps their factory (server) or transport (client); unwrapped paths are byte-identical to stock v2, and an unaware peer talking to an optional-mode server gets plain core MCP.
+> **Conformance is already testable**: the extension ships with a cross-language conformance-vector suite (negotiation vectors covering declared/absent/malformed/required/initialize-era cases, plus proof vectors), and the crypto/verification core is a peer dependency on `@kya-os/mcp`, live on npm with implementations shipping in two languages.
+> The prototype branch would add one `packages/` module plus tests that run the vectors against the real `Client`/`Server` over `InMemoryTransport`.
+> One small core ask (not a blocker): preserving extra `-32021` `data` members in `ProtocolError.fromError`, so typed reconstruction keeps the extension dispatch code the final spec has ride alongside the mandated `requiredCapabilities`. One optional nicety: a per-instance hook on the pre-dispatch capability gate.
+> Estimated effort on our side: about 7-10 person-days including tests and docs.
+> Would a draft PR against a fork be the right next step, or do you prefer prototype modules proposed as a `packages/` addition directly?
+
+---
+
+## 6. Open items and risks
+
+1. `registerCapabilities` throws after connect on both roles; the module must document that client registration happens before `connect` (the factory wrapper is inherently pre-connect on the server side).
+2. The gate must never gate `server/discover` or `ping` (discovery deadlock otherwise); the default exempt list encodes the normative exemption of SPEC-MCP-EXTENSION §4.2.
+3. Nonce replay containment needs a store that outlives per-request factory instances; the module takes a `nonceStore` option with an in-memory default and the SPEC-MCP-EXTENSION §10 item 4 multi-replica caveat in the README.
+4. The stdio entry also builds a discarded discover-probe instance from the same factory; the wrapper is idempotent per instance so this is free, but tests should pin it.
+5. On 2025-era traffic the declaration arrives via `initialize` `params.capabilities.extensions`; the gate transport reads both carriages through `readExtensionDeclaration` and must normalize them into one internal declaration (SPEC-MCP-EXTENSION §3.1), with the `negotiation/legacy-initialize-required` vector as the pin.
+6. Emit the `-32021` `data` payload with the core-mandated `requiredCapabilities` plus `{ reason, extension }`; the client module reads the raw wire error at the transport decorator (before `fromError` reconstruction), and the upstream `fromError` one-liner is the named companion ask (see §2d).


### PR DESCRIPTION
Stages the MCP Extensions Track submission package for working-group review, following the TAAWG discussions that landed the `org.kya-os/decentralized-authority` name and the framing conversation on how this work should present itself.

## The three documents under `submission/`

- **`decentralized-authority.md`**: the concise extension specification (~200 lines, Apache-2.0 per-file grant). This is the venue-shaped document: it follows the pattern the ext-auth extensions use, deferring normatively to SPEC.md and SPEC-ENTITY-CARD.md by section rather than restating them, and keeps its own normative statements to the minimum since every MUST eventually needs a mapped conformance check under the SEP traceability rules. It condenses SPEC-MCP-EXTENSION.md, which remains the full binding document in this repo.
- **`0000-decentralized-authority.md`**: the Extensions Track SEP draft in the venue's required eight-section format (`0000` placeholder per their process). The preamble states the three filing gates plainly (official-SDK reference module, MCP-side group association, sponsor) rather than hiding them; the Motivation carries both the venue's own demand signals and the operator need; the Rationale carries the OAuth-rails comparison including its conceded rows, the design-inputs lineage, and the identifier-and-governance path on acceptance stated head-on.
- **`sdk-v2-module-design.md`**: the scoping design for the official TypeScript SDK v2 module, the Extensions Track review gate. A commit-pinned read of v2.0.0 showing every needed seam is public API, so the module needs zero SDK core changes; roughly 7-10 person-days to the fork-branch prototype.

## Provenance, briefly

The design did not start from scratch. The delegation model applies object-capability discipline (attenuation-only chains, the designation invariant against the confused deputy, ZCAP-LD profiled as W3C VCs), and the alternative authorization rails were design inputs rather than foils: the `cnf.jkt` fusion exists because DPoP's sender-constraint semantics were worth adopting wherever an authorization server supplies them. The threat model is enumerated per-threat with named residual risks in the governing specifications, and the conformance suite's negative vectors are those attacks in executable form. Stewardship is active: the DIF TAAWG task force meets weekly, external review findings have already changed the specification (proof-key separation and the exact request-hash canonicalization, resolved in the 1.11.0 release), and conformance gates every change in CI.