### PR TITLE
fix(delegation): evaluate revocation status on every verification (close verdict-cache fail-open)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-12
+
+### Security
+
+- **Delegation verifier: revocation status and expiry are now evaluated on
+  every verification.** The per-instance cache previously stored the entire
+  verdict for `cacheTtl` (default 60 s), so a cache hit skipped the
+  credential-status check — a revoked credential kept verifying (and, on the
+  Data Integrity path, an expired one) until the entry lapsed. The cache now
+  holds only the signature/DID-validity result; basic checks and revocation
+  status run on every call, with signature and status still checked in
+  parallel. Warm-path latency now includes one status read — freshness policy
+  belongs in your `StatusListResolver`, never in the verdict. The `cached`
+  result flag now means "signature served from cache".
+
+### Added
+
+- **`withStatusCache(resolver, { maxStalenessMs, maxEntries? })`** — wraps any
+  `StatusListResolver` to cache status *bits* for an explicitly declared
+  staleness bound: the deployment names its revocation SLA instead of
+  inheriting a silent verdict cache. Throws are never cached (fail-closed
+  retry); `maxStalenessMs: 0` is a pass-through.
+- **`delegation.verificationCache` middleware config** (`{ ttlMs, maxEntries }`)
+  tuning the signature-verification cache; `ttlMs: 0` disables signature
+  caching (immediate issuer key-rotation pickup). Constructor `cacheTtl: 0`
+  is now honored (`??`, previously swallowed by `||`), and
+  `createDelegationVerifier` gains `maxCacheSize` parity.
+
 ## [1.12.0] - 2026-08-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.4",
@@ -914,9 +914,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: identity, delegation, proofs, sessions, and verifiable audit trails",
   "license": "MIT",
   "type": "module",

--- a/src/delegation/__tests__/status-cache.test.ts
+++ b/src/delegation/__tests__/status-cache.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { withStatusCache } from '../status-cache.js';
+import type { CredentialStatus } from '../../types/protocol.js';
+
+const entry = (index: string): CredentialStatus => ({
+  id: `https://status.example/1#${index}`,
+  type: 'StatusList2021Entry',
+  statusPurpose: 'revocation',
+  statusListIndex: index,
+  statusListCredential: 'https://status.example/1',
+});
+
+describe('withStatusCache', () => {
+  it('serves the cached bit within maxStalenessMs (one upstream read)', async () => {
+    let calls = 0;
+    const cached = withStatusCache(
+      { checkStatus: async () => { calls += 1; return false; } },
+      { maxStalenessMs: 60_000 },
+    );
+    expect(await cached.checkStatus(entry('1'))).toBe(false);
+    expect(await cached.checkStatus(entry('1'))).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it('re-reads upstream after maxStalenessMs — a revocation lands at the declared SLA', async () => {
+    let calls = 0;
+    let revoked = false;
+    const cached = withStatusCache(
+      { checkStatus: async () => { calls += 1; return revoked; } },
+      { maxStalenessMs: 10 },
+    );
+    expect(await cached.checkStatus(entry('2'))).toBe(false);
+    revoked = true;
+    await new Promise((r) => setTimeout(r, 15));
+    expect(await cached.checkStatus(entry('2'))).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  it('never caches a throw (fail-closed retry)', async () => {
+    let calls = 0;
+    const cached = withStatusCache(
+      {
+        checkStatus: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error('unreachable');
+          return false;
+        },
+      },
+      { maxStalenessMs: 60_000 },
+    );
+    await expect(cached.checkStatus(entry('3'))).rejects.toThrow('unreachable');
+    expect(await cached.checkStatus(entry('3'))).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it('maxStalenessMs <= 0 is a pass-through (every call reads upstream)', async () => {
+    let calls = 0;
+    const cached = withStatusCache(
+      { checkStatus: async () => { calls += 1; return false; } },
+      { maxStalenessMs: 0 },
+    );
+    await cached.checkStatus(entry('4'));
+    await cached.checkStatus(entry('4'));
+    expect(calls).toBe(2);
+  });
+
+  it('keys entries independently (a revoked neighbor does not leak)', async () => {
+    const bits: Record<string, boolean> = { '5': false, '6': true };
+    const cached = withStatusCache(
+      { checkStatus: async (s) => bits[s.statusListIndex] ?? true },
+      { maxStalenessMs: 60_000 },
+    );
+    expect(await cached.checkStatus(entry('5'))).toBe(false);
+    expect(await cached.checkStatus(entry('6'))).toBe(true);
+  });
+});

--- a/src/delegation/__tests__/vc-jwt-verify.test.ts
+++ b/src/delegation/__tests__/vc-jwt-verify.test.ts
@@ -197,6 +197,37 @@ describe("verifyDelegationJwt (VC-JWT / compact JWS wire format)", () => {
     expect(second.cached).toBe(true);
   });
 
+  it("denies the very next call after a mid-session revocation — warm cache, no clears", async () => {
+    let revoked = false;
+    const gated = new DelegationCredentialVerifier({
+      didResolver: resolverFor(publicJwk),
+      statusListResolver: { checkStatus: async () => revoked },
+    });
+    const jwt = await mintVcJwt(
+      privateKey,
+      delegationVcClaim({
+        id: "urn:uuid:revocation-freshness-jwt",
+        credentialStatus: {
+          id: "https://status.example/1#7",
+          type: "StatusList2021Entry",
+          statusPurpose: "revocation",
+          statusListIndex: "7",
+          statusListCredential: "https://status.example/1",
+        },
+      }),
+    );
+
+    const before = await gated.verifyDelegationJwt(jwt);
+    expect(before.valid).toBe(true);
+
+    revoked = true;
+
+    const after = await gated.verifyDelegationJwt(jwt);
+    expect(after.valid).toBe(false);
+    expect(after.statusOutcome).toBe("revoked");
+    expect(after.cached).toBe(true);
+  });
+
   it("honors skipSignature (trusts the envelope without re-checking)", async () => {
     const jwt = await mintVcJwt(privateKey);
     const result = await verifier.verifyDelegationJwt(jwt, {

--- a/src/delegation/__tests__/vc-verifier.integration.test.ts
+++ b/src/delegation/__tests__/vc-verifier.integration.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   DelegationCredentialVerifier,
   type DIDResolver,
+  type StatusListResolver,
 } from '../vc-verifier.js';
 import { DelegationCredentialIssuer } from '../vc-issuer.js';
 import { createDidKeyResolver } from '../did-key-resolver.js';
@@ -179,6 +180,57 @@ describe('DelegationCredentialVerifier (real crypto)', () => {
 
     expect(result.valid).toBe(false);
     expect(result.stage).toBe('basic');
+  });
+
+  // ── Revocation freshness (the 2026-08 fail-open regression) ───
+
+  it('denies the very next call after a mid-session revocation — warm cache, no clears', async () => {
+    let revoked = false;
+    const flipResolver: StatusListResolver = {
+      checkStatus: async () => revoked,
+    };
+
+    const gated = new DelegationCredentialVerifier({
+      didResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+      statusListResolver: flipResolver,
+    });
+
+    const vc = await issuer.issueDelegationCredential(
+      {
+        id: 'del-revocation-freshness',
+        issuerDid: issuerIdentity.did,
+        subjectDid: subjectIdentity.did,
+        vcId: 'urn:uuid:revocation-freshness',
+        constraints: {
+          scopes: ['tools:read'],
+          notBefore: Math.floor(Date.now() / 1000) - 3600,
+          notAfter: Math.floor(Date.now() / 1000) + 3600,
+        },
+        signature: '',
+        status: 'active',
+        createdAt: Date.now(),
+      },
+      {
+        credentialStatus: {
+          id: 'https://status.example/1#94',
+          type: 'StatusList2021Entry',
+          statusPurpose: 'revocation',
+          statusListIndex: '94',
+          statusListCredential: 'https://status.example/1',
+        },
+      },
+    );
+
+    const before = await gated.verifyDelegationCredential(vc);
+    expect(before.valid).toBe(true);
+
+    revoked = true; // the on-chain bit flips mid-session
+
+    const after = await gated.verifyDelegationCredential(vc);
+    expect(after.valid).toBe(false);
+    expect(after.statusOutcome).toBe('revoked');
+    expect(after.cached).toBe(true); // signature from cache — status still caught it
   });
 
   // ── Metrics ───────────────────────────────────────────────────

--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -136,6 +136,11 @@ describe("DelegationCredentialVerifier", () => {
       const verifier = createDelegationVerifier(options);
       expect(verifier).toBeInstanceOf(DelegationCredentialVerifier);
     });
+
+    it("passes maxCacheSize through the factory", () => {
+      const bounded = createDelegationVerifier({ cacheTtl: 3000, maxCacheSize: 10 });
+      expect(bounded).toBeInstanceOf(DelegationCredentialVerifier);
+    });
   });
 
   describe("verifyDelegationCredential - Basic Validation Stage", () => {
@@ -653,9 +658,8 @@ describe("DelegationCredentialVerifier", () => {
   });
 
   describe("verifyDelegationCredential - Caching", () => {
-    it("should return cached result when available", async () => {
+    it("serves the signature from cache while status stays live", async () => {
       await setupDefaultContractsMocks();
-      // First call - should verify and cache
       mockDidResolver.resolve.mockResolvedValue({
         id: "did:web:example.com:issuer",
         verificationMethod: [
@@ -674,17 +678,125 @@ describe("DelegationCredentialVerifier", () => {
       expect(result1.valid).toBe(true);
       expect(result1.cached).toBeUndefined();
 
-      // Second call - should return cached result
+      // Second call — the SIGNATURE comes from cache; nothing else does.
       mockSignatureVerifier.mockClear();
-      mockStatusListResolver.checkStatus.mockClear();
 
       const result2 = await verifier.verifyDelegationCredential(mockValidVC);
       expect(result2.valid).toBe(true);
       expect(result2.cached).toBe(true);
-
-      // Verifiers should not be called again
       expect(mockSignatureVerifier).not.toHaveBeenCalled();
-      expect(mockStatusListResolver.checkStatus).not.toHaveBeenCalled();
+    });
+
+    it("consults revocation status on every call — a cached signature never masks a fresh revocation", async () => {
+      await setupDefaultContractsMocks();
+      const vcWithStatus: DelegationCredential = {
+        ...mockValidVC,
+        credentialStatus: {
+          id: "https://example.com/status/1#94",
+          type: "StatusList2021Entry",
+          statusPurpose: "revocation",
+          statusListIndex: "94",
+          statusListCredential: "https://example.com/status/1",
+        },
+      };
+      mockDidResolver.resolve.mockResolvedValue({
+        id: "did:web:example.com:issuer",
+        verificationMethod: [
+          {
+            id: "did:web:example.com:issuer#key-1",
+            type: "Ed25519VerificationKey2020",
+            controller: "did:web:example.com:issuer",
+            publicKeyJwk: { kty: "OKP", crv: "Ed25519", x: "mock-key" },
+          },
+        ],
+      });
+      mockSignatureVerifier.mockResolvedValue({ valid: true });
+      mockStatusListResolver.checkStatus.mockResolvedValue(false); // live
+
+      const first = await verifier.verifyDelegationCredential(vcWithStatus);
+      expect(first.valid).toBe(true);
+
+      // REVOKED mid-session: no clearCache, no skipCache — the very next
+      // call must see it.
+      mockStatusListResolver.checkStatus.mockResolvedValue(true);
+
+      const second = await verifier.verifyDelegationCredential(vcWithStatus);
+      expect(second.valid).toBe(false);
+      expect(second.statusOutcome).toBe("revoked");
+      expect(second.reason).toContain("revoked");
+      expect(second.cached).toBe(true); // signature was cached — status still caught it
+      expect(mockStatusListResolver.checkStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it("honors expiry on a warm signature cache (DI path no longer skips basic checks on a hit)", async () => {
+      const contractsMock = await setupDefaultContractsMocks();
+      mockDidResolver.resolve.mockResolvedValue({
+        id: "did:web:example.com:issuer",
+        verificationMethod: [
+          {
+            id: "did:web:example.com:issuer#key-1",
+            type: "Ed25519VerificationKey2020",
+            controller: "did:web:example.com:issuer",
+            publicKeyJwk: { kty: "OKP", crv: "Ed25519", x: "mock-key" },
+          },
+        ],
+      });
+      mockSignatureVerifier.mockResolvedValue({ valid: true });
+
+      const first = await verifier.verifyDelegationCredential(mockValidVC);
+      expect(first.valid).toBe(true);
+
+      // The credential expires between the calls; a warm signature cache
+      // must not carry it past its window.
+      contractsMock.isDelegationCredentialExpired.mockReturnValue(true);
+
+      const second = await verifier.verifyDelegationCredential(mockValidVC);
+      expect(second.valid).toBe(false);
+      expect(second.stage).toBe("basic");
+      expect(second.reason).toBe("Delegation credential expired");
+    });
+
+    it("cacheTtl: 0 disables signature caching (0 is honored, not defaulted)", async () => {
+      await setupDefaultContractsMocks();
+      const uncached = new DelegationCredentialVerifier({
+        didResolver: mockDidResolver as DIDResolver,
+        statusListResolver: mockStatusListResolver as StatusListResolver,
+        signatureVerifier: mockSignatureVerifier,
+        cacheTtl: 0,
+      });
+      mockDidResolver.resolve.mockResolvedValue({
+        id: "did:web:example.com:issuer",
+        verificationMethod: [
+          {
+            id: "did:web:example.com:issuer#key-1",
+            type: "Ed25519VerificationKey2020",
+            controller: "did:web:example.com:issuer",
+            publicKeyJwk: { kty: "OKP", crv: "Ed25519", x: "mock-key" },
+          },
+        ],
+      });
+      mockSignatureVerifier.mockResolvedValue({ valid: true });
+
+      const first = await uncached.verifyDelegationCredential(mockValidVC);
+      expect(first.cached).toBeUndefined();
+      const second = await uncached.verifyDelegationCredential(mockValidVC);
+      expect(second.cached).toBeUndefined();
+      expect(mockSignatureVerifier).toHaveBeenCalledTimes(2);
+    });
+
+    it("never caches a skipSignature run (the cache holds only real verifications)", async () => {
+      await setupDefaultContractsMocks();
+
+      const first = await verifier.verifyDelegationCredential(mockValidVC, {
+        skipSignature: true,
+      });
+      expect(first.valid).toBe(true);
+      expect(first.cached).toBeUndefined();
+
+      const second = await verifier.verifyDelegationCredential(mockValidVC, {
+        skipSignature: true,
+      });
+      expect(second.cached).toBeUndefined();
     });
 
     it("should skip cache when skipCache is true", async () => {

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -7,6 +7,7 @@
 
 export * from './vc-issuer.js';
 export * from './vc-verifier.js';
+export * from './status-cache.js';
 export * from './vc-jwt-verify.js';
 export * from './bitstring.js';
 export * from './statuslist-manager.js';

--- a/src/delegation/status-cache.ts
+++ b/src/delegation/status-cache.ts
@@ -1,0 +1,46 @@
+/**
+ * `withStatusCache` — an EXPLICIT staleness knob for revocation checks.
+ *
+ * The delegation verifier consults `StatusListResolver.checkStatus` on every
+ * verification (the 2026-08-12 fail-open fix): freshness policy belongs HERE,
+ * at the resolver, where the deployment declares it — never in a silent
+ * verdict cache. This wrapper caches status BITS for a bounded, named
+ * `maxStalenessMs`, so "how stale may revocation data be?" is a deployment
+ * decision with a number attached — the same trade the old verdict cache made
+ * silently, now scoped to status data only and signed off by name.
+ *
+ * Fail-closed is preserved: a resolver THROW is never cached (the next call
+ * retries), and `maxStalenessMs <= 0` makes the wrapper a pass-through.
+ */
+import type { CredentialStatus } from '../types/protocol.js';
+import type { StatusListResolver } from './vc-verifier.types.js';
+import { TtlCache } from '../utils/ttl-cache.js';
+
+export interface StatusCacheOptions {
+  /** Upper bound on served staleness, in ms — your declared revocation SLA. `<= 0` disables caching. */
+  maxStalenessMs: number;
+  /** Maximum cached entries (FIFO eviction). Default 1000. */
+  maxEntries?: number;
+}
+
+export function withStatusCache(
+  resolver: StatusListResolver,
+  options: StatusCacheOptions,
+): StatusListResolver {
+  const cache = new TtlCache<boolean>({
+    ttlMs: options.maxStalenessMs,
+    maxEntries: options.maxEntries ?? 1000,
+  });
+
+  return {
+    async checkStatus(status: CredentialStatus): Promise<boolean> {
+      const key = `${status.statusListCredential}\0${status.statusListIndex}\0${status.statusPurpose}`;
+      const hit = cache.get(key);
+      if (hit !== undefined) return hit;
+      // A throw propagates uncached — fail-closed deny now, retry next call.
+      const revoked = await resolver.checkStatus(status);
+      cache.set(key, revoked);
+      return revoked;
+    },
+  };
+}

--- a/src/delegation/vc-verifier.ts
+++ b/src/delegation/vc-verifier.ts
@@ -10,7 +10,8 @@
  *
  * The stateless checks live in `./vc-verification-checks.ts`; the shapes in
  * `./vc-verifier.types.ts` (re-exported below). This class owns orchestration
- * and the per-instance result cache.
+ * and the per-instance SIGNATURE-result cache — revocation status and basic
+ * checks (expiry) are evaluated on every call, never served from cache.
  *
  * Related Spec: KYA-OS §4.3, W3C VC Data Model 1.1
  */
@@ -23,6 +24,7 @@ import type {
   StatusListResolver,
   StatusCheckResult,
   SignatureVerificationFunction,
+  SignatureVerificationResult,
 } from "./vc-verifier.types.js";
 import {
   validateBasicProperties,
@@ -36,6 +38,7 @@ import {
 } from "./vc-jwt-verify.js";
 import type { VcJwtSignatureResult } from "./vc-jwt-verify.js";
 import { canonicalizeJson } from "../utils/canonical-json.js";
+import { TtlCache } from "../utils/ttl-cache.js";
 
 // Re-export the shared type surface so existing imports of DIDResolver /
 // SignatureVerificationFunction / StatusListResolver / … are unchanged.
@@ -45,23 +48,18 @@ export class DelegationCredentialVerifier {
   private didResolver?: DIDResolver;
   private statusListResolver?: StatusListResolver;
   private signatureVerifier?: SignatureVerificationFunction;
-  private cache = new Map<
-    string,
-    { result: DelegationVCVerificationResult; expiresAt: number }
-  >();
-  private cacheInsertionOrder: string[] = [];
-  private cacheTtl: number;
   /**
-   * Maximum number of entries in the verification cache.
-   * In production deployments, configure maxCacheSize based on expected concurrent delegations.
-   * Default of 1000 is suitable for most use cases.
+   * Signature-result cache (FIFO eviction, TTL-bounded). Holds only REAL
+   * signature verifications; size `maxCacheSize` to the expected number of
+   * DISTINCT live credentials — the default of 1000 suits most deployments.
    */
-  private maxCacheSize: number;
+  private cache: TtlCache<SignatureVerificationResult>;
 
   constructor(options?: {
     didResolver?: DIDResolver;
     statusListResolver?: StatusListResolver;
     signatureVerifier?: SignatureVerificationFunction;
+    /** Signature-result TTL in ms. `0` disables signature caching. Default 60_000. */
     cacheTtl?: number;
     /** Maximum cache entries. Default: 1000 */
     maxCacheSize?: number;
@@ -69,8 +67,11 @@ export class DelegationCredentialVerifier {
     this.didResolver = options?.didResolver;
     this.statusListResolver = options?.statusListResolver;
     this.signatureVerifier = options?.signatureVerifier;
-    this.cacheTtl = options?.cacheTtl || 60_000;
-    this.maxCacheSize = options?.maxCacheSize ?? 1000;
+    this.cache = new TtlCache<SignatureVerificationResult>({
+      // `??`, not `||`: cacheTtl 0 means "no signature caching", not "the default".
+      ttlMs: options?.cacheTtl ?? 60_000,
+      maxEntries: options?.maxCacheSize ?? 1000,
+    });
   }
 
   /**
@@ -91,13 +92,8 @@ export class DelegationCredentialVerifier {
     const startTime = Date.now();
     const cacheKey = this.cacheKeyForCredential('di', vc, options);
 
-    if (cacheKey !== null) {
-      const cached = this.getFromCache(cacheKey);
-      if (cached) {
-        return { ...cached, cached: true };
-      }
-    }
-
+    // Basic checks run on EVERY call — expiry is time-sensitive, so a warm
+    // signature cache must never carry a credential past its window.
     const basicCheckStart = Date.now();
     const basicValidation = validateBasicProperties(vc);
     const basicCheckMs = Date.now() - basicCheckStart;
@@ -118,20 +114,21 @@ export class DelegationCredentialVerifier {
       return result;
     }
 
-    const signaturePromise = !options.skipSignature
-      ? verifySignature(
-          vc,
-          options.didResolver || this.didResolver,
-          this.signatureVerifier,
-        )
-      : Promise.resolve<{
-          valid: boolean;
-          reason?: string;
-          durationMs?: number;
-        }>({
-          valid: true,
-          durationMs: 0,
-        });
+    // Both promises are constructed before either is awaited: a signature
+    // cache hit resolves instantly ALONGSIDE the live status read; a miss
+    // runs signature and status concurrently (unchanged parallelism).
+    const signaturePromise = this.cachedSignature(cacheKey, () =>
+      options.skipSignature
+        ? Promise.resolve<SignatureVerificationResult>({
+            valid: true,
+            durationMs: 0,
+          })
+        : verifySignature(
+            vc,
+            options.didResolver || this.didResolver,
+            this.signatureVerifier,
+          ),
+    );
 
     const statusPromise =
       !options.skipStatus && vc.credentialStatus
@@ -149,7 +146,6 @@ export class DelegationCredentialVerifier {
       statusPromise,
       basicCheckMs,
       startTime,
-      cacheKey,
     );
   }
 
@@ -177,21 +173,19 @@ export class DelegationCredentialVerifier {
     const { vc, issuerDid, kid, basicCheckMs } = prepared;
     const cacheKey = this.cacheKeyForJwt(jwt, vc, options);
 
-    if (cacheKey !== null) {
-      const cached = this.getFromCache(cacheKey);
-      if (cached) {
-        return { ...cached, cached: true };
-      }
-    }
-
-    const signaturePromise = !options.skipSignature
-      ? verifyVcJwtSignature(
-          jwt,
-          issuerDid,
-          kid,
-          options.didResolver || this.didResolver,
-        )
-      : Promise.resolve<VcJwtSignatureResult>({ valid: true, durationMs: 0 });
+    // Same construction as the Data Integrity path: both promises exist
+    // before either is awaited, so a cached signature races a LIVE status
+    // read and a miss keeps full signature/status parallelism.
+    const signaturePromise = this.cachedSignature(cacheKey, () =>
+      options.skipSignature
+        ? Promise.resolve<VcJwtSignatureResult>({ valid: true, durationMs: 0 })
+        : verifyVcJwtSignature(
+            jwt,
+            issuerDid,
+            kid,
+            options.didResolver || this.didResolver,
+          ),
+    );
 
     const statusPromise =
       !options.skipStatus && vc.credentialStatus
@@ -209,41 +203,64 @@ export class DelegationCredentialVerifier {
       statusPromise,
       basicCheckMs,
       startTime,
-      cacheKey,
     );
   }
 
   /**
-   * Await the parallel signature + status checks, fold them into the final
-   * result via {@link combineVerificationResult}, and cache a valid one. Shared
-   * by the Data Integrity and VC-JWT paths; both reach here only after
-   * `validateBasicProperties` has passed.
+   * Resolve the signature dimension: an unexpired cached result when
+   * available, else `run()` — cached only when valid (failures are never
+   * cached). Returned as a promise so callers can race it with the status
+   * check; a hit reports `durationMs: 0` (the retrieval, not the original
+   * compute).
+   */
+  private async cachedSignature(
+    cacheKey: string | null,
+    run: () => Promise<SignatureVerificationResult>,
+  ): Promise<{ result: SignatureVerificationResult; cached: boolean }> {
+    if (cacheKey !== null) {
+      const hit = this.cache.get(cacheKey);
+      if (hit) {
+        return { result: { ...hit, durationMs: 0 }, cached: true };
+      }
+    }
+    const result = await run();
+    if (result.valid && cacheKey !== null) {
+      this.cache.set(cacheKey, result);
+    }
+    return { result, cached: false };
+  }
+
+  /**
+   * Await the parallel signature + status checks and fold them into the final
+   * result via {@link combineVerificationResult}. The combined verdict is
+   * NEVER cached — only the signature dimension is (inside
+   * {@link cachedSignature}) — so revocation status is consulted on every
+   * call. Shared by the Data Integrity and VC-JWT paths; both reach here only
+   * after `validateBasicProperties` has passed.
    */
   private async finalizeVerification(
     signaturePromise: Promise<{
-      valid: boolean;
-      reason?: string;
-      durationMs?: number;
+      result: SignatureVerificationResult;
+      cached: boolean;
     }>,
     statusPromise: Promise<StatusCheckResult>,
     basicCheckMs: number,
     startTime: number,
-    cacheKey: string | null,
   ): Promise<DelegationVCVerificationResult> {
-    const [signatureResult, statusResult] = await Promise.all([
+    const [signature, statusResult] = await Promise.all([
       signaturePromise,
       statusPromise,
     ]);
 
     const result = combineVerificationResult(
-      signatureResult,
+      signature.result,
       statusResult,
       basicCheckMs,
       startTime,
     );
 
-    if (result.valid && cacheKey !== null) {
-      this.setInCache(cacheKey, result);
+    if (signature.cached) {
+      result.cached = true;
     }
 
     return result;
@@ -256,7 +273,7 @@ export class DelegationCredentialVerifier {
   ): string | null {
     if (!this.cacheAllowed(options)) return null;
     try {
-      return `${mode}\0${vc.id ?? ''}\0${this.verificationProfile(options)}\0${canonicalizeJson(vc)}`;
+      return `${mode}\0${vc.id ?? ''}\0${canonicalizeJson(vc)}`;
     } catch {
       return null;
     }
@@ -268,61 +285,33 @@ export class DelegationCredentialVerifier {
     options: VerifyDelegationVCOptions,
   ): string | null {
     if (!this.cacheAllowed(options)) return null;
-    return `jwt\0${vc.id ?? ''}\0${this.verificationProfile(options)}\0${jwt}`;
+    return `jwt\0${vc.id ?? ''}\0${jwt}`;
   }
 
+  /**
+   * The cache holds only REAL signature verifications: a `skipSignature` run
+   * fabricates `{ valid: true }` at zero cost, so it neither reads nor writes
+   * the cache (which is what lets the key drop the old per-profile
+   * dimension). Per-call resolver overrides also bypass — conservative,
+   * unchanged.
+   */
   private cacheAllowed(options: VerifyDelegationVCOptions): boolean {
     return !options.skipCache &&
+      !options.skipSignature &&
       options.didResolver === undefined &&
       options.statusListResolver === undefined;
   }
 
-  private verificationProfile(options: VerifyDelegationVCOptions): string {
-    return `signature:${options.skipSignature ? 'skip' : 'verify'}|status:${options.skipStatus ? 'skip' : 'verify'}`;
-  }
-
-  private getFromCache(id: string): DelegationVCVerificationResult | null {
-    const entry = this.cache.get(id);
-    if (!entry) return null;
-
-    if (Date.now() > entry.expiresAt) {
-      this.cache.delete(id);
-      return null;
-    }
-
-    return entry.result;
-  }
-
-  private setInCache(id: string, result: DelegationVCVerificationResult): void {
-    // Evict oldest entry if cache exceeds maxCacheSize (simple FIFO)
-    while (this.cache.size >= this.maxCacheSize && this.cacheInsertionOrder.length > 0) {
-      const oldestId = this.cacheInsertionOrder.shift();
-      if (oldestId) {
-        this.cache.delete(oldestId);
-      }
-    }
-
-    this.cache.set(id, {
-      result,
-      expiresAt: Date.now() + this.cacheTtl,
-    });
-    this.cacheInsertionOrder.push(id);
-  }
-
   clearCache(): void {
     this.cache.clear();
-    this.cacheInsertionOrder = [];
   }
 
   clearCacheEntry(id: string): void {
     const diPrefix = `di\0${id}\0`;
     const jwtPrefix = `jwt\0${id}\0`;
-    for (const key of [...this.cache.keys()]) {
-      if (!key.startsWith(diPrefix) && !key.startsWith(jwtPrefix)) continue;
-      this.cache.delete(key);
-      const index = this.cacheInsertionOrder.indexOf(key);
-      if (index !== -1) this.cacheInsertionOrder.splice(index, 1);
-    }
+    this.cache.deleteWhere(
+      (key) => key.startsWith(diPrefix) || key.startsWith(jwtPrefix),
+    );
   }
 }
 
@@ -330,7 +319,10 @@ export function createDelegationVerifier(options?: {
   didResolver?: DIDResolver;
   statusListResolver?: StatusListResolver;
   signatureVerifier?: SignatureVerificationFunction;
+  /** Signature-result TTL in ms. `0` disables signature caching. Default 60_000. */
   cacheTtl?: number;
+  /** Maximum cache entries. Default: 1000 */
+  maxCacheSize?: number;
 }): DelegationCredentialVerifier {
   return new DelegationCredentialVerifier(options);
 }

--- a/src/delegation/vc-verifier.types.ts
+++ b/src/delegation/vc-verifier.types.ts
@@ -19,6 +19,18 @@ import type { CredentialStatus } from "../types/protocol.js";
  */
 export type StatusOutcome = "revoked" | "status_unresolvable";
 
+/**
+ * The signature/DID-validity dimension of a verification — the expensive,
+ * slow-changing half that the verifier caches. Shared by the Data Integrity
+ * path (`verifySignature`) and the VC-JWT path (`verifyVcJwtSignature`,
+ * whose `VcJwtSignatureResult` is structurally identical).
+ */
+export interface SignatureVerificationResult {
+  valid: boolean;
+  reason?: string;
+  durationMs?: number;
+}
+
 export interface DelegationVCVerificationResult {
   valid: boolean;
   reason?: string;
@@ -29,6 +41,13 @@ export interface DelegationVCVerificationResult {
    */
   statusOutcome?: StatusOutcome;
   stage: "basic" | "signature" | "status" | "complete";
+  /**
+   * True when the SIGNATURE verification was served from the per-instance
+   * cache. Basic checks (schema/expiry) and revocation status are always
+   * evaluated fresh on every call — only the signature/DID-validity result
+   * is ever cached. On a hit, `metrics.signatureCheckMs` reports the
+   * near-zero cache retrieval, not the original compute.
+   */
   cached?: boolean;
   metrics?: {
     basicCheckMs?: number;

--- a/src/middleware/__tests__/delegation-verify.verification-cache.test.ts
+++ b/src/middleware/__tests__/delegation-verify.verification-cache.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Delegation verification — `verificationCache` config threading.
+ *
+ * Proves `KyaOsDelegationConfig.verificationCache` reaches the
+ * `DelegationCredentialVerifier` through `createDelegationVerification`,
+ * observed from OUTSIDE the verifier: with the default cache, the second
+ * verification of the same credential serves the signature from cache (the
+ * custom DID resolver is consulted once); with `ttlMs: 0`, signature caching
+ * is disabled and the resolver is consulted on every call.
+ */
+import { describe, it, expect } from 'vitest';
+import { createDelegationVerification } from '../with-kya-os.delegation-verify.js';
+import type { MiddlewareDeps } from '../with-kya-os.deps.js';
+import type { KyaOsDelegationConfig } from '../with-kya-os.config-types.js';
+import { DelegationCredentialIssuer } from '../../delegation/vc-issuer.js';
+import { createDidKeyResolver } from '../../delegation/did-key-resolver.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealSigningFunction,
+} from '../../__tests__/audit/helpers/crypto-helpers.js';
+
+async function setup(
+  verificationCache?: NonNullable<KyaOsDelegationConfig['verificationCache']>,
+) {
+  const crypto = createRealCryptoProvider();
+  const issuerIdentity = await createRealIdentity(crypto);
+  const subjectIdentity = await createRealIdentity(crypto);
+  const issuer = new DelegationCredentialIssuer(
+    {
+      getDid: () => issuerIdentity.did,
+      getKeyId: () => issuerIdentity.kid,
+      getPrivateKey: () => issuerIdentity.privateKey,
+    },
+    createRealSigningFunction(crypto, issuerIdentity),
+  );
+  const vc = await issuer.issueDelegationCredential({
+    id: 'del-cache-config-test',
+    issuerDid: issuerIdentity.did,
+    subjectDid: subjectIdentity.did,
+    vcId: 'urn:uuid:cache-config-test',
+    constraints: {
+      scopes: ['tools:read'],
+      notBefore: Math.floor(Date.now() / 1000) - 3600,
+      notAfter: Math.floor(Date.now() / 1000) + 3600,
+    },
+    signature: '',
+    status: 'active',
+    createdAt: Date.now(),
+  });
+
+  const didKey = createDidKeyResolver();
+  let resolves = 0;
+  const deps = {
+    identity: {
+      did: issuerIdentity.did,
+      kid: issuerIdentity.kid,
+      privateKey: issuerIdentity.privateKey,
+      publicKey: issuerIdentity.publicKey,
+    },
+    cryptoProvider: crypto,
+    delegationConfig: {
+      didResolver: {
+        async resolve(did: string) {
+          resolves += 1;
+          return didKey.resolve(did);
+        },
+      },
+      ...(verificationCache ? { verificationCache } : {}),
+    },
+  } as unknown as MiddlewareDeps;
+
+  const verification = createDelegationVerification(deps);
+  return { verification, vc, resolveCount: () => resolves };
+}
+
+describe('verificationCache config threading', () => {
+  it('serves the signature from cache on the second call by default', async () => {
+    const { verification, vc, resolveCount } = await setup();
+    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect(resolveCount()).toBe(1);
+  });
+
+  it('ttlMs: 0 disables signature caching (resolver consulted every call)', async () => {
+    const { verification, vc, resolveCount } = await setup({ ttlMs: 0 });
+    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect(resolveCount()).toBe(2);
+  });
+});

--- a/src/middleware/with-kya-os.config-types.ts
+++ b/src/middleware/with-kya-os.config-types.ts
@@ -101,6 +101,19 @@ export interface KyaOsDelegationConfig {
    * rejected — so enabling `'enforce'` never breaks did:web traffic.
    */
   holderBinding?: "off" | "warn" | "enforce";
+  /**
+   * Tuning for the delegation verifier's SIGNATURE-verification cache (the
+   * expensive DID-resolve + crypto dimension). Revocation status and basic
+   * checks (expiry) are always evaluated fresh on every call and are NOT
+   * affected by this setting. Set `ttlMs: 0` to disable signature caching
+   * entirely (e.g. when issuer key rotation must take effect immediately).
+   */
+  verificationCache?: {
+    /** Signature-result TTL in milliseconds. Default 60_000. `0` disables caching. */
+    ttlMs?: number;
+    /** Maximum cached signature results (FIFO eviction). Default 1000. */
+    maxEntries?: number;
+  };
 }
 
 export interface KyaOsConfig {

--- a/src/middleware/with-kya-os.delegation-verify.ts
+++ b/src/middleware/with-kya-os.delegation-verify.ts
@@ -173,6 +173,8 @@ export function createDelegationVerification(
     didResolver,
     signatureVerifier,
     statusListResolver: delegationConfig?.statusListResolver,
+    cacheTtl: delegationConfig?.verificationCache?.ttlMs,
+    maxCacheSize: delegationConfig?.verificationCache?.maxEntries,
   });
 
   const buildDelegationErrorResponse = (

--- a/src/utils/__tests__/ttl-cache.test.ts
+++ b/src/utils/__tests__/ttl-cache.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { TtlCache } from '../ttl-cache.js';
+
+describe('TtlCache', () => {
+  it('serves an unexpired value and deletes an expired one on read', async () => {
+    const cache = new TtlCache<string>({ ttlMs: 10, maxEntries: 10 });
+    cache.set('k', 'v');
+    expect(cache.get('k')).toBe('v');
+    await new Promise((r) => setTimeout(r, 15));
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('ttlMs <= 0 disables storage entirely', () => {
+    const cache = new TtlCache<string>({ ttlMs: 0, maxEntries: 10 });
+    cache.set('k', 'v');
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('evicts the oldest entry at maxEntries (FIFO)', () => {
+    const cache = new TtlCache<number>({ ttlMs: 60_000, maxEntries: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('overwriting a key keeps order coherent — refresh survives, oldest neighbor evicts', () => {
+    const cache = new TtlCache<number>({ ttlMs: 60_000, maxEntries: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('a', 3); // refresh: delete + re-insert as newest, no phantom order entry
+    cache.set('c', 4); // full → evicts 'b' (now the oldest), never the refreshed 'a'
+    expect(cache.get('a')).toBe(3);
+    expect(cache.get('c')).toBe(4);
+    expect(cache.get('b')).toBeUndefined();
+  });
+
+  it('repeated overwrites of one key never evict below capacity', () => {
+    const cache = new TtlCache<number>({ ttlMs: 60_000, maxEntries: 2 });
+    cache.set('k', 1);
+    for (let i = 0; i < 100; i++) cache.set('k', i); // concurrent-miss shape: same key, many sets
+    cache.set('other', 7);
+    expect(cache.get('k')).toBe(99);
+    expect(cache.get('other')).toBe(7); // no phantom 'k' entries to mis-evict against
+  });
+
+  it('maxEntries <= 0 disables storage (parity with ttlMs)', () => {
+    const cache = new TtlCache<string>({ ttlMs: 60_000, maxEntries: 0 });
+    cache.set('k', 'v');
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('deleteWhere removes matching keys only', () => {
+    const cache = new TtlCache<number>({ ttlMs: 60_000, maxEntries: 10 });
+    cache.set('di id-1 x', 1);
+    cache.set('jwt id-1 y', 2);
+    cache.set('di id-2 z', 3);
+    cache.deleteWhere((key) => key.includes('id-1'));
+    expect(cache.get('di id-1 x')).toBeUndefined();
+    expect(cache.get('jwt id-1 y')).toBeUndefined();
+    expect(cache.get('di id-2 z')).toBe(3);
+  });
+});

--- a/src/utils/ttl-cache.ts
+++ b/src/utils/ttl-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Minimal TTL + FIFO-bounded map — the ONE eviction implementation shared by
+ * the delegation verifier's signature-result cache and the `withStatusCache`
+ * resolver wrapper (DRY). Internal utility; not exported from the package
+ * surface.
+ *
+ * Semantics: `ttlMs <= 0` or `maxEntries <= 0` disables storage entirely (an
+ * entry that is born expired or unstorable must never serve); expired entries
+ * are deleted on read; overwriting a key re-inserts it as newest; when full,
+ * the oldest inserted entry is evicted (simple FIFO, no LRU bookkeeping).
+ */
+export class TtlCache<T> {
+  private entries = new Map<string, { value: T; expiresAt: number }>();
+  private insertionOrder: string[] = [];
+
+  constructor(private options: { ttlMs: number; maxEntries: number }) {}
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    if (this.options.ttlMs <= 0 || this.options.maxEntries <= 0) return;
+
+    // Overwrite = delete + re-insert, keeping `entries` and `insertionOrder`
+    // in bijection. Without this, N concurrent misses on one key leave N-1
+    // phantom order entries (a slow leak keyed by KB-scale cache keys), and
+    // an at-capacity refresh evicts an innocent neighbor.
+    if (this.entries.has(key)) this.delete(key);
+
+    // Evict oldest entries if the cache is full (simple FIFO)
+    while (
+      this.entries.size >= this.options.maxEntries &&
+      this.insertionOrder.length > 0
+    ) {
+      const oldest = this.insertionOrder.shift();
+      if (oldest) this.entries.delete(oldest);
+    }
+
+    this.entries.set(key, {
+      value,
+      expiresAt: Date.now() + this.options.ttlMs,
+    });
+    this.insertionOrder.push(key);
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+    const index = this.insertionOrder.indexOf(key);
+    if (index !== -1) this.insertionOrder.splice(index, 1);
+  }
+
+  deleteWhere(predicate: (key: string) => boolean): void {
+    for (const key of [...this.entries.keys()]) {
+      if (predicate(key)) this.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.insertionOrder = [];
+  }
+}


### PR DESCRIPTION
## Description

The delegation verifier cached the full verdict for `cacheTtl` (60 s default), so a cache hit skipped the credential-status check entirely: a revoked credential kept authorizing until its cache entry expired — and on the Data Integrity path the hit also skipped basic checks, carrying an expired credential past its window. Surfaced by security review and independently hit during DEF CON 34 ["REVOKED"](https://www.loom.com/share/f32b82a292f14a6c952dba3a0a246e45) demo rehearsals (real testnet funds moved under a freshly revoked credential until an in-process gate rebuild was added as a workaround).

This PR decouples the cache into a **signature-validity cache**:

- Revocation status and basic checks (expiry) run on **every** verification; only the expensive signature/DID-resolution result is cached (real verifications only — `skipSignature` runs are never stored). Signature and status are still awaited in parallel.
- `cacheTtl: 0` is honored (`??`, previously swallowed by `||`) — signature caching can be disabled outright, e.g. for immediate issuer key-rotation pickup.
- New middleware config `delegation.verificationCache { ttlMs, maxEntries }`; `createDelegationVerifier` gains `maxCacheSize` parity.
- **`withStatusCache(resolver, { maxStalenessMs })`** — the explicit staleness knob: deployments that need the warm-path latency back cache status *bits* at a declared revocation SLA, at the resolver layer where freshness policy belongs. Fail-closed preserved (throws never cached).
- Regression coverage: mid-session revocation denied on the very next call (mocked + real-Ed25519, Data Integrity + VC-JWT wire formats), expiry honored on a warm cache, `ttlMs: 0`, config threading, status-cache SLA behavior, shared `TtlCache` utility.

Fail-closed posture is unchanged in kind and strengthened in practice: a resolver that starts failing now denies immediately instead of hiding behind a cached verdict. `cached` on the result now means "signature served from cache".

## Spec Impact

None to SPEC.md — verification semantics are implementation-level; the fail-closed invariant (§4.3) is preserved and strengthened. The `cached` flag's meaning is documented in `vc-verifier.types.ts` and the CHANGELOG.

## Checklist

- [x] Tests pass (`npm test`)
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable