### PR TITLE
fix(delegation): reject unsupported credential proof.type before signature check

### DIFF
--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -256,6 +256,37 @@ describe("DelegationCredentialVerifier", () => {
       expect(result.stage).toBe("basic");
     });
 
+    it("should reject an unsupported proof.type without invoking the signature verifier (#151)", async () => {
+      await setupDefaultContractsMocks();
+      const badVC = {
+        ...mockValidVC,
+        proof: { ...mockValidVC.proof, type: "BogusSuite2099" },
+      };
+
+      const result = await verifier.verifyDelegationCredential(badVC);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toMatch(/proof\.type/i);
+      // Rejected before the Ed25519-over-proofValue check runs: a valid
+      // signature cannot rescue an unsupported suite.
+      expect(mockSignatureVerifier).not.toHaveBeenCalled();
+    });
+
+    it("should accept a supported proof.type (DataIntegrityProof) through the suite gate", async () => {
+      await setupDefaultContractsMocks();
+      const okVC = {
+        ...mockValidVC,
+        proof: { ...mockValidVC.proof, type: "DataIntegrityProof" },
+      };
+
+      const result = await verifier.verifyDelegationCredential(okVC);
+
+      // The proof.type gate passes; any failure now is a later stage (here, DID
+      // resolution), never the suite. Had the gate rejected, the reason would
+      // name proof.type.
+      expect(result.reason).not.toMatch(/proof\.type/i);
+    });
+
     it("should reject invalid schema at basic validation stage", async () => {
       const contractsMock = await setupDefaultContractsMocks();
       // Create a mock ZodError-like object without importing zod

--- a/src/delegation/vc-verification-checks.ts
+++ b/src/delegation/vc-verification-checks.ts
@@ -13,6 +13,7 @@ import type {
 import {
   isDelegationCredentialExpired,
   isDelegationCredentialNotYetValid,
+  isSupportedCredentialProofType,
   validateDelegationCredential,
 } from "../types/protocol.js";
 import type {
@@ -174,6 +175,22 @@ export async function verifySignature(
         valid: false,
         reason:
           "No DID resolver or signature verifier configured — signature cannot be verified",
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    // Bind the declared proof suite to one this path can actually verify. The
+    // embedded-proof signature check below authenticates an Ed25519 signature
+    // over `proofValue`; a credential naming an unsupported/unknown `proof.type`
+    // must not verify merely because that signature happens to validate (#151).
+    // Checked here, before resolving the issuer DID, so an unrecognized suite
+    // fails fast without a network round-trip. The VC-JWT path skips signature
+    // verification entirely (its envelope JWS is the proof), so it never reaches
+    // this check and its `JwtProof2020` marker is correctly exempt.
+    if (vc.proof && !isSupportedCredentialProofType(vc.proof.type)) {
+      return {
+        valid: false,
+        reason: `Unsupported credential proof.type: ${String(vc.proof.type)}`,
         durationMs: Date.now() - startTime,
       };
     }

--- a/src/types/__tests__/protocol.test.ts
+++ b/src/types/__tests__/protocol.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractDelegationFromVC,
+  isSupportedCredentialProofType,
   readCredentialProofValue,
+  SUPPORTED_CREDENTIAL_PROOF_TYPES,
   type DelegationCredential,
 } from '../protocol.js';
 
@@ -64,5 +66,28 @@ describe('extractDelegationFromVC signature agreement', () => {
   it('extracts no signature when the credential has no proof', () => {
     const record = extractDelegationFromVC(credentialWithProof(undefined));
     expect(record.signature).toBe('');
+  });
+});
+
+describe('isSupportedCredentialProofType', () => {
+  it('accepts the suites the verifier can actually check', () => {
+    expect(isSupportedCredentialProofType('Ed25519Signature2020')).toBe(true);
+    expect(isSupportedCredentialProofType('DataIntegrityProof')).toBe(true);
+    for (const type of SUPPORTED_CREDENTIAL_PROOF_TYPES) {
+      expect(isSupportedCredentialProofType(type)).toBe(true);
+    }
+  });
+
+  it('rejects an unknown suite: naming it must not pass verification (#151)', () => {
+    expect(isSupportedCredentialProofType('BogusSuite2099')).toBe(false);
+    // jws-based suites are not verifiable here; the verifier checks proofValue.
+    expect(isSupportedCredentialProofType('JsonWebSignature2020')).toBe(false);
+  });
+
+  it('rejects a missing or non-string proof.type', () => {
+    expect(isSupportedCredentialProofType(undefined)).toBe(false);
+    expect(isSupportedCredentialProofType(null)).toBe(false);
+    expect(isSupportedCredentialProofType(42)).toBe(false);
+    expect(isSupportedCredentialProofType('')).toBe(false);
   });
 });

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -221,6 +221,25 @@ export function readCredentialProofValue(
 }
 
 /**
+ * The credential-proof signature suites a verifier can actually check here: an
+ * Ed25519 signature over the RFC 8785 (JCS) canonical credential, carried in
+ * `proofValue`. `Ed25519Signature2020` and `DataIntegrityProof` (the `eddsa-jcs`
+ * cryptosuite) are the two labels the reference implementation emits for that one
+ * construction. A credential naming any other `proof.type` must be rejected rather
+ * than pass merely because its Ed25519 signature happens to validate, so the suite
+ * named in the credential is bound to the suite actually used (#151).
+ */
+export const SUPPORTED_CREDENTIAL_PROOF_TYPES: ReadonlySet<string> = new Set([
+  'Ed25519Signature2020',
+  'DataIntegrityProof',
+]);
+
+/** True iff `type` names a credential-proof suite this verifier can verify. */
+export function isSupportedCredentialProofType(type: unknown): type is string {
+  return typeof type === 'string' && SUPPORTED_CREDENTIAL_PROOF_TYPES.has(type);
+}
+
+/**
  * Extract a DelegationRecord from a DelegationCredential.
  */
 export function extractDelegationFromVC(vc: DelegationCredential): DelegationRecord {


### PR DESCRIPTION
## Summary

A `DelegationCredential` declares its proof suite in `proof.type`, but the embedded-proof verifier authenticated the Ed25519 signature over `proofValue` **without** checking that the declared suite is one it actually verifies that way. A credential could name an unsupported or unknown suite (e.g. `JsonWebSignature2020`, or any arbitrary label) and still pass, because its signature happened to validate against the resolved issuer key. The suite named in the credential was not bound to the suite actually used (#151).

## Fix

Bind the named suite to the verified one:

- `SUPPORTED_CREDENTIAL_PROOF_TYPES` (`Ed25519Signature2020`, `DataIntegrityProof`) and an `isSupportedCredentialProofType` predicate on `types/protocol.ts`. These are the two labels the reference implementation emits for its one construction: an Ed25519 signature over the RFC 8785 (JCS) canonical credential, carried in `proofValue`.
- Enforced in `verifySignature`, **before** the issuer DID is resolved, so an unrecognized suite fails fast with no network round-trip.

The check lives in the **embedded-proof path only**. The VC-JWT path skips embedded-signature verification (its envelope JWS is the proof, verified separately by `verifyVcJwtSignature`), so its synthetic `JwtProof2020` marker never reaches this gate and stays exempt. That boundary is covered by the existing VC-JWT and grant-resolution suites, which stay green.

## Tests

- `types/__tests__/protocol.test.ts`: unit coverage for the predicate and the allow-list (accepts the supported suites; rejects an unknown suite and `JsonWebSignature2020`; rejects missing/non-string).
- `delegation/__tests__/vc-verifier.test.ts`: behavioral coverage that an unsupported `proof.type` is rejected without invoking the signature verifier, and a supported suite passes the gate and proceeds.

Full `delegation` + `middleware` suites: 641 passing. `tsc --noEmit` and `eslint` clean.

## Suggested working-group follow-up (not in this PR)

This PR is the implementation fix. Two normative points are left for the WG rather than changed unilaterally in the DIF-maintained spec:

- Promote the suite-binding requirement to a normative MUST in `SPEC.md` (a verifier MUST reject a credential whose `proof.type` is outside the supported set).
- Add a negative conformance vector (unsupported `proof.type` + otherwise-valid signature -> reject).

Closes #151.