### PR TITLE
docs(conformance): clarify signed-proof/tampered-meta requires meta-vs-jws reconciliation

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -430,6 +430,12 @@ protocol, and `negotiation` exercises the MCP extension admission gate
 A `fail` vector passes the suite only when the implementation correctly **rejects**
 it. The runner exits non-zero on any mismatch.
 
+**On `signed-proof/tampered-meta`.**
+The proof's `meta` block mirrors the claims signed inside the JWS, but it is a convenience for consumers that read the proof without decoding the token, not an authoritative copy.
+This vector leaves the JWS byte-identical to `valid-basic` and alters only the mirrored `meta.requestHash`, so the JWS signature still verifies.
+A conformant verifier MUST reconcile `meta` against the decoded JWS payload and reject on any mismatch.
+Signature validity alone does not pass this vector: it is the `requestHash` counterpart of the `responseHash` recompute rule in L2.11.
+
 ### Running the reference implementation
 
 ```bash


### PR DESCRIPTION
## Summary

The `signed-proof/tampered-meta` vector expects a `fail`, but its JWS is byte-identical to `valid-basic` and its signature verifies. What differs is the non-authoritative `meta` mirror carried alongside the token. A verifier that checks only JWS signature validity passes it and does not detect the tamper.

This surfaced in a conformance submission (#149): an independent implementation reported that a signature-only verifier passes the vector, and suggested documenting the distinction. The vector is correct by design, but `CONFORMANCE.md` did not state the requirement it exercises.

## Change

Adds a note to the harness section of `CONFORMANCE.md` making explicit that a conformant verifier MUST reconcile the `meta` mirror against the decoded JWS payload and reject on any mismatch, and that signature validity alone is insufficient. This is the `requestHash` counterpart of the `responseHash` recompute rule already documented under L2.11.

Docs only. No vector, schema, or code change.

Refs #149.