### PR TITLE
fix(delegation): agree on proofValue as the credential-proof signature field

### DIFF
--- a/src/middleware/with-kya-os.delegation-verify.ts
+++ b/src/middleware/with-kya-os.delegation-verify.ts
@@ -24,6 +24,7 @@ import { canonicalizeJSON } from "../delegation/utils.js";
 import { base64urlDecodeToBytes, bytesToBase64 } from "../utils/base64.js";
 import {
   createNeedsAuthorizationError,
+  readCredentialProofValue,
   type DelegationCredential,
   type NeedsAuthorizationError,
 } from "../types/protocol.js";
@@ -134,7 +135,7 @@ export function createDelegationVerification(
       return { valid: false, reason: "Missing proof" };
     }
 
-    const proofValue = proof["proofValue"] as string | undefined;
+    const proofValue = readCredentialProofValue(proof as Record<string, unknown>);
     if (!proofValue) {
       return { valid: false, reason: "Missing proofValue in proof" };
     }

--- a/src/types/__tests__/protocol.test.ts
+++ b/src/types/__tests__/protocol.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDelegationFromVC,
+  readCredentialProofValue,
+  type DelegationCredential,
+} from '../protocol.js';
+
+const baseDelegation = {
+  id: 'urn:delegation:1',
+  issuerDid: 'did:key:zIssuer',
+  subjectDid: 'did:key:zSubject',
+  controller: 'did:key:zIssuer',
+} as const;
+
+function credentialWithProof(proof: Record<string, unknown> | undefined): DelegationCredential {
+  return {
+    id: 'urn:vc:1',
+    credentialSubject: { delegation: { ...baseDelegation } },
+    ...(proof ? { proof } : {}),
+  } as unknown as DelegationCredential;
+}
+
+describe('readCredentialProofValue', () => {
+  it('reads the signature from proofValue, the only credential-proof signature field', () => {
+    expect(readCredentialProofValue({ type: 'Ed25519Signature2020', proofValue: 'sig-abc' })).toBe(
+      'sig-abc',
+    );
+  });
+
+  it('does not read jws: that field belongs to the detached tool-response proof, not a credential', () => {
+    expect(readCredentialProofValue({ type: 'Ed25519Signature2020', jws: 'jws-xyz' })).toBe('');
+  });
+
+  it('does not read the legacy signatureValue field', () => {
+    expect(readCredentialProofValue({ signatureValue: 'legacy' })).toBe('');
+  });
+
+  it('returns an empty string for a missing or non-string proof value', () => {
+    expect(readCredentialProofValue(undefined)).toBe('');
+    expect(readCredentialProofValue(null)).toBe('');
+    expect(readCredentialProofValue({})).toBe('');
+    expect(readCredentialProofValue({ proofValue: 42 })).toBe('');
+  });
+});
+
+describe('extractDelegationFromVC signature agreement', () => {
+  it('extracts the signature from proofValue', () => {
+    const record = extractDelegationFromVC(
+      credentialWithProof({ type: 'Ed25519Signature2020', proofValue: 'sig-abc' }),
+    );
+    expect(record.signature).toBe('sig-abc');
+  });
+
+  it('agrees with the verifier: a proof carrying only jws extracts no signature', () => {
+    // The verifier rejects a credential proof without proofValue. Extraction must
+    // not populate a signature from jws, or the extracted record misleads any
+    // caller that inspects it before verification (issue #152).
+    const record = extractDelegationFromVC(
+      credentialWithProof({ type: 'Ed25519Signature2020', jws: 'jws-xyz' }),
+    );
+    expect(record.signature).toBe('');
+  });
+
+  it('extracts no signature when the credential has no proof', () => {
+    const record = extractDelegationFromVC(credentialWithProof(undefined));
+    expect(record.signature).toBe('');
+  });
+});

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -205,6 +205,22 @@ export function wrapDelegationAsVC(
 }
 
 /**
+ * Read the signature from a credential's embedded proof.
+ *
+ * Per SPEC.md a delegation credential's proof carries its signature in
+ * `proofValue`. `jws` is the field on the *detached* per-request tool-response
+ * proof (a separate object) and never appears on a credential proof. Reading any
+ * other field here would let extraction accept a proof shape the verifier rejects,
+ * so extraction and verification share this one definition and cannot drift.
+ */
+export function readCredentialProofValue(
+  proof: Record<string, unknown> | null | undefined,
+): string {
+  const value = proof?.['proofValue'];
+  return typeof value === 'string' ? value : '';
+}
+
+/**
  * Extract a DelegationRecord from a DelegationCredential.
  */
 export function extractDelegationFromVC(vc: DelegationCredential): DelegationRecord {
@@ -221,11 +237,7 @@ export function extractDelegationFromVC(vc: DelegationCredential): DelegationRec
     );
   }
 
-  let signature = '';
-  if (vc.proof) {
-    const proof = vc.proof as Record<string, unknown>;
-    signature = (proof['proofValue'] || proof['jws'] || proof['signatureValue'] || '') as string;
-  }
+  const signature = readCredentialProofValue(vc.proof as Record<string, unknown> | undefined);
 
   return {
     id: delegation.id,


### PR DESCRIPTION
Closes #152.

## Problem

`extractDelegationFromVC` (`src/types/protocol.ts`) read the signature as `proof.proofValue || proof.jws || proof.signatureValue`, while the verifying path (`with-kya-os.delegation-verify.ts`) reads `proofValue` alone and returns `Missing proofValue in proof` when it is absent. A credential carrying only `jws` or `signatureValue` therefore extracted into a `DelegationRecord` with a **populated** `signature` and was then **rejected** at verification. The two paths disagreed about what counts as a proof, which makes the extracted record misleading for any caller that inspects it before verifying.

## Fix

Per `SPEC.md`, `proofValue` is the only signature field on a credential proof; `jws` is the field on the detached per-request tool-response proof (a separate object). Rather than pick one path to change, introduce a single shared reader both paths call, so they cannot drift again:

```ts
export function readCredentialProofValue(proof): string {
  const value = proof?.['proofValue'];
  return typeof value === 'string' ? value : '';
}
```

- `extractDelegationFromVC` uses it (drops the `jws`/`signatureValue` fallbacks).
- The verifier uses it (behaviour unchanged — it already read `proofValue` only).

## Tests

New `src/types/__tests__/protocol.test.ts`: `readCredentialProofValue` reads `proofValue`, ignores `jws`/`signatureValue`/non-strings; and `extractDelegationFromVC` now agrees with the verifier (a `jws`-only proof extracts no signature). `tsc` clean; existing middleware + delegation suites green (115 tests).

Scoped intentionally: this is the field-agreement fix only. #151 (proof.type enforcement) is separate.
