### PR TITLE
docs: mark KYA-OS v1 as ratified

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ Breaking changes to the specification require **explicit vote**:
 
 ## Relationship to DIF TAAWG
 
-This repository implements the KYA-OS specification, donated to the **Decentralized Identity Foundation (DIF) Trusted AI Agents Working Group (TAAWG)** and under review there for ratification as a DIF standard.
+This repository implements the KYA-OS specification, donated to the **Decentralized Identity Foundation (DIF) Trusted AI Agents Working Group (TAAWG)** and ratified there as a DIF standard.
 
 - **Spec decisions** are made in the working group
 - **Implementation decisions** are made here

--- a/SPEC.md
+++ b/SPEC.md
@@ -23,7 +23,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Status
 
-**Stable 1.0.0** — Donated to DIF TAAWG (Decentralized Identity Foundation, Trusted AI Agents Working Group). Under review for ratification as a DIF standard. The wire format is stable: any future change that breaks compatibility with this version will require a major version bump.
+**Stable 1.0.0** — Donated to DIF TAAWG (Decentralized Identity Foundation, Trusted AI Agents Working Group) and ratified as a DIF standard. The wire format is stable: any future change that breaks compatibility with this version will require a major version bump.
 
 ---
 


### PR DESCRIPTION
## What
v1 of the KYA-OS spec was ratified as a DIF standard by the DIF TAAWG. Two status lines still read "under review for ratification"; this brings them up to date.

## Changed
- `SPEC.md` — status line → ratified.
- `GOVERNANCE.md` — DIF-relationship line → ratified.

## Deliberately left as-is
- `SPEC-ENTITY-CARD.md` — the Entity Card is a separate profile on its own ratification track, so its ratification language is unchanged.
- `submission/0000-decentralized-authority.md` — the SEP draft's "not yet ratified" caveat is a deliberate scoping hedge.
- `CHANGELOG.md` — historical release entries.