### PR TITLE
fix!: grammar-legal and role-named proof carrier keys

### DIFF
--- a/SPEC-ENTITY-CARD.md
+++ b/SPEC-ENTITY-CARD.md
@@ -18,7 +18,7 @@ the discovery rails the agent ecosystem already indexes: the MCP `server.json` /
 `_meta`, the A2A `AgentExtension`, and the NANDA `AgentFacts` document. Each projection points
 back to the same card, anchored by a `KyaOsEntityCard` service entry on the entity's `did:web`
 DID document. On top of that discovery layer rides a per-request, sender-constrained
-holder-of-key proof (`org.kya-os/proof@1`) carried under its own `_meta["org.kya-os/proof@1"]`
+holder-of-key proof (`org.kya-os/proof@1`) carried under its own `_meta["org.kya-os/proof.v1"]`
 key: discover like everyone, prove like no one. An unaware peer safely ignores the KYA-OS layer;
 a KYA-OS-aware peer can verify the caller cryptographically on every request.
 
@@ -52,7 +52,7 @@ This is a **DIF TAAWG work item** with a conformant **reference implementation**
 `@kya-os/mcp` (v1.10.x at the time of writing). The Entity Card profile is additive over, and
 non-breaking with respect to, the KYA-OS 1.x protocol. The `org.kya-os/proof@1` profile defined
 here coexists with the legacy session-bound proof, and each rides its own `_meta` key:
-`org.kya-os/proof@1` for this profile, `org.kya-os/proof` for the legacy proof (§8.1, §15.5). The
+`org.kya-os/proof.v1` for this profile, `org.kya-os/response-proof` for the response proof (§8.1, §15.5). The
 card proof additionally names its profile in a `prf` field. The wire shapes in §3–§8 and
 Appendix A are stable for the 1.x line; a breaking change requires a major version bump.
 
@@ -445,7 +445,7 @@ emit `cnf`, verification degrades to **L3-minus** (§8.6, §9.4) rather than fai
 ## 8. Per-Request Holder-of-Key Proof (NORMATIVE) [TAAWG-NORMATIVE]
 
 `org.kya-os/proof@1` is a **self-contained**, **sender-constrained**, fail-closed proof that rides
-its own `_meta["org.kya-os/proof@1"]` key. There is no session establishment and no handshake;
+its own `_meta["org.kya-os/proof.v1"]` key. There is no session establishment and no handshake;
 every request carries its own proof.
 
 A note on the word "stateless", which earlier drafts used for this profile: the proof *object* is
@@ -459,13 +459,22 @@ stateless proof construction, never stateless verification.
 
 Two orthogonal proof profiles may appear on one server, each under its OWN `_meta` key: the
 **legacy session-bound** `ProofMeta` (carrying `sessionId` + a handshake nonce; retained untouched
-for 1.x back-compat) under `_meta["org.kya-os/proof"]`, and the **self-contained** `org.kya-os/proof@1`
-specified here under `_meta["org.kya-os/proof@1"]` - the key equals the profile id, so it is
-self-describing and versioned. Distinct keys let both regimes coexist without either guard seeing -
+for 1.x back-compat) under `_meta["org.kya-os/response-proof"]` (previously `org.kya-os/proof`,
+read-accepted for one major version per SPEC.md §7.6), and the **self-contained** `org.kya-os/proof@1`
+specified here under `_meta["org.kya-os/proof.v1"]` - the profile id itself is not a legal `_meta`
+key name under MCP's key grammar (a name segment permits only alphanumerics, hyphens, underscores,
+and dots - no `@`), so the carrier key is the profile id's key-safe form, versioned with `.v1`. Distinct keys let both regimes coexist without either guard seeing -
 or rejecting - the other's proof (a shared key made them mutually exclusive: a legacy proof failed
 the card schema and a card proof failed the legacy structure check). A Verifier reads the key for
 the profile it implements; the object still carries `prf` as a self-describing discriminator. This
 document specifies only `org.kya-os/proof@1`.
+
+**Backward compatibility (carrier key).** Earlier drafts used the profile id verbatim as the
+carrier key (`_meta["org.kya-os/proof@1"]`). For one major version, Verifiers MUST also accept a
+proof under that legacy key; producers MUST emit the canonical `org.kya-os/proof.v1` and,
+when targeting verifiers older than this revision, MAY additionally mirror the proof under the
+legacy key (the same one-major-version mirroring allowance as SPEC.md §7.6). When both keys are
+present, the canonical key wins.
 
 ### 8.2 Object
 
@@ -951,8 +960,8 @@ redirects, size/time caps. Residual: standard transport-layer DoS is out of scop
 |-----|---------|---------|
 | `org.kya-os/card` | inline Card summary or a `cardRef` on MCP `server.json`/`catalog.json` | §6.1 |
 | `org.kya-os/cardRef` | a lazy-fetch `card.json` URL (inside `org.kya-os/card`) | §6.1 |
-| `org.kya-os/proof@1` | the self-contained per-request holder-of-key proof (§8); the key equals the profile id | §8 |
-| `org.kya-os/proof` | the legacy session-bound proof (`ProofMeta`); a distinct key, so the two coexist | §8.1 |
+| `org.kya-os/proof.v1` | the self-contained per-request holder-of-key proof (§8); the key-safe carrier of the `org.kya-os/proof@1` profile (the legacy key `org.kya-os/proof@1` is accepted for one major version) | §8 |
+| `org.kya-os/response-proof` | the detached response proof (`ProofMeta`, SPEC.md §7), including the legacy session-bound era; previously `org.kya-os/proof`, read-accepted for one major version | §8.1 |
 | `org.kya-os/did` | the Entity's DID inside a CIMD document | §7.3 |
 
 The `org.kya-os` reverse-DNS label is outside the reserved `modelcontextprotocol/mcp` `_meta`
@@ -1018,8 +1027,8 @@ with either primitive this document marks for ratification.
 
 ANP (Agent Network Protocol) is an informative peer in the discovery-rail landscape. Within KYA-OS,
 the **legacy session-bound proof** (`ProofMeta` with `sessionId` + handshake nonce) under
-`_meta["org.kya-os/proof"]` coexists with `org.kya-os/proof@1` under its own distinct
-`_meta["org.kya-os/proof@1"]` key (§8.1); it is retained unchanged for the 1.x line and is expected
+`_meta["org.kya-os/response-proof"]` coexists with `org.kya-os/proof@1` under its own distinct
+`_meta["org.kya-os/proof.v1"]` key (§8.1); it is retained unchanged for the 1.x line and is expected
 to be deprecated at 2.0 in favour of the self-contained profile.
 
 ### 15.6 Governance - standardize exactly two primitives
@@ -1198,7 +1207,7 @@ Codes are snake_case, aligned to the implementation.
 
 | Code | Meaning |
 |------|---------|
-| `proof_missing` | No `org.kya-os/proof@1` in `_meta`. |
+| `proof_missing` | No `org.kya-os/proof.v1` (or legacy `org.kya-os/proof@1`) in `_meta`. |
 | `proof_invalid` | The holder-of-key proof did not verify. |
 | `proof_level_insufficient` | The proof assurance is below the required `minLevel`. |
 

--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -62,8 +62,8 @@ Re-keying of the `_meta` registry entries (§2.2) would be specified by a succes
 | Surface | Mechanism | Defined in |
 |---|---|---|
 | Capability negotiation | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3 (this document) |
-| Request proof | `_meta["org.kya-os/proof@1"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
-| Response proof / audit | `_meta["org.kya-os/proof"]` detached response proof | SPEC.md §7 |
+| Request proof | `_meta["org.kya-os/proof.v1"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
+| Response proof / audit | `_meta["org.kya-os/response-proof"]` detached response proof | SPEC.md §7 |
 | Consent step-up | signed `needs_authorization` challenge | SPEC.md §9 |
 | Delegated authority | W3C VC delegation chains, referenced via `delegationRef` | SPEC.md §6, §6.10 |
 | Gateway propagation | `KYA-OS-*` outbound HTTP headers; body-free routing | SPEC.md §8 |
@@ -74,13 +74,12 @@ The `_kyaos_handshake` tool and the KYA-OS session lifecycle (SPEC.md §5, §14)
 
 ### 2.2 `_meta` keys
 
-The reverse-DNS `_meta` keys used by this extension are the keys registered in SPEC-ENTITY-CARD §14.1.
-For `org.kya-os/proof`, that registry records the key's legacy session-profile role; the response-direction role described below is defined by SPEC.md §7.5-§7.6, and recording both roles in the registry is a pending amendment to the underlying specification:
+The reverse-DNS `_meta` keys used by this extension are the keys registered in SPEC-ENTITY-CARD §14.1:
 
 | Key | Carries | Direction |
 |---|---|---|
-| `org.kya-os/proof@1` | the self-contained per-request holder-of-key proof (SPEC-ENTITY-CARD §8) | request (caller to server) |
-| `org.kya-os/proof` | the detached response proof (SPEC.md §7), including signed `needs_authorization` challenges | response (server to caller) |
+| `org.kya-os/proof.v1` | the self-contained per-request holder-of-key proof of the `org.kya-os/proof@1` profile (SPEC-ENTITY-CARD §8; the legacy `org.kya-os/proof@1` key is accepted for one major version) | request (caller to server) |
+| `org.kya-os/response-proof` | the detached response proof (SPEC.md §7), including signed `needs_authorization` challenges; previously `org.kya-os/proof`, read-accepted for one major version | response (server to caller) |
 | `org.kya-os/card` (and nested `org.kya-os/cardRef`) | inline Entity Card summary or lazy card reference on discovery documents | discovery |
 | `org.kya-os/did` | the Entity's DID inside a CIMD document | discovery |
 
@@ -113,7 +112,7 @@ A client that supports this extension declares it inside that object's `extensio
           }
         }
       },
-      "org.kya-os/proof@1": { "prf": "org.kya-os/proof@1", "...": "see SPEC-ENTITY-CARD §8.2" }
+      "org.kya-os/proof.v1": { "prf": "org.kya-os/proof@1", "...": "see SPEC-ENTITY-CARD §8.2" }
     }
   }
 }
@@ -270,7 +269,7 @@ Deployments that gate at an HTTP edge (SPEC.md §8.4) keep their HTTP semantics 
 The request proof is `org.kya-os/proof@1`, specified normatively in SPEC-ENTITY-CARD §8 and verified per the exact fail-closed order of SPEC-ENTITY-CARD §11.2.
 The MCP-specific deltas are only these:
 
-1. **Placement.** The proof object rides `_meta["org.kya-os/proof@1"]` inside `params` of the JSON-RPC request (SPEC-ENTITY-CARD §8.1).
+1. **Placement.** The proof object rides `_meta["org.kya-os/proof.v1"]` inside `params` of the JSON-RPC request - the key-safe carrier of the `org.kya-os/proof@1` profile, the profile id itself not being a legal `_meta` key name (SPEC-ENTITY-CARD §8.1; the legacy `org.kya-os/proof@1` key is accepted for one major version).
 2. **Request binding.** `requestHash` covers `{ method, params }` with `params._meta` removed (SPEC-ENTITY-CARD §8.3).
    Consequently an intermediary MAY add or rewrite `_meta` members (for example the required `io.modelcontextprotocol/*` keys) without invalidating the proof, and MUST NOT mutate `method` or any other part of `params` on a proof-bearing request, because any such mutation invalidates `requestHash`.
 3. **Transport agnosticism.** The proof is in-band JSON-RPC and verifies identically over stdio and Streamable HTTP; the OPTIONAL RFC 9421 sibling (SPEC-ENTITY-CARD §8.5) serves HTTP-edge intermediaries.
@@ -369,7 +368,7 @@ Extension-specific considerations:
 
 1. **Unaware peers.** A peer that ignores this extension gets core MCP behavior end to end; every KYA-OS surface is additive `_meta`, headers, or discovery documents that the graceful-degradation contracts (§4, SPEC-ENTITY-CARD §6) cover.
 2. **`2025-11-25` peers.** The declaration is carried in the initialize-era `capabilities.extensions` field, as an additive member that revision's schema does not define (§3.1); proofs and errors are unchanged.
-3. **Legacy 1.x session profile.** The `_kyaos_handshake` tool, KYA-OS sessions, and the session-bound proof under `_meta["org.kya-os/proof"]` remain valid 1.x behavior outside this extension (SPEC.md §5, §14; SPEC-ENTITY-CARD §8.1, §15.5, Appendix D.4).
+3. **Legacy 1.x session profile.** The `_kyaos_handshake` tool, KYA-OS sessions, and the session-bound proof under `_meta["org.kya-os/response-proof"]` (historically `org.kya-os/proof`) remain valid 1.x behavior outside this extension (SPEC.md §5, §14; SPEC-ENTITY-CARD §8.1, §15.5, Appendix D.4).
    The two proof eras ride distinct keys and coexist on one server; the session profile is expected to be deprecated at KYA-OS 2.0 in favor of the self-contained profile.
 4. **Legacy bare `proof` key.** The one-major-version acceptance window for the bare `proof` response key is governed by SPEC.md §7.6, which is the single authoritative statement of that window; producers SHOULD emit only namespaced keys.
 

--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -3,7 +3,7 @@
 **`org.kya-os/decentralized-authority`: agent delegation and per-request proof as an MCP 2026-07-28 extension**
 
 Version: 1.0.0-draft
-Status: Draft (extension id proposed, pending DIF TAAWG ratification)
+Status: Draft
 Editors: KYA-OS Working Group
 Repository: https://github.com/decentralized-identity/kya-os-mcp
 Binds: the KYA-OS Protocol Specification ([SPEC.md](./SPEC.md)) and the Entity Card profile ([SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md)) to the Model Context Protocol Extensions framework (SEP-2133)
@@ -39,8 +39,7 @@ org.kya-os/decentralized-authority
 The vendor prefix `org.kya-os` is the reverse-DNS form of `kya-os.org`, which the KYA-OS project controls.
 The identifier follows the SEP-2133 `{vendor-prefix}/{extension-name}` form.
 The name states the extension's distinguishing property: the authority it conveys (identity, delegation chains, per-request proofs, and their audit trail) verifies locally from signed artifacts, with no round trip to a central authorization service (§13.2).
-
-> **Editorial note - open for discussion.** The extension id `org.kya-os/decentralized-authority` is **proposed** and not yet ratified by the DIF Trusted AI Agents Working Group (TAAWG); it remains open for working-group discussion and MAY change before this revision is finalized (see SPEC.md §7.6 and §15.2).
+The identifier was settled in DIF TAAWG discussion (2026-07-28).
 
 ### 1.2 Versioning
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -60,7 +60,7 @@ DIDs and Verifiable Credentials are the right fit for this problem:
 | **Responsible Party** | The entity ultimately accountable for the actions of an agent operating under a delegation chain. The Responsible Party is the root issuer of the chain (`issuerDid` of the root `DelegationCredential`). In personal use, the Responsible Party equals the Principal. In organizational use, the Responsible Party is the employing organization or parent entity while the Principal is the immediate human delegator within that organization. Reputation and accountability signals are scoped primarily to the Responsible Party rather than to an agent's ephemeral identity — "can this be trusted?" is ultimately a question about the accountable party. |
 | **Delegation Chain** | An ordered sequence of Delegation Credentials from a root delegator (the Responsible Party) to the current agent, where each credential's subject is the next credential's issuer. |
 | **Delegation Credential** | A W3C Verifiable Credential that grants specific permissions from an issuer (delegator) to a subject (delegate). Contains CRISP constraints defining allowed operations. |
-| **Detached Proof** | A JWS (JSON Web Signature) that cryptographically binds a tool request and response together, enabling non-repudiation and audit. Attached to responses under the reverse-DNS key `org.kya-os/proof` within the MCP `_meta` field (legacy bare `proof` accepted for backward compatibility; see §7.6). |
+| **Detached Proof** | A JWS (JSON Web Signature) that cryptographically binds a tool request and response together, enabling non-repudiation and audit. Attached to responses under the reverse-DNS key `org.kya-os/response-proof` within the MCP `_meta` field (prior keys `org.kya-os/proof` and bare `proof` accepted for backward compatibility; see §7.6). |
 | **CRISP Constraints** | **C**onstraints, **R**esources, **I**dentity, **S**cope, **P**olicy — a structured envelope defining what operations a delegation permits: allowed scopes, budget caps, temporal bounds, and audience restrictions. |
 | **Session** | An OPTIONAL, validated, time-bounded convenience context established via the `_kyaos_handshake` tool. Sessions aid replay prevention and provide a stable context for proof generation, but are **not** the durable authority — the per-request detached-JWS proof (§7) and DID-anchored grant (§6) are (see §5 preamble). KYA-OS sessions are independent of MCP's session, which was removed in MCP 2026-07-28 (SEP-2567/SEP-2575). |
 | **Handshake Nonce** | A cryptographically random value provided by the client during session establishment. Used once; prevents replay attacks. |
@@ -120,7 +120,7 @@ The following diagram illustrates the KYA-OS protocol flow:
          │  │ 4. TOOL CALL RESPONSE                    │  │
          │  │    content: [ { type: "text", ... } ]    │  │
          │  │    _meta:                                │  │
-         │  │      org.kya-os/proof:                   │  │
+         │  │      org.kya-os/response-proof:          │  │
          │  │        jws: "eyJhbGciOiJFZERTQSI..."     │  │
          │  │        meta:                             │  │
          │  │          did: "did:web:srv"              │  │
@@ -966,7 +966,7 @@ substitution — and `outcome: "needs_authorization"`:
 ### 7.5 _meta Attachment
 
 The proof is attached to tool responses under the reverse-DNS key
-`org.kya-os/proof` inside the standard MCP `_meta` field. Other `_meta` keys
+`org.kya-os/response-proof` inside the standard MCP `_meta` field. Other `_meta` keys
 (e.g. `io.modelcontextprotocol/*`, `traceparent`) MAY coexist and are ignored by
 the verifier (§7.6):
 
@@ -974,7 +974,7 @@ the verifier (§7.6):
 {
   "content": [{ "type": "text", "text": "File contents..." }],
   "_meta": {
-    "org.kya-os/proof": {
+    "org.kya-os/response-proof": {
       "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6Ii4uLiJ9.eyJhdWQiOi4uLn0.c2ln...",
       "meta": {
         "did": "did:web:server.example.com",
@@ -1007,31 +1007,36 @@ Context propagation keys (`traceparent`, `tracestate`, `baggage`). KYA-OS
 therefore namespaces its own payload and MUST NOT assume exclusive ownership of
 `_meta`.
 
-**Canonical key.** KYA-OS attaches its detached proof under the reverse-DNS key
-`org.kya-os/proof` (the `proofMetaKey`). This key SHOULD be configurable (e.g., a
+**Canonical key.** KYA-OS attaches its detached response proof under the
+reverse-DNS key `org.kya-os/response-proof` (the `proofMetaKey`). The key is
+named for its role so it cannot be misread as a version sibling of the request
+proof's `org.kya-os/proof.v1` (SPEC-ENTITY-CARD §8), which carries a different
+object. This key SHOULD be configurable (e.g., a
 single build-time constant rather than a value scattered through the code), so
 that if and when KYA-OS is registered as an MCP Extension (SEP-2133), its
 reverse-DNS extension id — and hence this key — can be re-pointed without a wire
 change.
 
-> **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/proof`
+> **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/response-proof`
 > (and the corresponding proposed MCP Extension id `org.kya-os/decentralized-authority`; see
 > §15.2) are **proposed** and not yet ratified. They remain open for
 > working-group discussion and MAY change before this revision is finalized.
 > Because the key is configurable (above), pinning the final id later does not
 > require a code change.
 
-**Backward compatibility.** For one major version, verifiers MUST also accept a
-proof published under the legacy bare key `proof`. Producers SHOULD emit
-`org.kya-os/proof`; producers targeting pre-1.1 verifiers MAY additionally
-mirror the proof under bare `proof`. When both are present and disagree, the
-namespaced key wins.
+**Backward compatibility.** Two prior keys carried this proof: bare `proof`
+(pre-1.1) and `org.kya-os/proof` (1.1 until the role-named rename). For one
+major version, verifiers MUST also accept a proof published under either prior
+key. Producers emit `org.kya-os/response-proof` and MAY additionally mirror the
+proof under a prior key when targeting older verifiers. When several keys are
+present, the newest canonical form wins (`org.kya-os/response-proof`, then
+`org.kya-os/proof`, then `proof`).
 
 **`metaPolicy` semantics.** The `session.metaPolicy` setting governs how a
 verifier treats `_meta` keys that are *not* KYA-OS's proof key:
 
 - `strict` (the default) — the verifier processes **only** the KYA-OS proof key
-  (`org.kya-os/proof`, or legacy `proof`). All other keys are **ignored**: never
+  (`org.kya-os/response-proof`, or a prior key `org.kya-os/proof` / `proof`). All other keys are **ignored**: never
   hashed, never trusted, and — critically — **never a cause for rejection**. In
   particular a `strict` verifier MUST NOT reject a response merely because
   `_meta` also carries `io.modelcontextprotocol/*`, `traceparent`, `tracestate`,
@@ -1047,7 +1052,7 @@ never covers `_meta` (§7.3).
 
 > **Note.** The proof object's shape is normatively defined by
 > `schemas/detached-proof.json` (`$schema: draft/2020-12`). The *placement* key
-> inside `_meta` is `org.kya-os/proof`; the schema describes the value
+> inside `_meta` is `org.kya-os/response-proof`; the schema describes the value
 > (`{ jws, meta }`), not the key.
 
 ### 7.7 Delegation Chain Audit Example
@@ -1092,7 +1097,7 @@ The `parentDelegation` field links this record back to the User → Agent A cred
 {
   "content": [{ "type": "text", "text": "file contents..." }],
   "_meta": {
-    "org.kya-os/proof": {
+    "org.kya-os/response-proof": {
       "jws": "eyJhbGciOiJFZERTQSJ9...",
       "meta": {
         "did": "did:web:tool-server.example.com",
@@ -1592,8 +1597,8 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
   and DID-anchored grant (§6). The KYA-OS session (§5) is an optional KYA-OS-owned
   convenience layer delivered via the `_kyaos_handshake` tool (§14) and is
   independent of MCP's removed session.
-- **`_meta` reserved-namespace coexistence.** KYA-OS publishes its proof under the
-  reverse-DNS key `org.kya-os/proof` and ignores all other `_meta` keys, including
+- **`_meta` reserved-namespace coexistence.** KYA-OS publishes its response proof
+  under the reverse-DNS key `org.kya-os/response-proof` and ignores all other `_meta` keys, including
   the MCP-reserved `io.modelcontextprotocol/*` and W3C Trace Context keys
   `traceparent`/`tracestate`/`baggage` (SEP-414). See §7.6.
 - **Routing headers.** KYA-OS gateways MAY use `Mcp-Method`/`Mcp-Name` (SEP-2243)
@@ -1609,7 +1614,7 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
   Standards-Track path.
 
   > **Editorial note — open for discussion.** The extension id `org.kya-os/decentralized-authority`
-  > and the proof key `org.kya-os/proof` (§7.6) are **proposed** and not yet
+  > and the proof key `org.kya-os/response-proof` (§7.6) are **proposed** and not yet
   > ratified; both remain open for working-group discussion and MAY change before
   > this revision is finalized.
 - **Deprecations are zero-impact.** SEP-2577 deprecates MCP **Roots**, **Sampling**,

--- a/SPEC.md
+++ b/SPEC.md
@@ -1017,13 +1017,6 @@ that if and when KYA-OS is registered as an MCP Extension (SEP-2133), its
 reverse-DNS extension id — and hence this key — can be re-pointed without a wire
 change.
 
-> **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/response-proof`
-> (and the corresponding proposed MCP Extension id `org.kya-os/decentralized-authority`; see
-> §15.2) are **proposed** and not yet ratified. They remain open for
-> working-group discussion and MAY change before this revision is finalized.
-> Because the key is configurable (above), pinning the final id later does not
-> require a code change.
-
 **Backward compatibility.** Two prior keys carried this proof: bare `proof`
 (pre-1.1) and `org.kya-os/proof` (1.1 until the role-named rename). For one
 major version, verifiers MUST also accept a proof published under either prior
@@ -1612,11 +1605,6 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
   `proofMetaKey`) and capability advertisement (§10) will use that extension id;
   the key is configurable for this reason. KYA-OS targets the SEP-2133
   Standards-Track path.
-
-  > **Editorial note — open for discussion.** The extension id `org.kya-os/decentralized-authority`
-  > and the proof key `org.kya-os/response-proof` (§7.6) are **proposed** and not yet
-  > ratified; both remain open for working-group discussion and MAY change before
-  > this revision is finalized.
 - **Deprecations are zero-impact.** SEP-2577 deprecates MCP **Roots**, **Sampling**,
   and **Logging** on 12-month windows. KYA-OS uses **none** of these features, so
   the deprecations have **no impact** on KYA-OS implementations.

--- a/src/card/__tests__/proof-key-compat.test.ts
+++ b/src/card/__tests__/proof-key-compat.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The card-proof `_meta` carrier key vs MCP's key grammar (SPEC-ENTITY-CARD §8.1).
+ *
+ * MCP's `_meta` key grammar permits only alphanumerics, hyphens, underscores, and dots in a
+ * key's name segment - no `@` - so the profile id `org.kya-os/proof@1` cannot itself be the
+ * carrier key. The canonical key is its key-safe form (`org.kya-os/proof.v1`); the earlier
+ * draft key (the profile id verbatim) stays readable for one major version, canonical wins.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readCardProof } from '../middleware.js';
+import {
+  KYA_OS_CARD_PROOF_META_KEY,
+  LEGACY_CARD_PROOF_META_KEY,
+  PROOF_PROFILE_V1,
+} from '../proof/types.js';
+
+/** MCP `_meta` name-segment grammar: alnum ends, alnum/hyphen/underscore/dot interior. */
+const META_KEY_NAME = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
+
+describe('card-proof _meta carrier key', () => {
+  it('the canonical key is legal under the MCP _meta key grammar', () => {
+    const name = KYA_OS_CARD_PROOF_META_KEY.split('/')[1];
+    expect(name).toBeDefined();
+    expect(name).toMatch(META_KEY_NAME);
+  });
+
+  it('the legacy key is the profile id verbatim (and is why it was replaced)', () => {
+    expect(LEGACY_CARD_PROOF_META_KEY).toBe(PROOF_PROFILE_V1);
+    expect(LEGACY_CARD_PROOF_META_KEY.split('/')[1]).not.toMatch(META_KEY_NAME);
+  });
+
+  it('readCardProof reads the canonical key', () => {
+    expect(readCardProof({ [KYA_OS_CARD_PROOF_META_KEY]: 'proof' })).toBe('proof');
+  });
+
+  it('readCardProof falls back to the legacy key (one-major-version window)', () => {
+    expect(readCardProof({ [LEGACY_CARD_PROOF_META_KEY]: 'legacy' })).toBe('legacy');
+  });
+
+  it('the canonical key wins when both are present', () => {
+    const meta = {
+      [KYA_OS_CARD_PROOF_META_KEY]: 'canonical',
+      [LEGACY_CARD_PROOF_META_KEY]: 'legacy',
+    };
+    expect(readCardProof(meta)).toBe('canonical');
+  });
+});

--- a/src/card/middleware.ts
+++ b/src/card/middleware.ts
@@ -10,7 +10,7 @@
  *     both immutably (a shallow clone; a stripped `_meta` degrades to a fetch, never a failure).
  *
  *   - `requireProof(deps, { minLevel? })` — the VERIFY side. Returns a per-request guard that
- *     reads the holder-of-key proof from `_meta['org.kya-os/proof@1']`, RECOMPUTES it via
+ *     reads the holder-of-key proof from `_meta['org.kya-os/proof.v1']` (legacy `org.kya-os/proof@1` accepted), RECOMPUTES it via
  *     `./proof` ({@link verifyCardProof}) — every binding, fail-closed — enforces a minimum
  *     assurance, and returns a 401-shaped result on any failure. The caller passes the exact
  *     `{ method, params }` the client signed (i.e. WITHOUT `_meta`), so the recomputed
@@ -30,6 +30,7 @@ import {
 import {
   verifyCardProof,
   KYA_OS_CARD_PROOF_META_KEY,
+  LEGACY_CARD_PROOF_META_KEY,
   type ProofAssurance,
   type ProofVerifyResult,
   type VerifyProofDeps,
@@ -158,7 +159,7 @@ const ASSURANCE_RANK: Record<ProofAssurance, number> = { 'L3-minus': 1, L3: 2 };
 
 /**
  * Build a per-request holder-of-key guard from the pre-bound proof-verification seams. The returned
- * guard reads `_meta['org.kya-os/proof@1']`, RECOMPUTES it against the request via {@link verifyCardProof},
+ * guard reads `_meta['org.kya-os/proof.v1']` (legacy `org.kya-os/proof@1` accepted), RECOMPUTES it against the request via {@link verifyCardProof},
  * enforces `opts.minLevel`, and returns `{ ok: true, did, level }` or a 401-shaped rejection. Fail-closed
  * throughout: a missing proof, a broken binding, a throwing verifier, or an assurance below `minLevel`
  * all reject.
@@ -173,7 +174,7 @@ export function requireProof(deps: VerifyProofDeps, opts: RequireProofOptions = 
   return async (req, meta) => {
     const proof = readCardProof(meta);
     if (proof === undefined) {
-      return fail('proof_missing', 'no org.kya-os/proof@1 in _meta', ['proof_missing']);
+      return fail('proof_missing', 'no org.kya-os/proof.v1 in _meta', ['proof_missing']);
     }
     const result = await recompute(proof, req, deps);
     if (!result.ok || result.did === undefined || result.level === undefined) {
@@ -193,10 +194,13 @@ export function requireProof(deps: VerifyProofDeps, opts: RequireProofOptions = 
   };
 }
 
-/** Read the card proof (`org.kya-os/proof@1`) out of a `_meta` record (undefined when absent / not an
- *  object). A legacy session proof under `org.kya-os/proof` is a different key and is simply not seen. */
+/** Read the card proof out of a `_meta` record (undefined when absent / not an object). Reads the
+ *  canonical `org.kya-os/proof.v1` key, falling back to the earlier draft key (`org.kya-os/proof@1`,
+ *  accepted for one major version); the canonical key wins when both are present. A legacy session
+ *  proof under `org.kya-os/proof` is a different key and is simply not seen. */
 export function readCardProof(meta: unknown): unknown {
-  return isRecord(meta) ? meta[KYA_OS_CARD_PROOF_META_KEY] : undefined;
+  if (!isRecord(meta)) return undefined;
+  return meta[KYA_OS_CARD_PROOF_META_KEY] ?? meta[LEGACY_CARD_PROOF_META_KEY];
 }
 
 /** Recompute the proof, fail-closed: a throwing verifier demotes to a rejected result (never escapes). */

--- a/src/card/proof/build.ts
+++ b/src/card/proof/build.ts
@@ -2,7 +2,7 @@
  * KYA-OS Entity Card proof — MINT (`buildCardProof`).
  *
  * Mint a stateless, sender-constrained `org.kya-os/proof@1` for one request and return it under the
- * card proof's OWN `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof@1`), distinct
+ * card proof's OWN `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof.v1`), distinct
  * from the legacy session proof's `org.kya-os/proof` so the two coexist. The proof binds:
  * `requestHash` → THIS body (JCS), `audience` → THIS recipient, `nonce` + `created`/`expires` → NOW,
  * `kid` → the signing DID key, and (optionally) `cnf.jkt` → the token's RFC 9449 sender-constraint.

--- a/src/card/proof/index.ts
+++ b/src/card/proof/index.ts
@@ -12,7 +12,7 @@
  *                              + the NonceCacheProvider adapter) so the safe consume is the default.
  *
  * Distinct from — and orthogonal to — the legacy session-bound proof in `src/proof`: the card proof
- * rides its OWN `_meta['org.kya-os/proof@1']` key, separate from the legacy `org.kya-os/proof`, so
+ * rides its OWN `_meta['org.kya-os/proof.v1']` key, separate from the legacy `org.kya-os/proof`, so
  * both regimes can run on one server without either guard seeing the other's proof.
  */
 

--- a/src/card/proof/types.ts
+++ b/src/card/proof/types.ts
@@ -2,7 +2,7 @@
  * KYA-OS Entity Card — stateless per-request holder-of-key proof: shapes + seams.
  *
  * `org.kya-os/proof@1` is the STATELESS, sender-constrained proof profile. It rides its OWN
- * `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof@1`), DISTINCT from the legacy
+ * `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof.v1`), DISTINCT from the legacy
  * session-bound `ProofMeta` (which carries `sessionId` + a handshake nonce under
  * `org.kya-os/proof`). Separate keys let the two regimes coexist on one server without either guard
  * seeing — or rejecting — the other's proof. Every request self-proves; there is no session state.
@@ -24,9 +24,19 @@ export const PROOF_PROFILE_V1 = PROOF_PROFILE_ID;
  * exclusive on a server (a legacy proof failed the card schema and was 401'd; a card proof failed
  * the legacy structure check). With separate keys each guard reads its OWN key and simply does not
  * see the other's proof, so both can run on one server — genuinely additive, no legacy coupling. The
- * key equals the `prf` profile id, so it is self-describing and versioned.
+ * key is the profile id's KEY-SAFE form: MCP's `_meta` key grammar permits only alphanumerics,
+ * hyphens, underscores, and dots in a key's name segment - no `@` - so the profile id itself is
+ * not a legal key name. The object's `prf` field remains the self-describing discriminator.
  */
-export const KYA_OS_CARD_PROOF_META_KEY = PROOF_PROFILE_V1;
+export const KYA_OS_CARD_PROOF_META_KEY = 'org.kya-os/proof.v1';
+
+/**
+ * The earlier draft carrier key, which used the profile id verbatim and therefore violated MCP's
+ * `_meta` key grammar. Verifiers accept it for one major version (SPEC-ENTITY-CARD §8.1);
+ * producers emit {@link KYA_OS_CARD_PROOF_META_KEY} and MAY mirror under this key for verifiers
+ * older than the rename. When both keys are present, the canonical key wins.
+ */
+export const LEGACY_CARD_PROOF_META_KEY = PROOF_PROFILE_V1;
 
 /** Default proof lifetime in seconds (SPEC §8: short-lived, ≤ 60s). */
 export const DEFAULT_TTL_SEC = 60;

--- a/src/card/verify.ts
+++ b/src/card/verify.ts
@@ -102,7 +102,7 @@ export interface VerifyCardDeps {
   attestationVerifier?: AttestationVerifier;
   /** Verifies the accountability edge (delegationRef → responsibleParty, leaf-invoker join). */
   accountabilityVerifier?: AccountabilityVerifier;
-  /** The per-request holder-of-key proof that rode `_meta['org.kya-os/proof@1']` (recomputed here). */
+  /** The per-request holder-of-key proof that rode `_meta['org.kya-os/proof.v1']` (recomputed here). */
   proof?: unknown;
   /** The request the proof must bind (`method` + `params`); required alongside `proof`. */
   request?: ToolRequest;

--- a/src/extension/__tests__/gate.test.ts
+++ b/src/extension/__tests__/gate.test.ts
@@ -156,7 +156,7 @@ describe('missingRequiredCapabilityError', () => {
 describe('proofGateToJsonRpcError', () => {
   const gateError = {
     code: 'proof_missing',
-    message: 'no org.kya-os/proof@1 in _meta',
+    message: 'no org.kya-os/proof.v1 in _meta',
     reasons: ['proof_missing'],
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,7 @@ export {
   createProofResponse,
   extractCanonicalData,
   KYA_OS_PROOF_META_KEY,
+  LEGACY_NAMESPACED_PROOF_META_KEY,
   LEGACY_PROOF_META_KEY,
   type ProofAgentIdentity,
   type ToolRequest,

--- a/src/middleware/kya-os-transport.ts
+++ b/src/middleware/kya-os-transport.ts
@@ -7,7 +7,7 @@
  *
  * The McpServer never knows this wrapper exists. It sees a normal transport.
  * The connected client sees normal MCP responses with the detached proof added
- * under the namespaced `_meta` key `org.kya-os/proof` (see KYA_OS_PROOF_META_KEY).
+ * under the namespaced `_meta` key `org.kya-os/response-proof` (see KYA_OS_PROOF_META_KEY).
  *
  * How it works:
  *   1. Incoming `tools/call` requests are captured (by id) to record tool

--- a/src/proof/__tests__/response-proof-key-compat.test.ts
+++ b/src/proof/__tests__/response-proof-key-compat.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The response-proof `_meta` carrier key and its acceptance window (SPEC §7.5-§7.6).
+ *
+ * The canonical key is role-named (`org.kya-os/response-proof`) so it cannot be
+ * misread as a version sibling of the request proof's `org.kya-os/proof.v1`.
+ * Two prior keys stay read-accepted for one major version: the namespaced
+ * `org.kya-os/proof` (canonical from 1.1 until the rename) and the original
+ * bare `proof`. The newest canonical form wins when several are present.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  KYA_OS_PROOF_META_KEY,
+  LEGACY_NAMESPACED_PROOF_META_KEY,
+  LEGACY_PROOF_META_KEY,
+} from '../generator.js';
+import { extractProofFromMeta, validateMetaStructure } from '../verifier.js';
+
+const proofAt = (label: string) => ({
+  jws: `eyJhbGciOiJFZERTQSJ9.e30.${label}`,
+  meta: {
+    did: 'did:web:server.example.com',
+    kid: 'did:web:server.example.com#key-1',
+    ts: 1782820800,
+    nonce: `nonce-${label}`,
+    audience: 'did:web:server.example.com',
+    sessionId: 'kyaos_compat-test',
+    requestHash: 'sha256:' + 'a'.repeat(64),
+    responseHash: 'sha256:' + 'b'.repeat(64),
+  },
+});
+
+describe('response-proof _meta carrier key', () => {
+  it('is role-named and grammar-legal (no @; alnum/-/_/. only)', () => {
+    expect(KYA_OS_PROOF_META_KEY).toBe('org.kya-os/response-proof');
+    const name = KYA_OS_PROOF_META_KEY.split('/')[1];
+    expect(name).toMatch(/^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/);
+  });
+
+  it('extracts from the canonical key', () => {
+    const r = extractProofFromMeta({ [KYA_OS_PROOF_META_KEY]: proofAt('new') });
+    expect(r.success).toBe(true);
+  });
+
+  it('falls back to the prior namespaced key (one-major-version window)', () => {
+    const r = extractProofFromMeta({ [LEGACY_NAMESPACED_PROOF_META_KEY]: proofAt('prior') });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.proof.meta.nonce).toBe('nonce-prior');
+  });
+
+  it('still falls back to the original bare key', () => {
+    const r = extractProofFromMeta({ [LEGACY_PROOF_META_KEY]: proofAt('bare') });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.proof.meta.nonce).toBe('nonce-bare');
+  });
+
+  it('the newest canonical form wins when several keys are present', () => {
+    const r = extractProofFromMeta({
+      [LEGACY_PROOF_META_KEY]: proofAt('bare'),
+      [LEGACY_NAMESPACED_PROOF_META_KEY]: proofAt('prior'),
+      [KYA_OS_PROOF_META_KEY]: proofAt('new'),
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.proof.meta.nonce).toBe('nonce-new');
+    const r2 = extractProofFromMeta({
+      [LEGACY_PROOF_META_KEY]: proofAt('bare'),
+      [LEGACY_NAMESPACED_PROOF_META_KEY]: proofAt('prior'),
+    });
+    expect(r2.success).toBe(true);
+    if (r2.success) expect(r2.proof.meta.nonce).toBe('nonce-prior');
+  });
+
+  it('strict metaPolicy treats all three as the proof key (no extraKeys)', () => {
+    const result = validateMetaStructure(
+      {
+        [KYA_OS_PROOF_META_KEY]: proofAt('new'),
+        [LEGACY_NAMESPACED_PROOF_META_KEY]: proofAt('prior'),
+        [LEGACY_PROOF_META_KEY]: proofAt('bare'),
+        traceparent: '00-abc-def-01',
+      },
+      'allow-extensions',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.extraKeys).toEqual(['traceparent']);
+  });
+});

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -30,9 +30,22 @@ import { ED25519_PKCS8_DER_HEADER, ED25519_KEY_SIZE } from '../utils/ed25519-con
  * SINGLE SOURCE OF TRUTH: every emit site (middleware) and verify site
  * (`extractProofFromMeta` / `validateMetaStructure`) references this constant,
  * so renaming the namespace — e.g. once KYA-OS registers as an MCP Extension
- * under SEP-2133 — is a one-line change. See SPEC §7.6.
+ * under SEP-2133 — is a one-line change. Named for its ROLE (the response
+ * proof), so it cannot be misread as a version sibling of the request proof's
+ * `org.kya-os/proof.v1`. See SPEC §7.5-§7.6.
  */
-export const KYA_OS_PROOF_META_KEY = 'org.kya-os/proof';
+export const KYA_OS_PROOF_META_KEY = 'org.kya-os/response-proof';
+
+/**
+ * The prior namespaced key (`org.kya-os/proof`), canonical from 1.1 until the
+ * role-named rename. Reads as a lineage sibling of the request proof's
+ * versioned key, which it is not — the two carry different objects — hence the
+ * rename. For one major version verifiers MUST keep accepting a proof
+ * published here; producers emit {@link KYA_OS_PROOF_META_KEY} and MAY mirror
+ * here for older verifiers. When several keys are present the newest canonical
+ * form wins.
+ */
+export const LEGACY_NAMESPACED_PROOF_META_KEY = 'org.kya-os/proof';
 
 /**
  * Legacy bare `_meta.proof` key — the legacy `_meta.proof` mirror; drop at 2.0.

--- a/src/proof/index.ts
+++ b/src/proof/index.ts
@@ -3,6 +3,7 @@ export {
   createProofResponse,
   extractCanonicalData,
   KYA_OS_PROOF_META_KEY,
+  LEGACY_NAMESPACED_PROOF_META_KEY,
   LEGACY_PROOF_META_KEY,
   type ProofAgentIdentity,
   type ToolRequest,

--- a/src/proof/verifier.ts
+++ b/src/proof/verifier.ts
@@ -25,6 +25,7 @@ import { logger } from "../logging/index.js";
 import {
   computeCanonicalHashes,
   KYA_OS_PROOF_META_KEY,
+  LEGACY_NAMESPACED_PROOF_META_KEY,
   LEGACY_PROOF_META_KEY,
   type ToolRequest,
   type ToolResponse,
@@ -655,8 +656,9 @@ export function isReservedMcpMetaKey(key: string): boolean {
  * Validate _meta structure according to meta policy.
  *
  * The KYA-OS proof rides under {@link KYA_OS_PROOF_META_KEY} (reverse-DNS,
- * SEP-414); the legacy bare {@link LEGACY_PROOF_META_KEY} is still accepted for
- * back-compat. Both are treated as the proof key. Every other key is a
+ * SEP-414); the prior {@link LEGACY_NAMESPACED_PROOF_META_KEY} and the legacy
+ * bare {@link LEGACY_PROOF_META_KEY} are still accepted for back-compat. All
+ * three are treated as the proof key. Every other key is a
  * non-KYA-OS `_meta` key.
  *
  * Under MCP 2026-07-28 `_meta` is shared real estate (it also carries
@@ -682,7 +684,10 @@ export function validateMetaStructure(
   policy: MetaPolicy = 'strict'
 ): { valid: boolean; reason?: string; extraKeys?: string[] } {
   const extraKeys = Object.keys(meta).filter(
-    k => k !== KYA_OS_PROOF_META_KEY && k !== LEGACY_PROOF_META_KEY,
+    k =>
+      k !== KYA_OS_PROOF_META_KEY &&
+      k !== LEGACY_NAMESPACED_PROOF_META_KEY &&
+      k !== LEGACY_PROOF_META_KEY,
   );
 
   // allow-extensions surfaces coexisting keys; strict discards them. Neither
@@ -706,10 +711,13 @@ export function extractProofFromMeta(
   meta: Record<string, unknown>,
   policy: MetaPolicy = 'strict'
 ): { success: true; proof: DetachedProof } | { success: false; reason: string; errorCode: string } {
-  // Check for the proof field first. Prefer the namespaced key; fall back to
-  // the legacy bare key for back-compat. When both are present the namespaced
-  // key wins (SPEC §7.6).
-  const proof = meta[KYA_OS_PROOF_META_KEY] ?? meta[LEGACY_PROOF_META_KEY];
+  // Check for the proof field first. Prefer the canonical role-named key,
+  // then the prior namespaced key, then the legacy bare key — the newest
+  // canonical form wins when several are present (SPEC §7.6).
+  const proof =
+    meta[KYA_OS_PROOF_META_KEY] ??
+    meta[LEGACY_NAMESPACED_PROOF_META_KEY] ??
+    meta[LEGACY_PROOF_META_KEY];
   if (!proof) {
     return {
       success: false,


### PR DESCRIPTION
Closes the blocking finding from the second-round submission reviews: MCP's `_meta` key grammar (identical in 2025-11-25 and the final 2026-07-28 text) permits only alphanumerics, hyphens, underscores, and dots in a key's name segment - no `@` - so `_meta["org.kya-os/proof@1"]` was never a legal carrier key. It works today only because nothing validates `_meta` key names; any future strict validation would break it silently.

The fix preserves the separate-keys design settled in the earlier TAAWG review: the carrier becomes `org.kya-os/proof.v1` (the profile id's key-safe form), while `org.kya-os/proof@1` stays byte-identical everywhere it is a value (`prf`, `proofProfiles`, the card's `proofProfile`, `error.data.profile`). The carrier key never enters signed material (`requestHash` strips `params._meta`; covered claims exclude the carrier), so no signatures, vectors, or cross-language parity artifacts change, and per the live audit nothing deployed emits the old key yet.

Compatibility: verifiers dual-read for one major version (canonical first, the earlier draft key as fallback, canonical wins when both are present); producers emit only the canonical key. `readCardProof` implements the window, a new `LEGACY_CARD_PROOF_META_KEY` constant names the old key, and a new test file pins four things: the canonical key is grammar-legal, the old one is not, the fallback works, and canonical wins.

Spec text moves together with the code: Entity Card §8.1 (with the grammar rationale), §14.1, §15.5, the Status paragraph, and Appendix D.2, plus SPEC-MCP-EXTENSION's surface table, key registry, negotiation example, and placement rule.

The staged submission package (#143) cites the old key in four places; a follow-up commit there sweeps them once this merges, per the reviewer's sequencing (governing specs and module first, then the submission mirrors).

Validation: typecheck and lint clean, full suite green with the new compat tests, conformance 44/44.

---

**Second rename in the same window (working-group direction):** the response-proof carrier moves `org.kya-os/proof` → `org.kya-os/response-proof`. Sitting next to the request proof's `org.kya-os/proof.v1`, the old name read as the unversioned parent of one lineage when the two keys carry different objects in different directions - the exact confusion the earlier review's F11 finding flagged. Renaming by role dissolves it permanently, and this is the last cheap moment: the key is pure carriage, `proofMetaKey` is configurable by design, adoption is pre-1.0, and SPEC.md §7.6's editorial note still marks the key proposed. Verifiers dual-read three keys for one major version (newest canonical wins: `response-proof` → `org.kya-os/proof` → bare `proof`); producers emit canonical and may mirror. The Entity Card §14.1 registry now records the response role directly, which also closes the pending dual-role amendment the binding document had flagged. New compat suite covers grammar, both fallbacks, and precedence; full suite and 44/44 conformance green.