### PR TITLE
spec: close the identifier editorial notes

### DIFF
--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -3,7 +3,7 @@
 **`org.kya-os/decentralized-authority`: agent delegation and per-request proof as an MCP 2026-07-28 extension**
 
 Version: 1.0.0-draft
-Status: Draft (extension id proposed, pending DIF TAAWG ratification)
+Status: Draft
 Editors: KYA-OS Working Group
 Repository: https://github.com/decentralized-identity/kya-os-mcp
 Binds: the KYA-OS Protocol Specification ([SPEC.md](./SPEC.md)) and the Entity Card profile ([SPEC-ENTITY-CARD.md](./SPEC-ENTITY-CARD.md)) to the Model Context Protocol Extensions framework (SEP-2133)
@@ -39,8 +39,7 @@ org.kya-os/decentralized-authority
 The vendor prefix `org.kya-os` is the reverse-DNS form of `kya-os.org`, which the KYA-OS project controls.
 The identifier follows the SEP-2133 `{vendor-prefix}/{extension-name}` form.
 The name states the extension's distinguishing property: the authority it conveys (identity, delegation chains, per-request proofs, and their audit trail) verifies locally from signed artifacts, with no round trip to a central authorization service (§13.2).
-
-> **Editorial note - open for discussion.** The extension id `org.kya-os/decentralized-authority` is **proposed** and not yet ratified by the DIF Trusted AI Agents Working Group (TAAWG); it remains open for working-group discussion and MAY change before this revision is finalized (see SPEC.md §7.6 and §15.2).
+The identifier was settled in DIF TAAWG discussion (2026-07-28).
 
 ### 1.2 Versioning
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1017,13 +1017,6 @@ that if and when KYA-OS is registered as an MCP Extension (SEP-2133), its
 reverse-DNS extension id — and hence this key — can be re-pointed without a wire
 change.
 
-> **Editorial note — open for discussion.** The reverse-DNS key `org.kya-os/response-proof`
-> (and the corresponding proposed MCP Extension id `org.kya-os/decentralized-authority`; see
-> §15.2) are **proposed** and not yet ratified. They remain open for
-> working-group discussion and MAY change before this revision is finalized.
-> Because the key is configurable (above), pinning the final id later does not
-> require a code change.
-
 **Backward compatibility.** Two prior keys carried this proof: bare `proof`
 (pre-1.1) and `org.kya-os/proof` (1.1 until the role-named rename). For one
 major version, verifiers MUST also accept a proof published under either prior
@@ -1612,11 +1605,6 @@ KYA-OS is designed to layer cleanly on the MCP 2026-07-28 Release Candidate.
   `proofMetaKey`) and capability advertisement (§10) will use that extension id;
   the key is configurable for this reason. KYA-OS targets the SEP-2133
   Standards-Track path.
-
-  > **Editorial note — open for discussion.** The extension id `org.kya-os/decentralized-authority`
-  > and the proof key `org.kya-os/response-proof` (§7.6) are **proposed** and not yet
-  > ratified; both remain open for working-group discussion and MAY change before
-  > this revision is finalized.
 - **Deprecations are zero-impact.** SEP-2577 deprecates MCP **Roots**, **Sampling**,
   and **Logging** on 12-month windows. KYA-OS uses **none** of these features, so
   the deprecations have **no impact** on KYA-OS implementations.


### PR DESCRIPTION
Removes the three "proposed - open for discussion" editorial notes (SPEC.md §7.6, §15.2; SPEC-MCP-EXTENSION.md §1.1) now that the identifiers they held open are settled: the TAAWG session of 2026-07-28 landed `org.kya-os/decentralized-authority`, and the carrier keys (`org.kya-os/proof.v1`, `org.kya-os/response-proof`) were fixed in #146's series.

This PR is deliberately single-purpose so that merging it **is** the working-group's closure act for those notes - the identifier decision gets its own reviewable artifact instead of riding a mechanical rename. Stacked on #146; it retargets to main automatically once #146 merges.

No normative behavior changes: the configurability language stays (graduation re-pointing remains a config change), and the spec's overall ratification-review Status is untouched - only the per-identifier hedges come out.