### PR TITLE
fix!: terminal proof naming - role-named keys, version only in the profile

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -416,7 +416,7 @@ so it is reproducible against any implementation without re-signing.
 | `vectors/status-list.json` | StatusList2021 revocation | active (bit unset) | revoked (bit set) |
 | `vectors/did-key-resolution.json` | did:key resolution | valid Ed25519 | malformed multibase, wrong method |
 | `vectors/did-web-resolution.json` | did:web resolution | well-formed id-matched document | document id mismatch, not found |
-| `vectors/card-proof.json` | `org.kya-os/proof@1` holder-of-key proof | valid signed proof, in-window, audience-bound | tampered body, tampered signature, wrong audience, expired, kid⇄did forgery |
+| `vectors/card-proof.json` | `org.kya-os/proof.v1` holder-of-key proof | valid signed proof, in-window, audience-bound | tampered body, tampered signature, wrong audience, expired, kid⇄did forgery |
 | `vectors/entity-card.json` | Entity Card `parseCard` + `verifyCard` | golden card per `entityType`, accountable agent | malformed (unknown field), broken accountability JOIN |
 | `vectors/audit-integrity.json` | Audit JCS + domain-separated hashing + RFC 9162 | fixed Unicode event, leaf/root, inclusion and consistency paths | mutated event/proof relationships are exercised by the audit unit suites |
 
@@ -468,7 +468,7 @@ const myAdapter: ConformanceAdapter = {
   async verifyStatusList(input)       { /* ... */ },
   async resolveDidKey(input)          { /* ... */ },
   async resolveDidWeb(input)          { /* ... */ },
-  async verifyCardProof(input)        { /* org.kya-os/proof@1 holder-of-key proof */ },
+  async verifyCardProof(input)        { /* org.kya-os/proof.v1 holder-of-key proof */ },
   async verifyEntityCard(input)       { /* parseCard + verifyCard */ },
   async verifyAuditIntegrity(input)   { /* JCS event digest + RFC 9162 proofs */ },
 };
@@ -514,12 +514,12 @@ The Entity Card is a **distinct, newer layer** on top of the Level 1–3 ladder 
 a typed, DID-anchored card plus a stateless, sender-constrained per-request proof.
 It is orthogonal to the legacy session-bound proof — the two coexist, each under
 its OWN distinct `_meta` key (`_meta['org.kya-os/proof']` for the legacy
-session-bound proof, `_meta['org.kya-os/proof@1']` for the stateless card proof),
+session-bound proof, `_meta['org.kya-os/proof.v1']` for the stateless card proof),
 and each verifier reads its own key and ignores the other. Its
 conformance vectors live in the SAME harness under two categories, wired to the two
 adapter methods `verifyCardProof` and `verifyEntityCard`.
 
-### `card-proof` — the `org.kya-os/proof@1` holder-of-key proof
+### `card-proof` — the `org.kya-os/proof.v1` holder-of-key proof
 
 `vectors/card-proof.json` carries fully-formed, pre-signed proofs. Each vector's
 `input` is self-contained: the proof object, the `request` it binds, the DID-keyed
@@ -566,7 +566,7 @@ onto the same ladder:
 
 `conformance/verify.py` is the **second-language complement** to the adapter contract:
 a pure-Python-stdlib re-implementation that shares no code with the TypeScript
-reference. It verifies the positive `org.kya-os/proof@1` vector and independently
+reference. It verifies the positive `org.kya-os/proof.v1` vector and independently
 re-derives the audit event's RFC 8785 bytes, domain-separated digest, RFC 9162
 root, inclusion path, and consistency path. Ed25519 uses the RFC 8032 reference
 without `pip install`.
@@ -580,7 +580,7 @@ Expected output:
 
 ```
 KYA-OS cross-language verifier (Python 3.x, stdlib-only)
-  proof: org.kya-os/proof@1  did: did:web:example.com:agents:acme-pay
+  proof: org.kya-os/proof.v1  did: did:web:example.com:agents:acme-pay
   [PASS] requestHash JCS+SHA-256 recompute
   [PASS] detached EdDSA JWS over JCS(coveredClaims)
   [PASS] RFC 9421 httpSig over the signature base

--- a/SPEC-ENTITY-CARD.md
+++ b/SPEC-ENTITY-CARD.md
@@ -18,7 +18,7 @@ the discovery rails the agent ecosystem already indexes: the MCP `server.json` /
 `_meta`, the A2A `AgentExtension`, and the NANDA `AgentFacts` document. Each projection points
 back to the same card, anchored by a `KyaOsEntityCard` service entry on the entity's `did:web`
 DID document. On top of that discovery layer rides a per-request, sender-constrained
-holder-of-key proof (`org.kya-os/proof@1`) carried under its own `_meta["org.kya-os/proof.v1"]`
+holder-of-key proof (`org.kya-os/proof.v1`) carried under its own `_meta["org.kya-os/request-proof"]`
 key: discover like everyone, prove like no one. An unaware peer safely ignores the KYA-OS layer;
 a KYA-OS-aware peer can verify the caller cryptographically on every request.
 
@@ -50,9 +50,9 @@ as the reference implementation (§15.6).
 
 This is a **DIF TAAWG work item** with a conformant **reference implementation** in
 `@kya-os/mcp` (v1.10.x at the time of writing). The Entity Card profile is additive over, and
-non-breaking with respect to, the KYA-OS 1.x protocol. The `org.kya-os/proof@1` profile defined
+non-breaking with respect to, the KYA-OS 1.x protocol. The `org.kya-os/proof.v1` profile defined
 here coexists with the legacy session-bound proof, and each rides its own `_meta` key:
-`org.kya-os/proof.v1` for this profile, `org.kya-os/response-proof` for the response proof (§8.1, §15.5). The
+`org.kya-os/request-proof` for this profile, `org.kya-os/response-proof` for the response proof (§8.1, §15.5). The
 card proof additionally names its profile in a `prf` field. The wire shapes in §3–§8 and
 Appendix A are stable for the 1.x line; a breaking change requires a major version bump.
 
@@ -90,7 +90,7 @@ This document specifies, normatively:
 - **anchoring** on `did:web` / `did:key` and the `KyaOsEntityCard` DID-document service (§5);
 - the four **discovery projections** and their graceful-degradation contract (§6);
 - the **CIMD on-ramp** binding `client_id ⇄ did:web`, `jwks_uri ⇄ DID keys` (§7);
-- the **per-request holder-of-key proof** `org.kya-os/proof@1`, its dual carrier, and the
+- the **per-request holder-of-key proof** `org.kya-os/proof.v1`, its dual carrier, and the
   `cnf.jkt` sender-constraint fusion (§8);
 - the **conformance ladder** L1/L2/L3 and its recompute-on-verify algorithm (§9);
 - the **accountability joins and revocation binding** Card verification consumes (§10); the
@@ -134,7 +134,7 @@ connects the two claims, from the L1 token to the L3 per-request proof, through 
 | **Principal** | The **immediate** delegator - typically the authorizing human - when it differs from the Responsible Party. Carried as `principal`. |
 | **Delegation Chain** | An ordered sequence of `DelegationCredential`s from the root delegator to the current Entity, each hop's delegate being the next hop's issuer (§10.1). |
 | **Capability** (Card field) | A declared operation NAME: what an Entity says it can do. Declaring one conveys no authority - authority is conveyed only by a delegation chain (§10), where the ZCAP-LD capability (the signed credential) is the authority object. A bare string is L1 (self-declared); an object `{ name, attestations }` is L2 (attested by a Verifiable Credential) (§4.1, §9). |
-| **Holder-of-Key Proof** | The per-request, sender-constrained `org.kya-os/proof@1` object (§8) that proves the caller currently controls the DID key bound to the Card. |
+| **Holder-of-Key Proof** | The per-request, sender-constrained `org.kya-os/proof.v1` object (§8) that proves the caller currently controls the DID key bound to the Card. |
 | **Audience** | The intended recipient of a proof - the recipient Entity's DID, read from its Card. Binds a proof to THIS recipient (anti-relay / anti-confused-deputy, §8.4). |
 | **`cnf.jkt`** | An RFC 7638 [RFC7638] JWK thumbprint used as an RFC 9449 [RFC9449] confirmation-key sender-constraint. The fusion anchor of §8.6. |
 | **CIMD** | Client ID Metadata Document (draft-ietf-oauth-client-id-metadata-document / SEP-991): the OAuth `client_id` is an HTTPS URL that serves the client's metadata. The KYA-OS L1 on-ramp (§7). |
@@ -215,7 +215,7 @@ top-level properties.
 | `delegationRef` | string | MAY | Locator for the signed delegation chain backing `responsibleParty`/`principal` (e.g. `vc_root>del_123`, hops joined by `>`); resolved, not inlined. |
 | `attestations` | array of `{type: "IdentityVerification"\|"CapabilityAttestation", vc, subject?, issuer?}` | MAY | Resolvable, signed credentials about the Entity or its `responsibleParty` (e.g. KYC/KYB). |
 | `didDocument` | string | MAY | URL of the DID document (for `did:web`, otherwise derivable, §5.3). |
-| `proofProfile` | literal `"org.kya-os/proof@1"` | MAY | Names the per-request proof profile the Entity's requests carry (§8). The proof itself is NEVER on the Card. |
+| `proofProfile` | literal `"org.kya-os/proof.v1"` | MAY | Names the per-request proof profile the Entity's requests carry (§8). The proof itself is NEVER on the Card. |
 | `cimd` | `{clientId, jwksUri}` | MAY | CIMD on-ramp coordinates (§7). |
 | `revocation` | `{statusListCredential, statusListIndex}` | MAY | W3C Bitstring Status List v1.0 entry for the Card's backing credential (§10.3). |
 
@@ -307,7 +307,7 @@ The value under the reverse-DNS key `org.kya-os/card` is EITHER an inline **clai
 
 ```json
 { "org.kya-os/card": { "id": "did:web:…", "entityType": "agent", "name": "…",
-  "capabilities": ["…"], "responsibleParty": "did:web:…", "proofProfile": "org.kya-os/proof@1" } }
+  "capabilities": ["…"], "responsibleParty": "did:web:…", "proofProfile": "org.kya-os/proof.v1" } }
 ```
 
 OR a lazy-fetch reference `{ "org.kya-os/card": { "org.kya-os/cardRef": "<https card.json>" } }`.
@@ -326,7 +326,7 @@ fail closed. The entry occupies `AgentCard.capabilities.extensions[]`:
   "description": "KYA-OS typed DID-anchored holder-of-key identity",
   "required": false,
   "params": { "id": "did:web:…", "entityType": "agent",
-    "cardUrl": "https://host/{path}/card.json", "proofProfile": "org.kya-os/proof@1" } }
+    "cardUrl": "https://host/{path}/card.json", "proofProfile": "org.kya-os/proof.v1" } }
 ```
 
 The extension version is pinned **in the URI**. `required: false` (the default) IS the
@@ -342,7 +342,7 @@ the uniquely-KYA-OS axes live under a `kya:` JSON-LD `@context`:
 { "@context": { "kya": "https://kya-os.org/ns/agentfacts/v1#" },
   "id": "did:web:…", "agent_name": "…", "kya:entityType": "agent",
   "owner": "did:web:…", "capabilities": ["…"],
-  "kya:conformanceLevel": "L2", "kya:proofProfile": "org.kya-os/proof@1",
+  "kya:conformanceLevel": "L2", "kya:proofProfile": "org.kya-os/proof.v1",
   "kya:delegationRef": "vc_root>del_123" }
 ```
 
@@ -444,8 +444,8 @@ emit `cnf`, verification degrades to **L3-minus** (§8.6, §9.4) rather than fai
 
 ## 8. Per-Request Holder-of-Key Proof (NORMATIVE) [TAAWG-NORMATIVE]
 
-`org.kya-os/proof@1` is a **self-contained**, **sender-constrained**, fail-closed proof that rides
-its own `_meta["org.kya-os/proof.v1"]` key. There is no session establishment and no handshake;
+`org.kya-os/proof.v1` is a **self-contained**, **sender-constrained**, fail-closed proof that rides
+its own `_meta["org.kya-os/request-proof"]` key. There is no session establishment and no handshake;
 every request carries its own proof.
 
 A note on the word "stateless", which earlier drafts used for this profile: the proof *object* is
@@ -460,27 +460,30 @@ stateless proof construction, never stateless verification.
 Two orthogonal proof profiles may appear on one server, each under its OWN `_meta` key: the
 **legacy session-bound** `ProofMeta` (carrying `sessionId` + a handshake nonce; retained untouched
 for 1.x back-compat) under `_meta["org.kya-os/response-proof"]` (previously `org.kya-os/proof`,
-read-accepted for one major version per SPEC.md §7.6), and the **self-contained** `org.kya-os/proof@1`
-specified here under `_meta["org.kya-os/proof.v1"]` - the profile id itself is not a legal `_meta`
-key name under MCP's key grammar (a name segment permits only alphanumerics, hyphens, underscores,
-and dots - no `@`), so the carrier key is the profile id's key-safe form, versioned with `.v1`. Distinct keys let both regimes coexist without either guard seeing -
+read-accepted for one major version per SPEC.md §7.6), and the **self-contained** `org.kya-os/proof.v1`
+specified here under `_meta["org.kya-os/request-proof"]` - the carrier key names the slot by role,
+pairing with the response proof's `org.kya-os/response-proof`, and the profile VERSION lives inside
+the object, in its `prf` field. Keys carry no versions and no `@` (which MCP's `_meta` key grammar
+forbids in a name segment anyway). Distinct keys let both regimes coexist without either guard seeing -
 or rejecting - the other's proof (a shared key made them mutually exclusive: a legacy proof failed
 the card schema and a card proof failed the legacy structure check). A Verifier reads the key for
 the profile it implements; the object still carries `prf` as a self-describing discriminator. This
-document specifies only `org.kya-os/proof@1`.
+document specifies only `org.kya-os/proof.v1`.
 
-**Backward compatibility (carrier key).** Earlier drafts used the profile id verbatim as the
-carrier key (`_meta["org.kya-os/proof@1"]`). For one major version, Verifiers MUST also accept a
-proof under that legacy key; producers MUST emit the canonical `org.kya-os/proof.v1` and,
-when targeting verifiers older than this revision, MAY additionally mirror the proof under the
-legacy key (the same one-major-version mirroring allowance as SPEC.md §7.6). When both keys are
-present, the canonical key wins.
+**Backward compatibility (carrier key and profile id).** The earlier draft used one string,
+`org.kya-os/proof@1`, as both the carrier key and the `prf` profile id. For one major version,
+Verifiers MUST accept a proof under that legacy key and MUST accept that legacy `prf` value (the
+covered claims are recomputed from the received object, so legacy-profile signatures verify
+unchanged); producers emit the canonical `org.kya-os/request-proof` key and `org.kya-os/proof.v1`
+profile id, and MAY additionally mirror the proof under the legacy key when targeting verifiers
+older than this revision (the same one-major-version allowance as SPEC.md §7.6). When both keys
+are present, the canonical key wins.
 
 ### 8.2 Object
 
 ```jsonc
 {
-  "prf": "org.kya-os/proof@1",           // profile discriminator (literal)
+  "prf": "org.kya-os/proof.v1",           // profile discriminator (literal)
   "alg": "EdDSA",                         // "EdDSA" (Ed25519) | "ES256" (P-256) - allow-list, no negotiation
   "did": "did:web:…",                     // caller DID (the accountable principal)
   "kid": "did:web:…#key-1",               // signing key id; kid.split('#')[0] MUST == did
@@ -602,7 +605,7 @@ integrator who intended L3 observe the downgrade rather than have it pass silent
 
 ### 8.8 Relationship to RFC 9449 (DPoP)
 
-`org.kya-os/proof@1` is a per-request proof-of-possession mechanism and it deliberately overlaps with
+`org.kya-os/proof.v1` is a per-request proof-of-possession mechanism and it deliberately overlaps with
 DPoP [RFC9449]: both bind a fresh, short-lived proof to every request, both carry a nonce and a
 validity window, and both express the sender-constraint as an RFC 7638 [RFC7638] `cnf.jkt` thumbprint.
 This profile does **not** aim to replace DPoP. Where an authorization server issues DPoP-sender-
@@ -669,7 +672,7 @@ implementation MUST derive the level per §9.4 / §11.1 step 7, not from this pr
 
 ### 9.3 L3 - live per-request proof-of-possession
 
-Evidence: L2 **plus** a valid sender-constrained `org.kya-os/proof@1` (§8) - `audience` === self,
+Evidence: L2 **plus** a valid sender-constrained `org.kya-os/proof.v1` (§8) - `audience` === self,
 nonce fresh, `requestHash` recomputes, and the `cnf.jkt` fusion when the AS supplies a token `cnf`
 (this is the proof floor that lifts the level to L3) - **plus** a LIVE Bitstring Status List
 freshness check on the leaf delegation/capability credentials. The leaf-invoker === `proof.did`
@@ -960,7 +963,7 @@ redirects, size/time caps. Residual: standard transport-layer DoS is out of scop
 |-----|---------|---------|
 | `org.kya-os/card` | inline Card summary or a `cardRef` on MCP `server.json`/`catalog.json` | §6.1 |
 | `org.kya-os/cardRef` | a lazy-fetch `card.json` URL (inside `org.kya-os/card`) | §6.1 |
-| `org.kya-os/proof.v1` | the self-contained per-request holder-of-key proof (§8); the key-safe carrier of the `org.kya-os/proof@1` profile (the legacy key `org.kya-os/proof@1` is accepted for one major version) | §8 |
+| `org.kya-os/request-proof` | the self-contained per-request holder-of-key proof (§8), carrying the `org.kya-os/proof.v1` profile (the legacy key and `prf` value `org.kya-os/proof@1` are accepted for one major version) | §8 |
 | `org.kya-os/response-proof` | the detached response proof (`ProofMeta`, SPEC.md §7), including the legacy session-bound era; previously `org.kya-os/proof`, read-accepted for one major version | §8.1 |
 | `org.kya-os/did` | the Entity's DID inside a CIMD document | §7.3 |
 
@@ -1027,8 +1030,8 @@ with either primitive this document marks for ratification.
 
 ANP (Agent Network Protocol) is an informative peer in the discovery-rail landscape. Within KYA-OS,
 the **legacy session-bound proof** (`ProofMeta` with `sessionId` + handshake nonce) under
-`_meta["org.kya-os/response-proof"]` coexists with `org.kya-os/proof@1` under its own distinct
-`_meta["org.kya-os/proof.v1"]` key (§8.1); it is retained unchanged for the 1.x line and is expected
+`_meta["org.kya-os/response-proof"]` coexists with `org.kya-os/proof.v1` under its own distinct
+`_meta["org.kya-os/request-proof"]` key (§8.1); it is retained unchanged for the 1.x line and is expected
 to be deprecated at 2.0 in favour of the self-contained profile.
 
 ### 15.6 Governance - standardize exactly two primitives
@@ -1089,7 +1092,7 @@ Golden, `parseCard`-valid Cards, one per type (full fixtures: the `entity-card` 
 **`mcp`**
 ```json
 { "id": "did:web:example.com:mcp:server", "entityType": "mcp", "name": "Acme MCP Server",
-  "capabilities": ["tools/list", "tools/call"], "proofProfile": "org.kya-os/proof@1" }
+  "capabilities": ["tools/list", "tools/call"], "proofProfile": "org.kya-os/proof.v1" }
 ```
 
 **`agent`** (L2 attested capability + accountability + revocation)
@@ -1101,14 +1104,14 @@ Golden, `parseCard`-valid Cards, one per type (full fixtures: the `entity-card` 
   "responsibleParty": "did:web:api.example",
   "principal": "did:web:example.com:users:alice",
   "delegationRef": "urn:zcap:root>urn:zcap:del1",
-  "proofProfile": "org.kya-os/proof@1",
+  "proofProfile": "org.kya-os/proof.v1",
   "revocation": { "statusListCredential": "https://example.com/status/cards", "statusListIndex": "3" } }
 ```
 
 **`client`** (CIMD on-ramp)
 ```json
 { "id": "did:web:app.example:clients:acme-cli", "entityType": "client", "name": "Acme CLI",
-  "proofProfile": "org.kya-os/proof@1",
+  "proofProfile": "org.kya-os/proof.v1",
   "cimd": { "clientId": "https://app.example/clients/acme-cli",
     "jwksUri": "https://app.example/clients/acme-cli/jwks.json" } }
 ```
@@ -1143,7 +1146,7 @@ reuse them.
 
 | Vector file | Contents |
 |-------------|----------|
-| `conformance/vectors/card-proof.json` | Signed `org.kya-os/proof@1` proofs + their RFC 9421 siblings, each carrying its request, the DID-keyed JWKS (`input.jwks`), audience, and window. One positive vector + five negatives (tampered body, tampered signature, wrong audience, expired, kid⇄did forgery). |
+| `conformance/vectors/card-proof.json` | Signed `org.kya-os/proof.v1` proofs + their RFC 9421 siblings, each carrying its request, the DID-keyed JWKS (`input.jwks`), audience, and window. One positive vector + five negatives (tampered body, tampered signature, wrong audience, expired, kid⇄did forgery). |
 | `conformance/vectors/entity-card.json` | Golden `parseCard`-valid Cards, one per `entityType`, plus the multi-hop VC 2.0 + ZCAP-LD delegation chain (attenuation invariants; leaf invoker === proof `did`) carried by the agent accountability vector. |
 | `conformance/card-vectors.ts` | Deterministic regenerator (TypeScript). |
 | `conformance/verify.py` | The INDEPENDENT cross-language verifier (pure Python stdlib). |
@@ -1161,7 +1164,7 @@ reuse them.
 
 ```
 KYA-OS cross-language verifier (Python 3.x, stdlib-only)
-  proof: org.kya-os/proof@1  did: did:web:example.com:agents:acme-pay
+  proof: org.kya-os/proof.v1  did: did:web:example.com:agents:acme-pay
   [PASS] requestHash JCS+SHA-256 recompute
   [PASS] detached EdDSA JWS over JCS(coveredClaims)
   [PASS] RFC 9421 httpSig over the signature base
@@ -1207,7 +1210,7 @@ Codes are snake_case, aligned to the implementation.
 
 | Code | Meaning |
 |------|---------|
-| `proof_missing` | No `org.kya-os/proof.v1` (or legacy `org.kya-os/proof@1`) in `_meta`. |
+| `proof_missing` | No `org.kya-os/request-proof` (or legacy `org.kya-os/proof@1`) in `_meta`. |
 | `proof_invalid` | The holder-of-key proof did not verify. |
 | `proof_level_insufficient` | The proof assurance is below the required `minLevel`. |
 

--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -61,7 +61,7 @@ Re-keying of the `_meta` registry entries (§2.2) would be specified by a succes
 | Surface | Mechanism | Defined in |
 |---|---|---|
 | Capability negotiation | `capabilities.extensions["org.kya-os/decentralized-authority"]` settings object | §3 (this document) |
-| Request proof | `_meta["org.kya-os/proof.v1"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
+| Request proof | `_meta["org.kya-os/request-proof"]` per-request holder-of-key proof | SPEC-ENTITY-CARD §8 |
 | Response proof / audit | `_meta["org.kya-os/response-proof"]` detached response proof | SPEC.md §7 |
 | Consent step-up | signed `needs_authorization` challenge | SPEC.md §9 |
 | Delegated authority | W3C VC delegation chains, referenced via `delegationRef` | SPEC.md §6, §6.10 |
@@ -77,13 +77,35 @@ The reverse-DNS `_meta` keys used by this extension are the keys registered in S
 
 | Key | Carries | Direction |
 |---|---|---|
-| `org.kya-os/proof.v1` | the self-contained per-request holder-of-key proof of the `org.kya-os/proof@1` profile (SPEC-ENTITY-CARD §8; the legacy `org.kya-os/proof@1` key is accepted for one major version) | request (caller to server) |
+| `org.kya-os/request-proof` | the self-contained per-request holder-of-key proof of the `org.kya-os/proof.v1` profile (SPEC-ENTITY-CARD §8; the legacy key and `prf` value `org.kya-os/proof@1` are accepted for one major version) | request (caller to server) |
 | `org.kya-os/response-proof` | the detached response proof (SPEC.md §7), including signed `needs_authorization` challenges; previously `org.kya-os/proof`, read-accepted for one major version | response (server to caller) |
 | `org.kya-os/card` (and nested `org.kya-os/cardRef`) | inline Entity Card summary or lazy card reference on discovery documents | discovery |
 | `org.kya-os/did` | the Entity's DID inside a CIMD document | discovery |
 
 These keys coexist with the MCP-reserved `io.modelcontextprotocol/*` keys and the W3C Trace Context keys (`traceparent`, `tracestate`, `baggage`) under the coexistence rules of SPEC.md §7.6.
 A KYA-OS verifier MUST NOT reject a message because `_meta` carries foreign namespaced keys, and MUST NOT include any non-KYA-OS `_meta` key in a hash or signature computation (SPEC.md §7.6).
+
+The full request cycle, including the consent step-up that issues a delegation credential:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (MCP client)
+    participant S as MCP Server (verifier)
+    participant AS as Authorization Service
+
+    Note over A: holds DID key + delegation credential
+    A->>S: request + _meta: capability declaration<br/>+ org.kya-os/request-proof (profile proof.v1)
+    Note over S: declared? (required mode: -32021 if not)<br/>verify fail-closed: kid⇄did, audience,<br/>requestHash, window, nonce, signature<br/>designated scope ∈ delegation
+    alt delegation sufficient
+        S-->>A: result + org.kya-os/response-proof (signed receipt)
+    else insufficient delegation
+        S-->>A: signed needs_authorization challenge<br/>(responseHash binds authorizationUrl)
+        A->>AS: user grants at authorizationUrl
+        AS-->>A: issues delegation credential
+        A->>S: retry with resumeToken + credential
+        S-->>A: result + response-proof
+    end
+```
 
 ---
 
@@ -106,12 +128,12 @@ A client that supports this extension declares it inside that object's `extensio
         "extensions": {
           "org.kya-os/decentralized-authority": {
             "version": "1.0.0",
-            "proofProfiles": ["org.kya-os/proof@1"],
+            "proofProfiles": ["org.kya-os/proof.v1"],
             "didMethods": ["did:key", "did:web"]
           }
         }
       },
-      "org.kya-os/proof.v1": { "prf": "org.kya-os/proof@1", "...": "see SPEC-ENTITY-CARD §8.2" }
+      "org.kya-os/request-proof": { "prf": "org.kya-os/proof.v1", "...": "see SPEC-ENTITY-CARD §8.2" }
     }
   }
 }
@@ -127,7 +149,7 @@ A server declares the extension in the `capabilities.extensions` member of its `
     "extensions": {
       "org.kya-os/decentralized-authority": {
         "version": "1.0.0",
-        "proofProfiles": ["org.kya-os/proof@1"],
+        "proofProfiles": ["org.kya-os/proof.v1"],
         "didMethods": ["did:key", "did:web"],
         "required": true
       }
@@ -147,7 +169,7 @@ All members are OPTIONAL; per SEP-2133, an **empty object** (`{}`) means "suppor
 | Member | Type | Meaning |
 |---|---|---|
 | `version` | string (semver) | The extension-document version the peer implements. Default `"1.0.0"`. |
-| `proofProfiles` | array of strings | Proof profiles the peer can mint (client) or verify (server). Default `["org.kya-os/proof@1"]`. |
+| `proofProfiles` | array of strings | Proof profiles the peer can mint (client) or verify (server). Default `["org.kya-os/proof.v1"]`. |
 | `didMethods` | array of strings (`did:` method ids) | DID methods the peer uses (client) or resolves (server). Default `["did:key", "did:web"]`; `did:cheqd` is opt-in per SPEC.md §4.4.1. |
 | `required` | boolean | Server-side only: whether the server rejects requests from clients that do not declare this extension (§4). Default `false`. Clients MUST ignore this member if present on a client declaration. |
 
@@ -246,7 +268,7 @@ When a KYA-OS failure surfaces as a JSON-RPC error, the error's numeric `code` i
     "message": "KYA-OS proof required",
     "data": {
       "reason": "proof_missing",
-      "profile": "org.kya-os/proof@1"
+      "profile": "org.kya-os/proof.v1"
     }
   }
 }
@@ -265,10 +287,10 @@ Deployments that gate at an HTTP edge (SPEC.md §8.4) keep their HTTP semantics 
 
 ## 6. Request Proof Binding
 
-The request proof is `org.kya-os/proof@1`, specified normatively in SPEC-ENTITY-CARD §8 and verified per the exact fail-closed order of SPEC-ENTITY-CARD §11.2.
+The request proof is `org.kya-os/proof.v1`, specified normatively in SPEC-ENTITY-CARD §8 and verified per the exact fail-closed order of SPEC-ENTITY-CARD §11.2.
 The MCP-specific deltas are only these:
 
-1. **Placement.** The proof object rides `_meta["org.kya-os/proof.v1"]` inside `params` of the JSON-RPC request - the key-safe carrier of the `org.kya-os/proof@1` profile, the profile id itself not being a legal `_meta` key name (SPEC-ENTITY-CARD §8.1; the legacy `org.kya-os/proof@1` key is accepted for one major version).
+1. **Placement.** The proof object rides `_meta["org.kya-os/request-proof"]` inside `params` of the JSON-RPC request - the role-named carrier of the `org.kya-os/proof.v1` profile (SPEC-ENTITY-CARD §8.1; the legacy key and `prf` value `org.kya-os/proof@1` are accepted for one major version).
 2. **Request binding.** `requestHash` covers `{ method, params }` with `params._meta` removed (SPEC-ENTITY-CARD §8.3).
    Consequently an intermediary MAY add or rewrite `_meta` members (for example the required `io.modelcontextprotocol/*` keys) without invalidating the proof, and MUST NOT mutate `method` or any other part of `params` on a proof-bearing request, because any such mutation invalidates `requestHash`.
 3. **Transport agnosticism.** The proof is in-band JSON-RPC and verifies identically over stdio and Streamable HTTP; the OPTIONAL RFC 9421 sibling (SPEC-ENTITY-CARD §8.5) serves HTTP-edge intermediaries.
@@ -399,7 +421,7 @@ An honest comparison against composing DPoP (proof-of-possession), Workload Iden
 
 ### 13.3 Fit with the 2026-07-28 core
 
-The stateless core made per-request, self-contained verification the only identity model that works on any replica; that is what `org.kya-os/proof@1` already is.
+The stateless core made per-request, self-contained verification the only identity model that works on any replica; that is what `org.kya-os/proof.v1` already is.
 The deprecation of core Logging, alongside standardized trace-context `_meta`, moves audit concerns toward extensions; KYA-OS's proof and auditability layers (SPEC.md §7, §15.3) are that story for agent actions.
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -1009,9 +1009,9 @@ therefore namespaces its own payload and MUST NOT assume exclusive ownership of
 
 **Canonical key.** KYA-OS attaches its detached response proof under the
 reverse-DNS key `org.kya-os/response-proof` (the `proofMetaKey`). The key is
-named for its role so it cannot be misread as a version sibling of the request
-proof's `org.kya-os/proof.v1` (SPEC-ENTITY-CARD §8), which carries a different
-object. This key SHOULD be configurable (e.g., a
+named for its role, pairing with the request proof's `org.kya-os/request-proof`
+(SPEC-ENTITY-CARD §8); the two keys carry different objects, and neither carries
+a version - the request proof's profile version lives inside the object (`prf`). This key SHOULD be configurable (e.g., a
 single build-time constant rather than a value scattered through the code), so
 that if and when KYA-OS is registered as an MCP Extension (SEP-2133), its
 reverse-DNS extension id — and hence this key — can be re-pointed without a wire

--- a/conformance/card-fixtures.ts
+++ b/conformance/card-fixtures.ts
@@ -10,7 +10,7 @@
 
 import type { Ed25519PrivateJwk } from '../src/card/index.js';
 
-/** The signing key behind the golden `org.kya-os/proof@1` proof (TEST-ONLY). */
+/** The signing key behind the golden `org.kya-os/proof.v1` proof (TEST-ONLY). */
 export const ENTITY_KEY: Ed25519PrivateJwk = {
   kty: 'OKP',
   crv: 'Ed25519',
@@ -113,7 +113,7 @@ export const GOLDEN_CARDS = {
     entityType: 'mcp',
     name: 'Acme MCP Server',
     capabilities: ['tools/list', 'tools/call'],
-    proofProfile: 'org.kya-os/proof@1',
+    proofProfile: 'org.kya-os/proof.v1',
   },
   agent: {
     id: ENTITY_DID,
@@ -124,14 +124,14 @@ export const GOLDEN_CARDS = {
     responsibleParty: OWNER,
     principal: 'did:web:example.com:users:alice',
     delegationRef: 'urn:zcap:root>urn:zcap:del1',
-    proofProfile: 'org.kya-os/proof@1',
+    proofProfile: 'org.kya-os/proof.v1',
     revocation: { statusListCredential: 'https://example.com/status/cards', statusListIndex: '3' },
   },
   client: {
     id: 'did:web:app.example:clients:acme-cli',
     entityType: 'client',
     name: 'Acme CLI',
-    proofProfile: 'org.kya-os/proof@1',
+    proofProfile: 'org.kya-os/proof.v1',
     cimd: { clientId: 'https://app.example/clients/acme-cli', jwksUri: 'https://app.example/clients/acme-cli/jwks.json' },
   },
   verifier: {

--- a/conformance/card-vectors.ts
+++ b/conformance/card-vectors.ts
@@ -3,7 +3,7 @@
  * Deterministic generator for the Entity Card conformance vectors —
  * `conformance/vectors/card-proof.json` + `conformance/vectors/entity-card.json`.
  *
- * It signs the golden `org.kya-os/proof@1` proof (and the kid⇄did forgery) with the FIXED
+ * It signs the golden `org.kya-os/proof.v1` proof (and the kid⇄did forgery) with the FIXED
  * {@link ENTITY_KEY} at the FIXED {@link T0_MS} clock, so re-running reproduces
  * byte-identical files. Every negative variant is derived by surgical tampering or
  * a pinned mismatch, so the positive/negative relationships hold by construction.
@@ -37,7 +37,7 @@ import {
 
 const clock = (): number => T0_MS;
 
-/** Mint a signed `org.kya-os/proof@1` for {@link REQUEST} under the given identity. */
+/** Mint a signed `org.kya-os/proof.v1` for {@link REQUEST} under the given identity. */
 async function mintProof(opts: {
   did: string;
   kid: string;
@@ -91,7 +91,7 @@ export async function cardProofVectorFile(): Promise<VectorFile> {
     {
       id: 'card-proof/valid',
       category: 'card-proof',
-      description: 'A well-formed org.kya-os/proof@1 with a valid detached JWS, in-window and audience-bound',
+      description: 'A well-formed org.kya-os/proof.v1 with a valid detached JWS, in-window and audience-bound',
       expected: 'pass',
       reason: 'Every binding — signature, requestHash, audience, nonce, window, kid⇄did — holds',
       input: proofInput(valid),

--- a/conformance/reference-adapter.ts
+++ b/conformance/reference-adapter.ts
@@ -31,7 +31,7 @@ import {
 } from '../src/delegation/chain-enforcement.js';
 import { BitstringManager } from '../src/delegation/bitstring.js';
 import { ClockProvider, FetchProvider } from '../src/providers/base.js';
-// The Entity Card layer (`org.kya-os/proof@1` + the typed card) lives on the
+// The Entity Card layer (`org.kya-os/proof.v1` + the typed card) lives on the
 // `@kya-os/mcp/card` subpath, NOT the package root — wire its PUBLIC verify
 // primitives here exactly as the legacy ones above (no forked logic).
 import {

--- a/conformance/types.ts
+++ b/conformance/types.ts
@@ -19,7 +19,7 @@
  * The first five exercise the LEGACY session-bound primitives (detached
  * `ProofMeta`, `DelegationCredential` + StatusList2021, the DID resolvers). The
  * last two exercise the NEWER Entity Card layer — the stateless
- * `org.kya-os/proof@1` holder-of-key proof (`card-proof`) and the typed,
+ * `org.kya-os/proof.v1` holder-of-key proof (`card-proof`) and the typed,
  * DID-anchored card (`entity-card`) — which is a distinct, orthogonal profile.
  * `negotiation` exercises the MCP extension admission gate
  * (`org.kya-os/decentralized-authority`, SPEC-MCP-EXTENSION.md §3-§5).
@@ -135,7 +135,7 @@ export interface Ed25519PublicJwkLike {
 }
 
 /**
- * Input for the stateless Entity Card holder-of-key proof (`org.kya-os/proof@1`).
+ * Input for the stateless Entity Card holder-of-key proof (`org.kya-os/proof.v1`).
  * Carries the full, pre-signed proof plus the resolver material a verifier needs
  * to recompute every binding — the DID-keyed JWKS (the signer's public JWK[s]),
  * the recipient `expectedAudience`, and a pinned `now`/`skew` window. All fields
@@ -143,7 +143,7 @@ export interface Ed25519PublicJwkLike {
  */
 export interface CardProofInput {
   /**
-   * The `org.kya-os/proof@1` proof object: `{ prf, alg, did, kid, audience,
+   * The `org.kya-os/proof.v1` proof object: `{ prf, alg, did, kid, audience,
    * nonce, created, expires, requestHash, cnf?, jws, httpSig? }`.
    */
   proof: unknown;
@@ -277,7 +277,7 @@ export interface ConformanceAdapter {
   resolveDidWeb(input: DidResolutionInput): Promise<AdapterResult>;
 
   /**
-   * Verify a stateless `org.kya-os/proof@1` holder-of-key proof: recompute the
+   * Verify a stateless `org.kya-os/proof.v1` holder-of-key proof: recompute the
    * signature, `requestHash`, `audience`, nonce freshness, `created`/`expires`
    * window, the `kid`⇄`did` binding, and the DID-key membership.
    */

--- a/conformance/vectors/card-proof.json
+++ b/conformance/vectors/card-proof.json
@@ -5,12 +5,12 @@
     {
       "id": "card-proof/valid",
       "category": "card-proof",
-      "description": "A well-formed org.kya-os/proof@1 with a valid detached JWS, in-window and audience-bound",
+      "description": "A well-formed org.kya-os/proof.v1 with a valid detached JWS, in-window and audience-bound",
       "expected": "pass",
       "reason": "Every binding — signature, requestHash, audience, nonce, window, kid⇄did — holds",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -22,7 +22,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCQ",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {
@@ -59,7 +59,7 @@
       "reason": "requestHash no longer recomputes to the signed value — the body binding breaks",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -71,7 +71,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCQ",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {
@@ -108,7 +108,7 @@
       "reason": "A mutated signature must fail EdDSA verification over the covered claims",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -120,7 +120,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBA",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCA",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {
@@ -157,7 +157,7 @@
       "reason": "Audience binding (anti-relay / confused-deputy) must reject a mismatched recipient",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -169,7 +169,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCQ",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {
@@ -206,7 +206,7 @@
       "reason": "A stale proof outside created/expires (±skew) must fail closed (replay guard)",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -218,7 +218,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCQ",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {
@@ -255,7 +255,7 @@
       "reason": "kid⇄did binding (kid.split(\"#\")[0] === did) closes the forgeable-principal gap",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:victim.example",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -267,7 +267,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..mEbNlkKtsmKVULYOQIqs1FoJ3TvicWeAIwswNQmQxwhmQtdzqxyOchBOJquk-KvDvhyndjC9Wf8A5GtRD7nuCw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..DyXgfq3m_D2sKY4BzkGcXus9L79gjA9LDxUG8fU7vWrxgEPsqMkgRPBMJSyztMjA7gm8xAm38WEeXzisVIT3AQ",
           "httpSig": "EW8xp6SCcCAUPklsc_NhE_P9HpNLWd-85x6E3sUyT3X7R8S3Ti_t5EiExYXAdpRuMmC3ma8ySXgnGxqR6W2lDA"
         },
         "request": {
@@ -304,7 +304,7 @@
       "reason": "Without an atomic consumeNonceIfFresh seam there is no replay defense — fail closed (nonce_seam_missing)",
       "input": {
         "proof": {
-          "prf": "org.kya-os/proof@1",
+          "prf": "org.kya-os/proof.v1",
           "alg": "EdDSA",
           "did": "did:web:example.com:agents:acme-pay",
           "kid": "did:web:example.com:agents:acme-pay#key-1",
@@ -316,7 +316,7 @@
           "cnf": {
             "jkt": "0Z9PGGnrUbAvSHRWxKkBxjgrUrvu6ETEhOl2StPyW7c"
           },
-          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..NFt4aac7bm-dylDH3A08Fc4s2yPiDTTJ-2m08QZPlYPhv1cfayO2XciAEJHu_M4VfqqsGBm3pOCXm70Nmn2kBw",
+          "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZXhhbXBsZS5jb206YWdlbnRzOmFjbWUtcGF5I2tleS0xIn0..wmgkENimr6GhpCJkk7gvCo7Zwgi63-SKf5tcbbQ1rIjYCUiUkLwRmYFrdft1lQijKPS9Q99EFykFVdH0p3jsCQ",
           "httpSig": "iDE_f0kDMwJUAVxNngtbVNslLGF26Ie1SeJYt-nF-UuRV4D8VPzd2fGF43TnbtBryq3X7J2AuGClgc5tidzCDA"
         },
         "request": {

--- a/conformance/vectors/entity-card.json
+++ b/conformance/vectors/entity-card.json
@@ -17,7 +17,7 @@
             "tools/list",
             "tools/call"
           ],
-          "proofProfile": "org.kya-os/proof@1"
+          "proofProfile": "org.kya-os/proof.v1"
         }
       }
     },
@@ -32,7 +32,7 @@
           "id": "did:web:app.example:clients:acme-cli",
           "entityType": "client",
           "name": "Acme CLI",
-          "proofProfile": "org.kya-os/proof@1",
+          "proofProfile": "org.kya-os/proof.v1",
           "cimd": {
             "clientId": "https://app.example/clients/acme-cli",
             "jwksUri": "https://app.example/clients/acme-cli/jwks.json"
@@ -97,7 +97,7 @@
           "responsibleParty": "did:web:api.example",
           "principal": "did:web:example.com:users:alice",
           "delegationRef": "urn:zcap:root>urn:zcap:del1",
-          "proofProfile": "org.kya-os/proof@1",
+          "proofProfile": "org.kya-os/proof.v1",
           "revocation": {
             "statusListCredential": "https://example.com/status/cards",
             "statusListIndex": "3"
@@ -219,7 +219,7 @@
             "tools/list",
             "tools/call"
           ],
-          "proofProfile": "org.kya-os/proof@1",
+          "proofProfile": "org.kya-os/proof.v1",
           "bogusField": true
         }
       }
@@ -250,7 +250,7 @@
           "responsibleParty": "did:web:api.example",
           "principal": "did:web:example.com:users:alice",
           "delegationRef": "urn:zcap:root>urn:zcap:del1",
-          "proofProfile": "org.kya-os/proof@1",
+          "proofProfile": "org.kya-os/proof.v1",
           "revocation": {
             "statusListCredential": "https://example.com/status/cards",
             "statusListIndex": "3"

--- a/conformance/vectors/negotiation.json
+++ b/conformance/vectors/negotiation.json
@@ -9,7 +9,7 @@
       "expected": "pass",
       "reason": "A declared extension on an optional server is admitted with the extension active",
       "input": {
-        "serverSettings": { "version": "1.0.0", "proofProfiles": ["org.kya-os/proof@1"] },
+        "serverSettings": { "version": "1.0.0", "proofProfiles": ["org.kya-os/proof.v1"] },
         "request": {
           "method": "tools/call",
           "params": {
@@ -21,7 +21,7 @@
                 "extensions": {
                   "org.kya-os/decentralized-authority": {
                     "version": "1.0.0",
-                    "proofProfiles": ["org.kya-os/proof@1"],
+                    "proofProfiles": ["org.kya-os/proof.v1"],
                     "didMethods": ["did:key", "did:web"]
                   }
                 }
@@ -81,7 +81,7 @@
                 "extensions": {
                   "org.kya-os/decentralized-authority": {
                     "version": 1,
-                    "proofProfiles": "org.kya-os/proof@1"
+                    "proofProfiles": "org.kya-os/proof.v1"
                   }
                 }
               }

--- a/conformance/verify.py
+++ b/conformance/verify.py
@@ -2,7 +2,7 @@
 """KYA-OS Entity Card proof — INDEPENDENT cross-language conformance verifier.
 
 The second-language complement to the TypeScript `ConformanceAdapter` contract: a pure-Python-stdlib
-re-implementation of the `org.kya-os/proof@1` verification path that shares NO code with the reference
+re-implementation of the `org.kya-os/proof.v1` verification path that shares NO code with the reference
 adapter. It reads the SAME framework vector file the runner does (`conformance/vectors/card-proof.json`),
 selects the positive (`expected == "pass"`) vector, and against that self-contained artifact it re-derives
 the RFC 8785 (JCS) canonicalization, recomputes the SHA-256 `requestHash`, and verifies BOTH the detached

--- a/schemas/kya-os-card.schema.json
+++ b/schemas/kya-os-card.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.kya-os.org/v1/protocol/identity/card/v1.1.0",
   "title": "KYA-OS Entity Card",
-  "description": "A typed, DID-anchored identity card for a KYA-OS entity (mcp | agent | client | verifier | human). One canonical card is anchored by a `KyaOsEntityCard` service entry on the entity's did:web DID document and projected onto the four discovery surfaces the ecosystem already indexes (MCP server.json / catalog.json `_meta['org.kya-os/card']`, A2A AgentExtension, NANDA AgentFacts, and the MCP catalog entry). The card asserts identity + type + declared capabilities; everything trust-bearing (accountability, attested capabilities, KYC/KYB) is proven by referenced credentials, not self-claimed (claim-minimalism). The sender-constrained holder-of-key proof (`org.kya-os/proof@1`) is NEVER on the static card — it rides per-request `_meta` on top (see detached-proof); `proofProfile` only names the profile a verifier should expect.",
+  "description": "A typed, DID-anchored identity card for a KYA-OS entity (mcp | agent | client | verifier | human). One canonical card is anchored by a `KyaOsEntityCard` service entry on the entity's did:web DID document and projected onto the four discovery surfaces the ecosystem already indexes (MCP server.json / catalog.json `_meta['org.kya-os/card']`, A2A AgentExtension, NANDA AgentFacts, and the MCP catalog entry). The card asserts identity + type + declared capabilities; everything trust-bearing (accountability, attested capabilities, KYC/KYB) is proven by referenced credentials, not self-claimed (claim-minimalism). The sender-constrained holder-of-key proof (`org.kya-os/proof.v1`) is NEVER on the static card — it rides per-request `_meta` on top (see detached-proof); `proofProfile` only names the profile a verifier should expect.",
   "type": "object",
   "required": ["id", "entityType", "name"],
   "properties": {
@@ -69,8 +69,8 @@
       "description": "URL of the entity's DID document (the trust anchor for did:web; integrity derives from domain control). The DID document carries the `KyaOsEntityCard` service entry that anchors this card."
     },
     "proofProfile": {
-      "const": "org.kya-os/proof@1",
-      "description": "Names the per-request holder-of-key proof profile this entity's requests carry — the stateless, sender-constrained `org.kya-os/proof@1` envelope (distinct from the legacy session-bound ProofMeta). The proof itself is NEVER on this static card; it rides per-request `_meta`. This field only advertises the profile a verifier should expect."
+      "enum": ["org.kya-os/proof.v1", "org.kya-os/proof@1"],
+      "description": "Names the per-request holder-of-key proof profile this entity's requests carry — the stateless, sender-constrained `org.kya-os/proof.v1` envelope (distinct from the legacy session-bound ProofMeta). The proof itself is NEVER on this static card; it rides per-request `_meta`. This field only advertises the profile a verifier should expect."
     },
     "cimd": {
       "$ref": "#/$defs/CimdBinding",
@@ -234,7 +234,7 @@
       "name": "KYA-OS Inspector (dev)",
       "capabilities": ["handshake", "signing", "verification"],
       "conformanceLevel": "L1",
-      "proofProfile": "org.kya-os/proof@1"
+      "proofProfile": "org.kya-os/proof.v1"
     },
     {
       "id": "did:web:example.com:mcp:acme-search",
@@ -255,7 +255,7 @@
       "responsibleParty": "did:web:example.com:org:acme",
       "delegationRef": "vc_root>del_mcp",
       "didDocument": "https://example.com/mcp/acme-search/did.json",
-      "proofProfile": "org.kya-os/proof@1",
+      "proofProfile": "org.kya-os/proof.v1",
       "cimd": {
         "clientId": "https://example.com/mcp/acme-search",
         "jwksUri": "https://example.com/mcp/acme-search/jwks.json"
@@ -274,7 +274,7 @@
       "conformanceLevel": "L1",
       "responsibleParty": "did:web:example.com:org:acme",
       "didDocument": "https://example.com/clients/acme-cli/did.json",
-      "proofProfile": "org.kya-os/proof@1",
+      "proofProfile": "org.kya-os/proof.v1",
       "cimd": {
         "clientId": "https://example.com/clients/acme-cli",
         "jwksUri": "https://example.com/clients/acme-cli/jwks.json"

--- a/schemas/mcp-extension-settings.json
+++ b/schemas/mcp-extension-settings.json
@@ -13,11 +13,11 @@
     },
     "proofProfiles": {
       "type": "array",
-      "description": "Proof profiles the peer can mint (client) or verify (server). Defaults to [\"org.kya-os/proof@1\"].",
+      "description": "Proof profiles the peer can mint (client) or verify (server). Defaults to [\"org.kya-os/proof.v1\"].",
       "items": { "type": "string", "minLength": 1 },
       "minItems": 1,
       "uniqueItems": true,
-      "default": ["org.kya-os/proof@1"]
+      "default": ["org.kya-os/proof.v1"]
     },
     "didMethods": {
       "type": "array",

--- a/src/card/__tests__/__fixtures__/emit-golden.json
+++ b/src/card/__tests__/__fixtures__/emit-golden.json
@@ -12,7 +12,7 @@
     "responsibleParty": "did:web:example.com:org:acme",
     "principal": "did:web:example.com:users:alice",
     "delegationRef": "vc_root>del_123",
-    "proofProfile": "org.kya-os/proof@1"
+    "proofProfile": "org.kya-os/proof.v1"
   },
   "didServiceEntry": {
     "id": "#kya-os-card",
@@ -27,7 +27,7 @@
       "capabilities": ["handshake", "payments.transfer"],
       "responsibleParty": "did:web:example.com:org:acme",
       "delegationRef": "vc_root>del_123",
-      "proofProfile": "org.kya-os/proof@1"
+      "proofProfile": "org.kya-os/proof.v1"
     }
   },
   "serverCardMetaByRef": {
@@ -51,7 +51,7 @@
       "id": "did:web:example.com:agents:acme-pay",
       "entityType": "agent",
       "cardUrl": "https://example.com/agents/acme-pay/card.json",
-      "proofProfile": "org.kya-os/proof@1"
+      "proofProfile": "org.kya-os/proof.v1"
     }
   },
   "agentFacts": {
@@ -62,7 +62,7 @@
     "owner": "did:web:example.com:org:acme",
     "capabilities": ["handshake", "payments.transfer"],
     "kya:conformanceLevel": "L2",
-    "kya:proofProfile": "org.kya-os/proof@1",
+    "kya:proofProfile": "org.kya-os/proof.v1",
     "kya:delegationRef": "vc_root>del_123"
   }
 }

--- a/src/card/__tests__/builder.test.ts
+++ b/src/card/__tests__/builder.test.ts
@@ -126,9 +126,9 @@ describe('card() builder — infrastructure coordinates (finding 15)', () => {
   const DID_DOC = 'https://example.com/agents/acme/did.json';
   const JWK = { kty: 'OKP' as const, crv: 'Ed25519' as const, x: 'abc123' };
 
-  it('.usesProof() advertises the org.kya-os/proof@1 profile', () => {
+  it('.usesProof() advertises the org.kya-os/proof.v1 profile', () => {
     const built = card({ did: DID, entityType: 'agent', name: 'Acme' }).usesProof().build();
-    expect(built.proofProfile).toBe('org.kya-os/proof@1');
+    expect(built.proofProfile).toBe('org.kya-os/proof.v1');
     expect(() => parseCard(built)).not.toThrow();
   });
 
@@ -170,7 +170,7 @@ describe('card() builder — infrastructure coordinates (finding 15)', () => {
       .revocation(REVOCATION)
       .build();
     expect(() => parseCard(built)).not.toThrow();
-    expect(built.proofProfile).toBe('org.kya-os/proof@1');
+    expect(built.proofProfile).toBe('org.kya-os/proof.v1');
     expect(built.cimd).toEqual({ clientId: CLIENT_ID, jwksUri: JWKS });
     expect(built.revocation).toEqual(REVOCATION);
   });

--- a/src/card/__tests__/canonical.test.ts
+++ b/src/card/__tests__/canonical.test.ts
@@ -36,7 +36,7 @@ describe('the §8.3 pre-signing transformation (strip params._meta)', () => {
       method: REQ.method,
       params: {
         ...REQ.params,
-        _meta: { 'org.kya-os/proof@1': { prf: 'org.kya-os/proof@1', jws: 'x..y' }, progressToken: 7 },
+        _meta: { 'org.kya-os/proof.v1': { prf: 'org.kya-os/proof.v1', jws: 'x..y' }, progressToken: 7 },
       },
     });
     expect(carried).toBe(bare); // the proof's own carrier is never part of the signed material

--- a/src/card/__tests__/card.test.ts
+++ b/src/card/__tests__/card.test.ts
@@ -149,7 +149,7 @@ describe('verifyCard — live proof, revocation, and CIMD seams', () => {
     const res = await verifyCard(attestedCard, {
       capabilityVerifier: allAttested,
       accountabilityVerifier: accountable,
-      proof: { prf: 'org.kya-os/proof@1' },
+      proof: { prf: 'org.kya-os/proof.v1' },
       request,
       proofVerifier,
     });
@@ -162,7 +162,7 @@ describe('verifyCard — live proof, revocation, and CIMD seams', () => {
     const res = await verifyCard(attestedCard, {
       capabilityVerifier: allAttested,
       accountabilityVerifier: accountable,
-      proof: { prf: 'org.kya-os/proof@1' },
+      proof: { prf: 'org.kya-os/proof.v1' },
       request,
       proofVerifier,
     });
@@ -641,15 +641,15 @@ describe('parseCard', () => {
       id: 'did:web:example.com:agents:acme',
       entityType: 'agent',
       name: 'Acme',
-      proofProfile: 'org.kya-os/proof@1',
+      proofProfile: 'org.kya-os/proof.v1',
       cimd: { clientId: 'https://example.com/agents/acme', jwksUri: 'https://example.com/agents/acme/jwks.json' },
       revocation: { statusListCredential: 'https://example.com/status/1', statusListIndex: '94567' },
     });
-    expect(card.proofProfile).toBe('org.kya-os/proof@1');
+    expect(card.proofProfile).toBe('org.kya-os/proof.v1');
     expect(card.cimd?.jwksUri).toBe('https://example.com/agents/acme/jwks.json');
     expect(card.revocation?.statusListIndex).toBe('94567');
   });
-  it('rejects a proofProfile other than the org.kya-os/proof@1 literal', () => {
+  it('rejects a proofProfile other than the org.kya-os/proof.v1 literal', () => {
     expect(() =>
       parseCard({ id: 'did:web:x', entityType: 'agent', name: 'X', proofProfile: 'org.kya-os/proof@2' }),
     ).toThrow(/proofProfile/);

--- a/src/card/__tests__/devx-examples.test.ts
+++ b/src/card/__tests__/devx-examples.test.ts
@@ -49,7 +49,7 @@ describe('examples/entity-card/server.ts — the 10-minute path runs end-to-end 
     const entityCard = buildAcmeCard();
     expect(entityCard.entityType).toBe('agent');
     expect(entityCard.id).toBe(AGENT_DID);
-    expect(entityCard.proofProfile).toBe('org.kya-os/proof@1');
+    expect(entityCard.proofProfile).toBe('org.kya-os/proof.v1');
     expect(entityCard).not.toHaveProperty('conformanceLevel');
   });
 

--- a/src/card/__tests__/emit.test.ts
+++ b/src/card/__tests__/emit.test.ts
@@ -126,7 +126,7 @@ describe('emit — bare did:web org roots can publish (finding 7: emit/resolve s
 });
 
 describe('emit — proofProfile consistent across all four projections (finding 14)', () => {
-  // Pre-fix, toA2AExtension hardcoded proofProfile: org.kya-os/proof@1 while _meta and AgentFacts
+  // Pre-fix, toA2AExtension hardcoded proofProfile: org.kya-os/proof.v1 while _meta and AgentFacts
   // gated it on card.proofProfile — so a builder-produced card (which could never set proofProfile)
   // advertised proof on the A2A rail but stayed silent on the others: one identity, divergent signals.
   const init = { did: 'did:web:example.com:agents:acme', entityType: 'agent' as const, name: 'Acme' };
@@ -142,10 +142,10 @@ describe('emit — proofProfile consistent across all four projections (finding 
 
   it('a card WITH a proof profile advertises it on ALL four rails (they agree)', () => {
     const c = cardBuilder(init).usesProof().build();
-    expect(c.proofProfile).toBe('org.kya-os/proof@1');
-    expect(toA2AExtension(c).params.proofProfile).toBe('org.kya-os/proof@1');
-    expect(summaryOf(c).proofProfile).toBe('org.kya-os/proof@1');
-    expect(toAgentFacts(c)['kya:proofProfile']).toBe('org.kya-os/proof@1');
+    expect(c.proofProfile).toBe('org.kya-os/proof.v1');
+    expect(toA2AExtension(c).params.proofProfile).toBe('org.kya-os/proof.v1');
+    expect(summaryOf(c).proofProfile).toBe('org.kya-os/proof.v1');
+    expect(toAgentFacts(c)['kya:proofProfile']).toBe('org.kya-os/proof.v1');
   });
 });
 

--- a/src/card/__tests__/proof-helpers.ts
+++ b/src/card/__tests__/proof-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Shared fixtures for the `org.kya-os/proof@1` test suites. Not a test file (no `.test.ts`),
+ * Shared fixtures for the `org.kya-os/proof.v1` test suites. Not a test file (no `.test.ts`),
  * so vitest does not collect it; excluded from coverage as an `__tests__` module.
  */
 

--- a/src/card/__tests__/proof-key-compat.test.ts
+++ b/src/card/__tests__/proof-key-compat.test.ts
@@ -2,8 +2,8 @@
  * The card-proof `_meta` carrier key vs MCP's key grammar (SPEC-ENTITY-CARD §8.1).
  *
  * MCP's `_meta` key grammar permits only alphanumerics, hyphens, underscores, and dots in a
- * key's name segment - no `@` - so the profile id `org.kya-os/proof@1` cannot itself be the
- * carrier key. The canonical key is its key-safe form (`org.kya-os/proof.v1`); the earlier
+ * key's name segment - no `@` - so the profile id `org.kya-os/proof.v1` cannot itself be the
+ * carrier key. The canonical key is its key-safe form (`org.kya-os/request-proof`); the earlier
  * draft key (the profile id verbatim) stays readable for one major version, canonical wins.
  */
 
@@ -14,6 +14,7 @@ import {
   LEGACY_CARD_PROOF_META_KEY,
   PROOF_PROFILE_V1,
 } from '../proof/types.js';
+import { LEGACY_PROOF_PROFILE_ID } from '../schema.js';
 
 /** MCP `_meta` name-segment grammar: alnum ends, alnum/hyphen/underscore/dot interior. */
 const META_KEY_NAME = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
@@ -25,9 +26,14 @@ describe('card-proof _meta carrier key', () => {
     expect(name).toMatch(META_KEY_NAME);
   });
 
-  it('the legacy key is the profile id verbatim (and is why it was replaced)', () => {
-    expect(LEGACY_CARD_PROOF_META_KEY).toBe(PROOF_PROFILE_V1);
+  it('the legacy key is the legacy profile id verbatim (and is why it was replaced)', () => {
+    expect(LEGACY_CARD_PROOF_META_KEY).toBe(LEGACY_PROOF_PROFILE_ID);
     expect(LEGACY_CARD_PROOF_META_KEY.split('/')[1]).not.toMatch(META_KEY_NAME);
+  });
+
+  it('the canonical profile id carries no @ and versions only itself', () => {
+    expect(PROOF_PROFILE_V1).toBe('org.kya-os/proof.v1');
+    expect(PROOF_PROFILE_V1).not.toContain('@');
   });
 
   it('readCardProof reads the canonical key', () => {

--- a/src/card/__tests__/proof.test.ts
+++ b/src/card/__tests__/proof.test.ts
@@ -35,7 +35,7 @@ async function signAdversarial(
 }
 
 describe('buildCardProof', () => {
-  it('mints an org.kya-os/proof@1 under the shipped _meta key, binding did/kid/audience/cnf', async () => {
+  it('mints an org.kya-os/proof.v1 under the shipped _meta key, binding did/kid/audience/cnf', async () => {
     const { signer } = await keypair();
     const env = await buildCardProof(REQ, signer, { audience: AUD, nonce: NONCE, now: clock });
     const proof = env[PROOF_KEY];

--- a/src/card/__tests__/review-regressions.test.ts
+++ b/src/card/__tests__/review-regressions.test.ts
@@ -118,7 +118,7 @@ describe('PR #110 review — real-path regressions', () => {
 
   it('#8 the card proof and the legacy proof occupy DISTINCT _meta keys (they coexist)', () => {
     expect(KYA_OS_CARD_PROOF_META_KEY).not.toBe(KYA_OS_PROOF_META_KEY);
-    const cardProof = { prf: 'org.kya-os/proof@1', jws: 'x' };
+    const cardProof = { prf: 'org.kya-os/proof.v1', jws: 'x' };
     const legacyProof = { sessionId: 's-1', ts: 1 };
     // Both present on one server's request _meta:
     const meta = { [KYA_OS_CARD_PROOF_META_KEY]: cardProof, [KYA_OS_PROOF_META_KEY]: legacyProof };
@@ -197,7 +197,7 @@ describe('PR #110 review — real-path regressions', () => {
   // ── Round 3 (A+ review — schema hardening + fail-closed convention locks) ──────
 
   const validCardProof = (): Record<string, unknown> => ({
-    prf: 'org.kya-os/proof@1',
+    prf: 'org.kya-os/proof.v1',
     alg: 'EdDSA',
     did: 'did:web:example.com:agents:acme-pay',
     kid: 'did:web:example.com:agents:acme-pay#key-1',

--- a/src/card/__tests__/vectors.test.ts
+++ b/src/card/__tests__/vectors.test.ts
@@ -108,11 +108,11 @@ function proofDeps(over: Partial<VerifyProofDeps> = {}): VerifyProofDeps {
   };
 }
 
-// ── card-proof/valid — the signed org.kya-os/proof@1 + its RFC 9421 sibling ──────────
-describe('conformance vector: card-proof.json (org.kya-os/proof@1)', () => {
+// ── card-proof/valid — the signed org.kya-os/proof.v1 + its RFC 9421 sibling ──────────
+describe('conformance vector: card-proof.json (org.kya-os/proof.v1)', () => {
   it('is a schema-valid CardProofMeta carrying a detached JWS + an httpSig sibling', () => {
     const parsed = CardProofMetaSchema.parse(proof);
-    expect(parsed.prf).toBe('org.kya-os/proof@1');
+    expect(parsed.prf).toBe('org.kya-os/proof.v1');
     expect(parsed.jws.split('.')[1]).toBe(''); // detached JWS: header..signature
     expect(parsed.httpSig).toBeTruthy();
   });

--- a/src/card/builder.ts
+++ b/src/card/builder.ts
@@ -126,7 +126,7 @@ export class CardBuilder {
   }
 
   /**
-   * Advertise the per-request holder-of-key proof profile (`org.kya-os/proof@1`). This only NAMES
+   * Advertise the per-request holder-of-key proof profile (`org.kya-os/proof.v1`). This only NAMES
    * the profile — the proof itself is never on the static card; it rides per-request `_meta`.
    */
   usesProof(): this {

--- a/src/card/emit.ts
+++ b/src/card/emit.ts
@@ -30,6 +30,7 @@ import {
 import {
   capabilityNames,
   PROOF_PROFILE_ID,
+  type ProofProfile,
   type BitstringStatusListEntry,
   type EntityCard,
   type EntityType,
@@ -106,7 +107,7 @@ export interface A2AExtension {
     entityType: 'agent';
     cardUrl: string;
     /** Emitted only when the card DECLARES a proof profile — consistent with the other rails. */
-    proofProfile?: typeof PROOF_PROFILE;
+    proofProfile?: ProofProfile;
   };
 }
 

--- a/src/card/index.ts
+++ b/src/card/index.ts
@@ -13,7 +13,7 @@
  *   - cimd        (./cimd):    BIND the L1 CIMD on-ramp — `client_id` ⇄ `did:web`, DID-keyed
  *                              JWKS, and the fail-closed origin/`alsoKnownAs` substitution graft.
  *   - proof       (./proof):   MINT + VERIFY the stateless per-request holder-of-key proof
- *                              (`org.kya-os/proof@1`) — sender-constrained, fail-closed.
+ *                              (`org.kya-os/proof.v1`) — sender-constrained, fail-closed.
  *   - delegation  (./delegation): VALIDATE the W3C VC 2.0 + ZCAP-LD delegation chain — CRISP
  *                              attenuation + continuity, `responsibleParty`/leaf-invoker, fail-closed.
  *   - builder     (./builder):  the fluent `card()` chain — the 10-minute path to a valid card.

--- a/src/card/middleware.ts
+++ b/src/card/middleware.ts
@@ -10,7 +10,7 @@
  *     both immutably (a shallow clone; a stripped `_meta` degrades to a fetch, never a failure).
  *
  *   - `requireProof(deps, { minLevel? })` — the VERIFY side. Returns a per-request guard that
- *     reads the holder-of-key proof from `_meta['org.kya-os/proof.v1']` (legacy `org.kya-os/proof@1` accepted), RECOMPUTES it via
+ *     reads the holder-of-key proof from `_meta['org.kya-os/request-proof']` (legacy `org.kya-os/proof.v1` accepted), RECOMPUTES it via
  *     `./proof` ({@link verifyCardProof}) — every binding, fail-closed — enforces a minimum
  *     assurance, and returns a 401-shaped result on any failure. The caller passes the exact
  *     `{ method, params }` the client signed (i.e. WITHOUT `_meta`), so the recomputed
@@ -159,7 +159,7 @@ const ASSURANCE_RANK: Record<ProofAssurance, number> = { 'L3-minus': 1, L3: 2 };
 
 /**
  * Build a per-request holder-of-key guard from the pre-bound proof-verification seams. The returned
- * guard reads `_meta['org.kya-os/proof.v1']` (legacy `org.kya-os/proof@1` accepted), RECOMPUTES it against the request via {@link verifyCardProof},
+ * guard reads `_meta['org.kya-os/request-proof']` (legacy `org.kya-os/proof.v1` accepted), RECOMPUTES it against the request via {@link verifyCardProof},
  * enforces `opts.minLevel`, and returns `{ ok: true, did, level }` or a 401-shaped rejection. Fail-closed
  * throughout: a missing proof, a broken binding, a throwing verifier, or an assurance below `minLevel`
  * all reject.
@@ -174,7 +174,7 @@ export function requireProof(deps: VerifyProofDeps, opts: RequireProofOptions = 
   return async (req, meta) => {
     const proof = readCardProof(meta);
     if (proof === undefined) {
-      return fail('proof_missing', 'no org.kya-os/proof.v1 in _meta', ['proof_missing']);
+      return fail('proof_missing', 'no org.kya-os/request-proof in _meta', ['proof_missing']);
     }
     const result = await recompute(proof, req, deps);
     if (!result.ok || result.did === undefined || result.level === undefined) {
@@ -195,7 +195,7 @@ export function requireProof(deps: VerifyProofDeps, opts: RequireProofOptions = 
 }
 
 /** Read the card proof out of a `_meta` record (undefined when absent / not an object). Reads the
- *  canonical `org.kya-os/proof.v1` key, falling back to the earlier draft key (`org.kya-os/proof@1`,
+ *  canonical `org.kya-os/request-proof` key, falling back to the earlier draft key (`org.kya-os/proof.v1`,
  *  accepted for one major version); the canonical key wins when both are present. A legacy session
  *  proof under `org.kya-os/proof` is a different key and is simply not seen. */
 export function readCardProof(meta: unknown): unknown {

--- a/src/card/proof/build.ts
+++ b/src/card/proof/build.ts
@@ -1,8 +1,8 @@
 /**
  * KYA-OS Entity Card proof — MINT (`buildCardProof`).
  *
- * Mint a stateless, sender-constrained `org.kya-os/proof@1` for one request and return it under the
- * card proof's OWN `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof.v1`), distinct
+ * Mint a stateless, sender-constrained `org.kya-os/proof.v1` for one request and return it under the
+ * card proof's OWN `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/request-proof`), distinct
  * from the legacy session proof's `org.kya-os/proof` so the two coexist. The proof binds:
  * `requestHash` → THIS body (JCS), `audience` → THIS recipient, `nonce` + `created`/`expires` → NOW,
  * `kid` → the signing DID key, and (optionally) `cnf.jkt` → the token's RFC 9449 sender-constraint.
@@ -23,7 +23,7 @@ import {
 } from './types.js';
 
 /**
- * Mint an `org.kya-os/proof@1` for `req`, signed by `signer`, bound to `ctx`. Returns the proof
+ * Mint an `org.kya-os/proof.v1` for `req`, signed by `signer`, bound to `ctx`. Returns the proof
  * keyed by {@link KYA_OS_CARD_PROOF_META_KEY} so it can be spread straight into an MCP request
  * `_meta`. The `cnf.jkt` is `ctx.cnfJkt` when given, else the signer's own key thumbprint, else
  * omitted (an L3-minus proof — still bound by request + audience + nonce + key).

--- a/src/card/proof/http-sig.ts
+++ b/src/card/proof/http-sig.ts
@@ -81,7 +81,7 @@ export function httpSignatureBaseBytes(proof: CardProofMeta): Uint8Array {
 }
 
 /**
- * Project a minted `org.kya-os/proof@1` into its RFC 9421 header set. Emits EVERY covered
+ * Project a minted `org.kya-os/proof.v1` into its RFC 9421 header set. Emits EVERY covered
  * component as a real HTTP field — `Content-Digest`/`Kya-Audience`/`Kya-Nonce` (and `Kya-Cnf`
  * when a `cnf` is present), each byte-identical to its {@link httpSignatureBase} line — plus
  * `Signature-Input` (the covered-component list + params) and `Signature` (the RAW `httpSig` as a

--- a/src/card/proof/index.ts
+++ b/src/card/proof/index.ts
@@ -1,5 +1,5 @@
 /**
- * KYA-OS Entity Card — stateless per-request holder-of-key proof (`org.kya-os/proof@1`).
+ * KYA-OS Entity Card — stateless per-request holder-of-key proof (`org.kya-os/proof.v1`).
  *
  * The security-critical module, split into focused units re-exported here:
  *   - types      (./types):    CardProofMeta + the minting/verifying seams and result shapes.
@@ -12,7 +12,7 @@
  *                              + the NonceCacheProvider adapter) so the safe consume is the default.
  *
  * Distinct from — and orthogonal to — the legacy session-bound proof in `src/proof`: the card proof
- * rides its OWN `_meta['org.kya-os/proof.v1']` key, separate from the legacy `org.kya-os/proof`, so
+ * rides its OWN `_meta['org.kya-os/request-proof']` key, separate from the legacy `org.kya-os/proof`, so
  * both regimes can run on one server without either guard seeing the other's proof.
  */
 

--- a/src/card/proof/nonce-cache.ts
+++ b/src/card/proof/nonce-cache.ts
@@ -1,5 +1,5 @@
 /**
- * KYA-OS Entity Card — batteries-included replay defense for `org.kya-os/proof@1`.
+ * KYA-OS Entity Card — batteries-included replay defense for `org.kya-os/proof.v1`.
  *
  * The {@link ConsumeNonceIfFresh} seam is security-critical: it MUST be an ATOMIC test-AND-set
  * (record the nonce AND report whether it was already seen, in one step). Hand-rolling it is the

--- a/src/card/proof/types.ts
+++ b/src/card/proof/types.ts
@@ -1,8 +1,8 @@
 /**
  * KYA-OS Entity Card — stateless per-request holder-of-key proof: shapes + seams.
  *
- * `org.kya-os/proof@1` is the STATELESS, sender-constrained proof profile. It rides its OWN
- * `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/proof.v1`), DISTINCT from the legacy
+ * `org.kya-os/proof.v1` is the STATELESS, sender-constrained proof profile. It rides its OWN
+ * `_meta` key ({@link KYA_OS_CARD_PROOF_META_KEY} = `org.kya-os/request-proof`), DISTINCT from the legacy
  * session-bound `ProofMeta` (which carries `sessionId` + a handshake nonce under
  * `org.kya-os/proof`). Separate keys let the two regimes coexist on one server without either guard
  * seeing — or rejecting — the other's proof. Every request self-proves; there is no session state.
@@ -13,7 +13,7 @@
  */
 
 import { z } from 'zod';
-import { Did, PROOF_PROFILE_ID, type ProofPublicJwk } from '../schema.js';
+import { Did, LEGACY_PROOF_PROFILE_ID, PROOF_PROFILE_ID, type ProofPublicJwk } from '../schema.js';
 
 /** The stateless per-request proof profile tag (the `prf` discriminator). */
 export const PROOF_PROFILE_V1 = PROOF_PROFILE_ID;
@@ -24,19 +24,19 @@ export const PROOF_PROFILE_V1 = PROOF_PROFILE_ID;
  * exclusive on a server (a legacy proof failed the card schema and was 401'd; a card proof failed
  * the legacy structure check). With separate keys each guard reads its OWN key and simply does not
  * see the other's proof, so both can run on one server — genuinely additive, no legacy coupling. The
- * key is the profile id's KEY-SAFE form: MCP's `_meta` key grammar permits only alphanumerics,
- * hyphens, underscores, and dots in a key's name segment - no `@` - so the profile id itself is
- * not a legal key name. The object's `prf` field remains the self-describing discriminator.
+ * key names the slot by ROLE (the request proof), pairing with the response proof's
+ * `org.kya-os/response-proof`; the profile VERSION lives inside the object, in its `prf` field.
+ * Keys carry no versions and no `@` (which MCP's `_meta` key grammar forbids anyway).
  */
-export const KYA_OS_CARD_PROOF_META_KEY = 'org.kya-os/proof.v1';
+export const KYA_OS_CARD_PROOF_META_KEY = 'org.kya-os/request-proof';
 
 /**
- * The earlier draft carrier key, which used the profile id verbatim and therefore violated MCP's
- * `_meta` key grammar. Verifiers accept it for one major version (SPEC-ENTITY-CARD §8.1);
+ * The earlier draft carrier key, which used the then-profile-id verbatim and therefore violated
+ * MCP's `_meta` key grammar. Verifiers accept it for one major version (SPEC-ENTITY-CARD §8.1);
  * producers emit {@link KYA_OS_CARD_PROOF_META_KEY} and MAY mirror under this key for verifiers
  * older than the rename. When both keys are present, the canonical key wins.
  */
-export const LEGACY_CARD_PROOF_META_KEY = PROOF_PROFILE_V1;
+export const LEGACY_CARD_PROOF_META_KEY = LEGACY_PROOF_PROFILE_ID;
 
 /** Default proof lifetime in seconds (SPEC §8: short-lived, ≤ 60s). */
 export const DEFAULT_TTL_SEC = 60;
@@ -76,7 +76,7 @@ export const CardProofCnfSchema = z.object({
 });
 
 /**
- * The `org.kya-os/proof@1` payload. Every field except the two signatures (`jws`, `httpSig`) is a
+ * The `org.kya-os/proof.v1` payload. Every field except the two signatures (`jws`, `httpSig`) is a
  * COVERED claim: the detached EdDSA `jws` signs the RFC 8785 (JCS) canonicalization of the claims,
  * so tampering any of them fails the signature. `cnf.jkt` is OPTIONAL — present it degrades to
  * L3-minus rather than blocking when the authorization server does not emit an RFC 9449 `cnf`.
@@ -89,7 +89,7 @@ export const CardProofCnfSchema = z.object({
  * It degrades gracefully: a signer without a `signRaw` seam mints a JWS-only proof (no sibling).
  */
 export const CardProofMetaSchema = z.object({
-  prf: z.literal(PROOF_PROFILE_V1),
+  prf: z.union([z.literal(PROOF_PROFILE_V1), z.literal(LEGACY_PROOF_PROFILE_ID)]),
   alg: z.enum(['EdDSA', 'ES256']),
   did: Did,
   // The signing key reference MUST carry a `#fragment` (a verificationMethod id); the runtime also

--- a/src/card/proof/verify.ts
+++ b/src/card/proof/verify.ts
@@ -1,7 +1,7 @@
 /**
  * KYA-OS Entity Card proof — VERIFY (`verifyCardProof`), fail-closed.
  *
- * Recompute EVERY binding a stateless `org.kya-os/proof@1` asserts and reject on the first thing
+ * Recompute EVERY binding a stateless `org.kya-os/proof.v1` asserts and reject on the first thing
  * that does not hold. The signature only proves the proof is AUTHENTIC (signed by the holder of
  * `kid`); accountability requires binding that key to the accountable principal `did`:
  *
@@ -34,7 +34,7 @@ import {
 } from './types.js';
 
 /**
- * Verify an `org.kya-os/proof@1` against the request it should bind and the injected seams.
+ * Verify an `org.kya-os/proof.v1` against the request it should bind and the injected seams.
  * Fail-closed: returns `{ ok:false, reasons }` on any broken binding; on success returns the
  * derived assurance (`L3` on full cnf fusion, `L3-minus` without an AS `cnf`) and the principal.
  */

--- a/src/card/schema.ts
+++ b/src/card/schema.ts
@@ -70,15 +70,27 @@ export const AttestationSchema = z
 
 /** The canonical per-request proof profile id — the ONE source of truth every consumer
  *  references (the proof's `prf` tag, its `_meta` key, and the card's `proofProfile` field). */
-export const PROOF_PROFILE_ID = 'org.kya-os/proof@1';
+export const PROOF_PROFILE_ID = 'org.kya-os/proof.v1';
+
+/**
+ * The profile id of the earlier draft (`proof@1`), replaced because the `@`
+ * spelling collided with MCP's `_meta` key grammar and duplicated the version
+ * the `prf` field already carries. Verifiers accept it (in `prf` and in
+ * `proofProfile`) for one major version; producers emit only
+ * {@link PROOF_PROFILE_ID}.
+ */
+export const LEGACY_PROOF_PROFILE_ID = 'org.kya-os/proof@1';
 
 /**
  * Self-declared per-request holder-of-key proof profile. A card carrying this advertises
- * that its requests ride the stateless, sender-constrained `org.kya-os/proof@1` envelope
+ * that its requests ride the stateless, sender-constrained `org.kya-os/proof.v1` envelope
  * (distinct from the legacy session-bound ProofMeta). The proof itself is NEVER on the
  * static card — it rides per-request `_meta`; this field only names the profile.
  */
-export const ProofProfileSchema = z.literal(PROOF_PROFILE_ID);
+export const ProofProfileSchema = z.union([
+  z.literal(PROOF_PROFILE_ID),
+  z.literal(LEGACY_PROOF_PROFILE_ID),
+]);
 
 /**
  * CIMD (draft-ietf-oauth-client-id-metadata-document) binding — the L1 on-ramp

--- a/src/card/verify.ts
+++ b/src/card/verify.ts
@@ -102,7 +102,7 @@ export interface VerifyCardDeps {
   attestationVerifier?: AttestationVerifier;
   /** Verifies the accountability edge (delegationRef → responsibleParty, leaf-invoker join). */
   accountabilityVerifier?: AccountabilityVerifier;
-  /** The per-request holder-of-key proof that rode `_meta['org.kya-os/proof.v1']` (recomputed here). */
+  /** The per-request holder-of-key proof that rode `_meta['org.kya-os/request-proof']` (recomputed here). */
   proof?: unknown;
   /** The request the proof must bind (`method` + `params`); required alongside `proof`. */
   request?: ToolRequest;

--- a/src/extension/__tests__/gate.test.ts
+++ b/src/extension/__tests__/gate.test.ts
@@ -156,7 +156,7 @@ describe('missingRequiredCapabilityError', () => {
 describe('proofGateToJsonRpcError', () => {
   const gateError = {
     code: 'proof_missing',
-    message: 'no org.kya-os/proof.v1 in _meta',
+    message: 'no org.kya-os/request-proof in _meta',
     reasons: ['proof_missing'],
   };
 

--- a/src/extension/__tests__/settings.test.ts
+++ b/src/extension/__tests__/settings.test.ts
@@ -23,7 +23,7 @@ describe('parseExtensionSettings', () => {
   it('accepts a fully-populated settings object', () => {
     const settings = {
       version: '1.0.0',
-      proofProfiles: ['org.kya-os/proof@1'],
+      proofProfiles: ['org.kya-os/proof.v1'],
       didMethods: ['did:key', 'did:web'],
       required: true,
     };
@@ -49,7 +49,7 @@ describe('parseExtensionSettings', () => {
   it.each([
     ['a non-semver version', { version: 'v1' }],
     ['a numeric version', { version: 1 }],
-    ['a string proofProfiles', { proofProfiles: 'org.kya-os/proof@1' }],
+    ['a string proofProfiles', { proofProfiles: 'org.kya-os/proof.v1' }],
     ['an empty proofProfiles array', { proofProfiles: [] }],
     ['duplicate proofProfiles', { proofProfiles: ['p', 'p'] }],
     ['an empty proofProfiles entry', { proofProfiles: [''] }],
@@ -85,7 +85,7 @@ describe('resolveExtensionSettings', () => {
     const resolved = resolveExtensionSettings({});
     resolved.proofProfiles.push('mutated');
     resolved.didMethods.push('did:mutated');
-    expect(DEFAULT_EXTENSION_SETTINGS.proofProfiles).toEqual(['org.kya-os/proof@1']);
+    expect(DEFAULT_EXTENSION_SETTINGS.proofProfiles).toEqual(['org.kya-os/proof.v1']);
     expect(DEFAULT_EXTENSION_SETTINGS.didMethods).toEqual(['did:key', 'did:web']);
   });
 });

--- a/src/proof/__tests__/response-proof-key-compat.test.ts
+++ b/src/proof/__tests__/response-proof-key-compat.test.ts
@@ -2,7 +2,7 @@
  * The response-proof `_meta` carrier key and its acceptance window (SPEC §7.5-§7.6).
  *
  * The canonical key is role-named (`org.kya-os/response-proof`) so it cannot be
- * misread as a version sibling of the request proof's `org.kya-os/proof.v1`.
+ * misread as a version sibling of the request proof's `org.kya-os/request-proof`.
  * Two prior keys stay read-accepted for one major version: the namespaced
  * `org.kya-os/proof` (canonical from 1.1 until the rename) and the original
  * bare `proof`. The newest canonical form wins when several are present.

--- a/src/proof/generator.ts
+++ b/src/proof/generator.ts
@@ -32,7 +32,7 @@ import { ED25519_PKCS8_DER_HEADER, ED25519_KEY_SIZE } from '../utils/ed25519-con
  * so renaming the namespace — e.g. once KYA-OS registers as an MCP Extension
  * under SEP-2133 — is a one-line change. Named for its ROLE (the response
  * proof), so it cannot be misread as a version sibling of the request proof's
- * `org.kya-os/proof.v1`. See SPEC §7.5-§7.6.
+ * `org.kya-os/request-proof`. See SPEC §7.5-§7.6.
  */
 export const KYA_OS_PROOF_META_KEY = 'org.kya-os/response-proof';
 


### PR DESCRIPTION
Completes the naming convention at its terminal shape, per the working-group direction: **keys name the envelope slot by role; the version lives inside the envelope.**

Two moves, one coherent end state:

- **Carrier key**: `org.kya-os/proof.v1` → **`org.kya-os/request-proof`**, completing the role-named pair with `org.kya-os/response-proof` (#146).
- **Profile id**: `org.kya-os/proof@1` → **`org.kya-os/proof.v1`**. The version marker is load-bearing (`prf` is how the format evolves); the `@` spelling was imported npm idiom that produced the illegal carrier key and a permanent two-spellings-of-one-version confusion. The 1.x wire-stability waiver for this is deliberate and pre-launch: the live audit showed nothing emits card proofs yet, so the window where signed material can change is open today and closes at launch.

Compatibility, one major version everywhere: verifiers read the legacy carrier key and accept the legacy `prf`/`proofProfile` value (covered claims recompute from the received object, so legacy-profile signatures verify unchanged); producers emit only canonical names and may mirror under the legacy key. Canonical wins wherever both appear.

Signed conformance vectors regenerated deterministically (fixed test keys); the stdlib Python verifier confirms cross-language JCS + Ed25519 parity against the new bytes. Validation: typecheck, lint, 1,942 tests, conformance 44/44, crosslang PASS.

Final family: `decentralized-authority` (extension) · `request-proof` / `response-proof` (keys) · `proof.v1` (format, in `prf`) · `card` / `did` (discovery). No `@` anywhere, no version in any key, the version exactly once - inside the object it versions.

#143 gets its matching sweep and should merge after this.