### PR TITLE
fix(extension): reject a required-mode malformed declaration with -32602

### DIFF
--- a/SPEC-MCP-EXTENSION.md
+++ b/SPEC-MCP-EXTENSION.md
@@ -174,7 +174,7 @@ All members are OPTIONAL; per SEP-2133, an **empty object** (`{}`) means "suppor
 | `required` | boolean | Server-side only: whether the server rejects requests from clients that do not declare this extension (§4). Default `false`. Clients MUST ignore this member if present on a client declaration. |
 
 Unknown members MUST be ignored (forward compatibility).
-A peer that receives a malformed settings object MUST treat the declaration as absent (fail closed to non-declaration, §4), not guess at intent.
+A peer that receives a settings object it cannot parse - a declaration that is present but malformed, as distinct from one that is absent - MUST NOT treat it as a valid declaration, and MUST NOT guess at intent. The declaration is an untrusted, intermediary-mutable, proof-excluded `_meta` member, so its handling is mode-dependent. In **optional mode** a malformed declaration degrades to non-declaration exactly like an absent one (core MCP behavior, §4); a corrupting intermediary therefore cannot turn an otherwise-valid request into a rejection when a mere strip would let it through. In **required mode**, where a non-declaring request is rejected regardless, the server MUST reject the request with JSON-RPC `-32602` (Invalid params) carrying `reason: "malformed_declaration"`, distinguishing a garbled declaration from a genuinely absent one (`-32021`, §4).
 
 ### 3.3 Meaning of a declaration
 
@@ -277,7 +277,7 @@ When a KYA-OS failure surfaces as a JSON-RPC error, the error's numeric `code` i
 Clients MUST dispatch on `error.data.reason`, never on the implementation-defined numeric code.
 The proof-gate codes are `proof_missing`, `proof_invalid`, and `proof_level_insufficient` (SPEC-ENTITY-CARD Appendix D.2); fine-grained verification reasons (Appendix D.1) MAY additionally be surfaced under `error.data.reasons` for diagnostics.
 No new numeric codes are invented for any Appendix D code.
-This document defines exactly one reason code of its own: `extension_not_declared`, emitted only inside the `data` member of a core `-32021` error (§4.2); every other reason code this extension surfaces is defined by SPEC-ENTITY-CARD Appendix D or SPEC.md Appendix A.
+This document defines two reason codes of its own, each riding the `data.reason` member of a core JSON-RPC error: `extension_not_declared` inside a `-32021` (required mode, no declaration; §4.2) and `malformed_declaration` inside a `-32602` (required mode, a present-but-malformed declaration; §3.2). Every other reason code this extension surfaces is defined by SPEC-ENTITY-CARD Appendix D or SPEC.md Appendix A.
 
 ### 5.3 HTTP-layer failures
 

--- a/conformance/vectors/negotiation.json
+++ b/conformance/vectors/negotiation.json
@@ -68,7 +68,7 @@
       "category": "negotiation",
       "description": "Client declaration entry is present but malformed; server requires the extension",
       "expected": "fail",
-      "reason": "A malformed settings object MUST be treated as absent (fail closed), so a required server rejects with -32021",
+      "reason": "A required server rejects a present-but-malformed declaration with -32602 (malformed_declaration), distinct from the -32021 it returns for a genuinely absent one",
       "input": {
         "serverSettings": { "required": true },
         "request": {

--- a/src/extension/__tests__/gate.test.ts
+++ b/src/extension/__tests__/gate.test.ts
@@ -1,15 +1,17 @@
 /**
  * The admission gate (SPEC-MCP-EXTENSION.md §4) and the JSON-RPC error surface
- * (§5): required mode answers absence with core -32021 and the
- * `extension_not_declared` reason; optional mode degrades to core behavior;
- * proof-gate failures map their snake_case codes onto `error.data.reason`
- * verbatim and never allocate from the MCP-reserved code range.
+ * (§5): required mode answers absence with core -32021 (`extension_not_declared`)
+ * and a present-but-malformed declaration with -32602 (`malformed_declaration`);
+ * optional mode degrades both to core behavior; proof-gate failures map their
+ * snake_case codes onto `error.data.reason` verbatim and never allocate from the
+ * MCP-reserved code range.
  */
 
 import { describe, it, expect } from 'vitest';
 import { PROOF_PROFILE_ID } from '../../card/schema.js';
 import {
   DEFAULT_EXEMPT_METHODS,
+  INVALID_PARAMS_CODE,
   KYA_OS_DOMAIN_ERROR_CODE,
   missingRequiredCapabilityError,
   proofGateToJsonRpcError,
@@ -18,6 +20,7 @@ import {
 import {
   EXTENSION_NOT_DECLARED_REASON,
   KYA_OS_EXTENSION_ID,
+  MALFORMED_DECLARATION_REASON,
   MCP_CLIENT_CAPABILITIES_META_KEY,
   MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
 } from '../settings.js';
@@ -75,11 +78,15 @@ describe('requireExtension - required mode', () => {
     }
   });
 
-  it('rejects a stripped-to-malformed declaration exactly like an absent one', () => {
+  it('rejects a present-but-malformed declaration with -32602, distinct from the absent -32021 case', () => {
+    // `["web"]` is not a valid DID method (the schema wants `did:...`), so the
+    // entry is present but malformed - a client-integrity error, not a missing one.
     const verdict = guard({ meta: metaDeclaring({ didMethods: ['web'] }) });
     expect(verdict.ok).toBe(false);
     if (!verdict.ok) {
-      expect(verdict.error.code).toBe(MISSING_REQUIRED_CLIENT_CAPABILITY_CODE);
+      expect(verdict.error.code).toBe(INVALID_PARAMS_CODE);
+      expect(verdict.error.data.reason).toBe(MALFORMED_DECLARATION_REASON);
+      expect(verdict.error.data.extension).toBe(KYA_OS_EXTENSION_ID);
     }
   });
 

--- a/src/extension/declaration.ts
+++ b/src/extension/declaration.ts
@@ -9,9 +9,10 @@
  *     initialize exchange, supplied by the host as `initializeCapabilities`
  *
  * Precedence: the per-request stateless entry, when PRESENT, is final - a
- * malformed stateless entry is treated as no declaration (fail closed, §3.2)
- * and the initialize-era entry is NOT consulted as a fallback, because the
- * per-request carriage supersedes initialize-era state.
+ * malformed stateless entry is classified as `malformed` (never a silent
+ * fallback to the initialize-era entry), because the per-request carriage
+ * supersedes initialize-era state. What a malformed entry MEANS is the gate's
+ * call (§3.2): degrade-to-absent in optional mode, -32602 in required mode.
  */
 
 import { isRecord } from '../utils/guards.js';
@@ -41,29 +42,55 @@ export interface ReadDeclarationInput {
   extensionId?: string;
 }
 
+/** The three outcomes of reading a peer's declaration (SPEC-MCP-EXTENSION.md §3.2). */
+export type DeclarationClassification =
+  | { status: 'declared'; declaration: ExtensionDeclaration }
+  | { status: 'absent' }
+  | { status: 'malformed'; carriage: DeclarationCarriage };
+
 /**
- * Read and validate the peer's declaration from either carriage.
- * Returns `undefined` when the extension is not declared - including when the
- * declared settings object is malformed (treated as absent, §3.2).
+ * Classify the peer's declaration from either carriage, distinguishing a
+ * present-but-malformed entry from a genuinely absent one. That distinction is
+ * what lets the gate answer malformed with `-32602` in required mode (§3.2)
+ * while still degrading it to core behavior in optional mode - so a corrupted,
+ * untrusted, proof-excluded `_meta` member never turns an otherwise-valid
+ * optional-mode request into a rejection.
  */
-export function readExtensionDeclaration(
+export function classifyExtensionDeclaration(
   input: ReadDeclarationInput,
-): ExtensionDeclaration | undefined {
+): DeclarationClassification {
   const id = input.extensionId ?? KYA_OS_EXTENSION_ID;
 
   const stateless = extensionsEntry(clientCapabilitiesFromMeta(input.meta), id);
   if (stateless.present) {
     const settings = parseExtensionSettings(stateless.value);
-    return settings === undefined ? undefined : { settings, carriage: 'stateless' };
+    return settings === undefined
+      ? { status: 'malformed', carriage: 'stateless' }
+      : { status: 'declared', declaration: { settings, carriage: 'stateless' } };
   }
 
   const legacy = extensionsEntry(input.initializeCapabilities, id);
   if (legacy.present) {
     const settings = parseExtensionSettings(legacy.value);
-    return settings === undefined ? undefined : { settings, carriage: 'initialize' };
+    return settings === undefined
+      ? { status: 'malformed', carriage: 'initialize' }
+      : { status: 'declared', declaration: { settings, carriage: 'initialize' } };
   }
 
-  return undefined;
+  return { status: 'absent' };
+}
+
+/**
+ * Read and validate the peer's declaration from either carriage.
+ * Returns `undefined` when there is no usable declaration - including a
+ * malformed one; callers that must distinguish malformed from absent (the gate)
+ * use {@link classifyExtensionDeclaration} instead.
+ */
+export function readExtensionDeclaration(
+  input: ReadDeclarationInput,
+): ExtensionDeclaration | undefined {
+  const classification = classifyExtensionDeclaration(input);
+  return classification.status === 'declared' ? classification.declaration : undefined;
 }
 
 /** Pull `io.modelcontextprotocol/clientCapabilities` out of a `_meta` bag. */

--- a/src/extension/gate.ts
+++ b/src/extension/gate.ts
@@ -7,25 +7,29 @@
  * extension is strictly opt-in.
  *
  *   - `required: false` (default): an undeclared peer gets core MCP behavior;
- *     the gate always admits and merely reports the declaration when present.
+ *     the gate always admits and merely reports the declaration when present. A
+ *     malformed declaration also degrades to core behavior here (§3.2), so a
+ *     corrupted untrusted `_meta` member can never reject a valid request.
  *   - `required: true`: a request without a declaration is rejected with the
- *     core MCP error `-32021` (`MissingRequiredClientCapabilityError`) carrying
- *     the core `requiredCapabilities` member plus this extension's
- *     `reason`/`extension` pair - except on exempt methods (`server/discover`,
- *     `ping` by default), which are never gated so discovery stays reachable.
+ *     core MCP error `-32021` (`MissingRequiredClientCapabilityError`); a
+ *     present-but-malformed one is rejected with `-32602` (Invalid params,
+ *     `malformed_declaration`). Both carry this extension's `reason`/`extension`
+ *     pair, and exempt methods (`server/discover`, `ping` by default) are never
+ *     gated so discovery stays reachable.
  *
- * A stripped or malformed declaration is an ABSENT declaration (fail closed,
- * §4.3) - never silent acceptance, never a guess.
+ * A stripped declaration is an ABSENT declaration (fail closed, §4.3) - never
+ * silent acceptance, never a guess.
  */
 
 import { PROOF_PROFILE_ID } from '../card/schema.js';
 import {
-  readExtensionDeclaration,
+  classifyExtensionDeclaration,
   type ExtensionDeclaration,
 } from './declaration.js';
 import {
   EXTENSION_NOT_DECLARED_REASON,
   KYA_OS_EXTENSION_ID,
+  MALFORMED_DECLARATION_REASON,
   MISSING_REQUIRED_CLIENT_CAPABILITY_CODE,
   buildExtensionSettings,
   resolveExtensionSettings,
@@ -97,17 +101,29 @@ export function requireExtension(
   const extensionId = opts.extensionId ?? KYA_OS_EXTENSION_ID;
   const exemptMethods = opts.exemptMethods ?? DEFAULT_EXEMPT_METHODS;
   return (input) => {
-    const declaration = readExtensionDeclaration({ ...input, extensionId });
-    if (declaration !== undefined) {
-      return { ok: true, declaration };
+    const classification = classifyExtensionDeclaration({ ...input, extensionId });
+    if (classification.status === 'declared') {
+      return { ok: true, declaration: classification.declaration };
     }
+    // Optional mode: both absent AND malformed degrade to core MCP behavior. The
+    // declaration is an untrusted, intermediary-mutable, proof-excluded `_meta`
+    // member (§7), so rejecting on a malformed one would let a corrupting
+    // intermediary turn an otherwise-valid request into a failure while a mere
+    // strip lets it through - the "corrupt vs. strip" asymmetry (§3.2).
     if (!settings.required) {
       return { ok: true };
     }
+    // Discovery/ping stay reachable so a non-declaring client can learn the requirement.
     if (input.method !== undefined && exemptMethods.includes(input.method)) {
       return { ok: true };
     }
-    return { ok: false, error: missingRequiredCapabilityError(extensionId) };
+    // Required mode rejects an absent declaration anyway, so surfacing the
+    // distinction carries no new DoS: a present-but-malformed declaration is a
+    // client-integrity error (-32602); a genuinely absent one is the
+    // missing-capability error (-32021).
+    return classification.status === 'malformed'
+      ? { ok: false, error: malformedDeclarationError(extensionId) }
+      : { ok: false, error: missingRequiredCapabilityError(extensionId) };
   };
 }
 
@@ -121,6 +137,29 @@ export function missingRequiredCapabilityError(
     data: {
       requiredCapabilities: { extensions: { [extensionId]: {} } },
       reason: EXTENSION_NOT_DECLARED_REASON,
+      extension: extensionId,
+    },
+  };
+}
+
+/** JSON-RPC "Invalid params" - the core code a present-but-malformed declaration rejects with (§3.2). */
+export const INVALID_PARAMS_CODE = -32602;
+
+/**
+ * The `-32602` rejection for a required-mode request whose declaration is present
+ * but malformed (SPEC-MCP-EXTENSION.md §3.2). Distinct from
+ * {@link missingRequiredCapabilityError}: a garbled declaration is a client-
+ * integrity error, not a missing one. In optional mode the gate never reaches
+ * here - a malformed declaration degrades to core behavior instead.
+ */
+export function malformedDeclarationError(
+  extensionId: string = KYA_OS_EXTENSION_ID,
+): JsonRpcErrorObject {
+  return {
+    code: INVALID_PARAMS_CODE,
+    message: `Invalid params: the ${extensionId} settings declaration is present but malformed`,
+    data: {
+      reason: MALFORMED_DECLARATION_REASON,
       extension: extensionId,
     },
   };

--- a/src/extension/settings.ts
+++ b/src/extension/settings.ts
@@ -22,11 +22,15 @@ export const MCP_CLIENT_CAPABILITIES_META_KEY = 'io.modelcontextprotocol/clientC
 export const MISSING_REQUIRED_CLIENT_CAPABILITY_CODE = -32021;
 
 /**
- * The one reason code this extension defines itself (SPEC-MCP-EXTENSION.md §5.2):
- * emitted only inside the `data` member of a core `-32021` error. Every other
- * reason code is defined by SPEC-ENTITY-CARD Appendix D or SPEC.md Appendix A.
+ * The reason codes this extension defines itself (SPEC-MCP-EXTENSION.md §5.2),
+ * each riding the `data.reason` member of a core JSON-RPC error:
+ * `extension_not_declared` inside a `-32021` (required mode, no declaration) and
+ * `malformed_declaration` inside a `-32602` (required mode, a present-but-
+ * unparseable declaration). Every other reason code is defined by
+ * SPEC-ENTITY-CARD Appendix D or SPEC.md Appendix A.
  */
 export const EXTENSION_NOT_DECLARED_REASON = 'extension_not_declared';
+export const MALFORMED_DECLARATION_REASON = 'malformed_declaration';
 
 const SEMVER = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
 const DID_METHOD = /^did:[a-z0-9]+$/;


### PR DESCRIPTION
Aligns the reference implementation with the malformed-settings handling, and revises §3.2 to **resolve the "corrupt vs. strip" DoS** an unconditional `-32602` would introduce.

## The change: mode-dependent
A present-but-malformed settings declaration is now distinguished from an absent one:

- **Optional mode** — malformed degrades to core MCP behavior, like absent. The declaration is an untrusted, intermediary-mutable, proof-excluded `_meta` member, so rejecting on it would let a **corrupting intermediary DoS an otherwise-valid request** (a mere strip lets it through), and would contradict "`_meta` is untrusted; derive no security decision from it except by verifying the proof."
- **Required mode** — malformed → `-32602` (`malformed_declaration`), distinct from the `-32021` an absent declaration gets. Required mode rejects a non-declaring request anyway, so the distinction adds **no new DoS** — just a precise client-integrity error.

## Why not unconditional `-32602`?
Rejecting malformed in *both* modes (an earlier draft) reintroduces the corrupt-vs-strip asymmetry in optional mode and contradicts the untrusted-`_meta` rule. Mode-dependent keeps the precise error where it's safe and degrades gracefully where it isn't.

## Contents
- `SPEC-MCP-EXTENSION.md` §3.2 (mode-dependent) + §6 (two reason codes)
- `src/extension/` — `classifyExtensionDeclaration()`, the gate branch, `malformedDeclarationError()`; `readExtensionDeclaration` stays a backward-compatible wrapper
- `conformance/vectors/negotiation.json` (malformed-required → `-32602`) + `gate.test.ts`

Full suite green (1958 passed), cross-language conformance PASS. Companion spec change on #143.