### PR TITLE
docs(spec): name the delegation key model as an up-front principle

### DIFF
--- a/SPEC-ENTITY-CARD.md
+++ b/SPEC-ENTITY-CARD.md
@@ -112,6 +112,23 @@ populates); CIMD proves key possession once, at the token endpoint (session-inte
 them type the principal, and none prove the live caller per request. The `cnf.jkt` fusion (§8.6)
 connects the two claims, from the L1 token to the L3 per-request proof, through one DID key.
 
+### 1.4 Delegation key model
+
+A delegation names a **key**, not a long-lived identity that has to be maintained. The RECOMMENDED
+delegate subject is a fresh, single-purpose `did:key` minted per delegation: the identifier *is* the
+public key, so there is nothing to rotate, and no question of whether a delegation was signed before
+or after a rotation. Possession of that key is proven on every request: the leaf delegate a Verifier
+recomputes from the chain must equal the request-proof key (`leafInvoker === proof.did`, §8, §11), so
+a captured credential is inert to anyone who does not hold the key. Delegations are short-lived and
+attenuating (the delegation profile in SPEC.md; §10), which keeps the key's exposure window small.
+
+An Entity that needs a durable, resolvable name across devices MAY instead use a `did:web` subject.
+There, key rotation is a DID-document update with superseded keys retained for historical proof
+verification, and delegations are reissued bound to a specific `kid` (§12.5); that likewise removes
+any before-or-after-rotation ambiguity. The per-request holder-of-key check for `did:web` subjects is
+the `cnf.jkt` sender-constraint fusion (§8.6), and is OPTIONAL relative to the RECOMMENDED one-off-key
+model. See also the per-delegation-keys note (§13).
+
 ---
 
 ## 2. Terminology & Roles


### PR DESCRIPTION
## What

Adds a short, named subsection **§1.4 Delegation key model** to `SPEC-ENTITY-CARD.md`, right after §1.3 (The two claims).

## Why

The profile already answers the recurring "how does delegation handle key rotation?" question, but only implicitly: the answer lives as proof/verification mechanics (§8, §11) plus a single line in the privacy considerations (§13, per-delegation keys). A careful reader can review the whole document and still not connect that one bullet to the design stance. This promotes it to an up-front, named principle so the intent is legible on first read.

## The stance it states

- The recommended delegate subject is a fresh, single-purpose `did:key` minted per delegation. The identifier *is* the public key, so there is nothing to rotate and no "signed before or after a rotation?" question.
- Possession of that key is proven on every request (`leafInvoker === proof.did`, §8/§11), so a captured credential is inert without the key.
- Entities that need a durable, resolvable name may use `did:web`, where rotation is a DID-document update, superseded keys are retained for historical verification, and delegations are reissued bound to a specific `kid` (§12.5). The per-request holder-of-key check for `did:web` is the `cnf.jkt` fusion (§8.6), called out as **optional** relative to the recommended one-off-key model.

## Scope

Additive and descriptive. It cross-references the existing normative sections and **introduces no new normative requirements**. Column-wrapped to match the document's house style. No TOC to update (§1.x are headings, not a listed TOC).
