### PR TITLE
feat(delegation): accept multibase/base58 verification-method keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- **Multibase verification-method keys.** Both delegation signature paths
+  (Data Integrity and VC-JWT) now accept verification methods that publish
+  `publicKeyMultibase` (base58btc Ed25519, with or without the 0xed01
+  multicodec prefix) or legacy `publicKeyBase58`, synthesizing the OKP JWK at
+  the point of use — did:cheqd issuers verify end-to-end without a
+  JWK-rewriting resolver. Fail-closed: anything not provably a 32-byte
+  Ed25519 key still denies.
+
 ## [1.13.0] - 2026-08-12
 
 ### Security

--- a/src/delegation/__tests__/vc-jwt-verify.test.ts
+++ b/src/delegation/__tests__/vc-jwt-verify.test.ts
@@ -228,6 +228,33 @@ describe("verifyDelegationJwt (VC-JWT / compact JWS wire format)", () => {
     expect(after.cached).toBe(true);
   });
 
+  it("accepts a VC-JWT when the issuer publishes only publicKeyMultibase", async () => {
+    const { base58Encode } = await import("../../utils/base58.js");
+    const raw = Buffer.from(publicJwk.x as string, "base64url");
+    const multibase = `z${base58Encode(new Uint8Array([0xed, 0x01, ...raw]))}`;
+    const multibaseResolver: DIDResolver = {
+      async resolve(did: string): Promise<DIDDocument | null> {
+        if (did !== ISSUER_DID) return null;
+        return {
+          id: ISSUER_DID,
+          verificationMethod: [
+            {
+              id: KID,
+              type: "Ed25519VerificationKey2020",
+              controller: ISSUER_DID,
+              publicKeyMultibase: multibase,
+            },
+          ],
+        };
+      },
+    };
+    const verifier = new DelegationCredentialVerifier({ didResolver: multibaseResolver });
+    const jwt = await mintVcJwt(privateKey);
+    const result = await verifier.verifyDelegationJwt(jwt, { skipCache: true });
+    expect(result.valid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
   it("honors skipSignature (trusts the envelope without re-checking)", async () => {
     const jwt = await mintVcJwt(privateKey);
     const result = await verifier.verifyDelegationJwt(jwt, {

--- a/src/delegation/__tests__/vc-verifier.integration.test.ts
+++ b/src/delegation/__tests__/vc-verifier.integration.test.ts
@@ -233,6 +233,74 @@ describe('DelegationCredentialVerifier (real crypto)', () => {
     expect(after.cached).toBe(true); // signature from cache — status still caught it
   });
 
+  // ── Multibase verification methods (PR 2a) ────────────────────
+
+  it('verifies a signed VC when the issuer publishes only publicKeyMultibase', async () => {
+    const { base58Encode } = await import('../../utils/base58.js');
+    const { base64urlDecodeToBytes } = await import('../../utils/base64.js');
+    const didKeyDoc = await didResolver.resolve(issuerIdentity.did);
+    const jwk = didKeyDoc?.verificationMethod?.[0]?.publicKeyJwk as { x: string };
+    const rawKey = base64urlDecodeToBytes(jwk.x);
+    const multibase = `z${base58Encode(new Uint8Array([0xed, 0x01, ...rawKey]))}`;
+
+    const multibaseOnlyResolver: DIDResolver = {
+      async resolve(did: string) {
+        const doc = await didResolver.resolve(did);
+        if (!doc?.verificationMethod) return doc;
+        return {
+          ...doc,
+          verificationMethod: doc.verificationMethod.map((m) => ({
+            id: m.id,
+            type: 'Ed25519VerificationKey2020',
+            controller: m.controller,
+            publicKeyMultibase: multibase,
+          })),
+        };
+      },
+    };
+
+    const vc = await issueVC({ vcId: 'urn:uuid:multibase-only' });
+    const multibaseVerifier = new DelegationCredentialVerifier({
+      didResolver: multibaseOnlyResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+
+    const result = await multibaseVerifier.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.checks?.signatureValid).toBe(true);
+  });
+
+  it('still denies a verification method with no usable key', async () => {
+    const keylessResolver: DIDResolver = {
+      async resolve(did: string) {
+        const doc = await didResolver.resolve(did);
+        if (!doc?.verificationMethod) return doc;
+        return {
+          ...doc,
+          verificationMethod: doc.verificationMethod.map((m) => ({
+            id: m.id,
+            type: 'Ed25519VerificationKey2020',
+            controller: m.controller,
+          })),
+        };
+      },
+    };
+    const vc = await issueVC({ vcId: 'urn:uuid:keyless' });
+    const keyless = new DelegationCredentialVerifier({
+      didResolver: keylessResolver,
+      signatureVerifier: createRealSignatureVerifier(crypto),
+    });
+    const result = await keyless.verifyDelegationCredential(vc, {
+      skipStatus: true,
+      skipCache: true,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('no usable public key');
+  });
+
   // ── Metrics ───────────────────────────────────────────────────
 
   it('should report timing metrics for all stages', async () => {

--- a/src/delegation/__tests__/vc-verifier.test.ts
+++ b/src/delegation/__tests__/vc-verifier.test.ts
@@ -432,7 +432,9 @@ describe("DelegationCredentialVerifier", () => {
       const result = await verifier.verifyDelegationCredential(mockValidVC);
 
       expect(result.valid).toBe(false);
-      expect(result.reason).toBe("Verification method missing publicKeyJwk");
+      expect(result.reason).toBe(
+        "Verification method has no usable public key (publicKeyJwk / publicKeyMultibase / publicKeyBase58)",
+      );
       expect(result.checks?.signatureValid).toBe(false);
     });
 

--- a/src/delegation/__tests__/verification-method-key.test.ts
+++ b/src/delegation/__tests__/verification-method-key.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { verificationMethodJwk } from '../verification-method-key.js';
+import { base58Encode } from '../../utils/base58.js';
+import type { VerificationMethod } from '../vc-verifier.types.js';
+
+const RAW = new Uint8Array(32).map((_, i) => i + 1);
+const WITH_CODEC = new Uint8Array([0xed, 0x01, ...RAW]);
+const vm = (extra: Partial<VerificationMethod>): VerificationMethod => ({
+  id: 'did:example:issuer#key-1',
+  type: 'Ed25519VerificationKey2020',
+  controller: 'did:example:issuer',
+  ...extra,
+});
+
+describe('verificationMethodJwk', () => {
+  it('passes an existing publicKeyJwk through untouched', () => {
+    const jwk = { kty: 'OKP', crv: 'Ed25519', x: 'abc' };
+    expect(verificationMethodJwk(vm({ publicKeyJwk: jwk }))).toBe(jwk);
+  });
+
+  it('synthesizes from publicKeyMultibase with the 0xed01 multicodec prefix', () => {
+    const result = verificationMethodJwk(
+      vm({ publicKeyMultibase: `z${base58Encode(WITH_CODEC)}` }),
+    );
+    expect(result).toMatchObject({ kty: 'OKP', crv: 'Ed25519' });
+    expect(typeof result?.x).toBe('string');
+  });
+
+  it('synthesizes from a bare 32-byte publicKeyMultibase (no codec prefix)', () => {
+    const result = verificationMethodJwk(
+      vm({ publicKeyMultibase: `z${base58Encode(RAW)}` }),
+    );
+    expect(result).toMatchObject({ kty: 'OKP', crv: 'Ed25519' });
+  });
+
+  it('synthesizes from legacy publicKeyBase58', () => {
+    const result = verificationMethodJwk(vm({ publicKeyBase58: base58Encode(RAW) }));
+    expect(result).toMatchObject({ kty: 'OKP', crv: 'Ed25519' });
+  });
+
+  it('prefers publicKeyJwk when several encodings are present', () => {
+    const jwk = { kty: 'OKP', crv: 'Ed25519', x: 'explicit' };
+    const result = verificationMethodJwk(
+      vm({ publicKeyJwk: jwk, publicKeyMultibase: `z${base58Encode(WITH_CODEC)}` }),
+    );
+    expect(result).toBe(jwk);
+  });
+
+  it('rejects a non-Ed25519 multicodec prefix (fail-closed)', () => {
+    const wrongCodec = new Uint8Array([0xec, 0x01, ...RAW]); // x25519, 34 bytes
+    expect(
+      verificationMethodJwk(vm({ publicKeyMultibase: `z${base58Encode(wrongCodec)}` })),
+    ).toBeUndefined();
+  });
+
+  it('rejects wrong key lengths (fail-closed)', () => {
+    expect(
+      verificationMethodJwk(vm({ publicKeyMultibase: `z${base58Encode(RAW.slice(0, 31))}` })),
+    ).toBeUndefined();
+    expect(
+      verificationMethodJwk(vm({ publicKeyBase58: base58Encode(new Uint8Array(33)) })),
+    ).toBeUndefined();
+  });
+
+  it('rejects a non-z multibase prefix (fail-closed)', () => {
+    expect(
+      verificationMethodJwk(vm({ publicKeyMultibase: `f${base58Encode(RAW)}` })),
+    ).toBeUndefined();
+  });
+
+  it('rejects malformed base58 and absent key material (fail-closed)', () => {
+    expect(verificationMethodJwk(vm({ publicKeyMultibase: 'z0OIl' }))).toBeUndefined();
+    expect(verificationMethodJwk(vm({}))).toBeUndefined();
+  });
+});

--- a/src/delegation/did-key-resolver.ts
+++ b/src/delegation/did-key-resolver.ts
@@ -21,10 +21,10 @@ import type { DIDResolver, DIDDocument, VerificationMethod } from './vc-verifier
 import { logger } from '../logging/index.js';
 
 /** Ed25519 multicodec prefix (0xed 0x01) */
-const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01]);
+export const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01]);
 
 /** Ed25519 public key length */
-const ED25519_PUBLIC_KEY_LENGTH = 32;
+export const ED25519_PUBLIC_KEY_LENGTH = 32;
 
 /**
  * Check if a DID is a valid did:key with Ed25519 key

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -8,6 +8,7 @@
 export * from './vc-issuer.js';
 export * from './vc-verifier.js';
 export * from './status-cache.js';
+export * from './verification-method-key.js';
 export * from './vc-jwt-verify.js';
 export * from './bitstring.js';
 export * from './statuslist-manager.js';

--- a/src/delegation/vc-jwt-verify.ts
+++ b/src/delegation/vc-jwt-verify.ts
@@ -28,6 +28,7 @@ import type {
 } from "./vc-verifier.types.js";
 import { parseVCJWT } from "./utils.js";
 import { validateBasicProperties } from "./vc-verification-checks.js";
+import { verificationMethodJwk } from "./verification-method-key.js";
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -180,12 +181,16 @@ export async function verifyVcJwtSignature(
         : "DID Document has no verification method",
     );
   }
-  if (!vm.publicKeyJwk) {
-    return done(false, "Verification method missing publicKeyJwk");
+  const publicKeyJwk = verificationMethodJwk(vm);
+  if (!publicKeyJwk) {
+    return done(
+      false,
+      "Verification method has no usable public key (publicKeyJwk / publicKeyMultibase / publicKeyBase58)",
+    );
   }
 
   try {
-    const key = await importJWK(vm.publicKeyJwk as JWK, "EdDSA");
+    const key = await importJWK(publicKeyJwk as JWK, "EdDSA");
     await compactVerify(jwt, key, { algorithms: ["EdDSA"] });
     return done(true);
   } catch (err) {

--- a/src/delegation/vc-verification-checks.ts
+++ b/src/delegation/vc-verification-checks.ts
@@ -25,6 +25,7 @@ import type {
   SignatureVerificationFunction,
   DelegationVCVerificationResult,
 } from "./vc-verifier.types.js";
+import { verificationMethodJwk } from "./verification-method-key.js";
 
 /**
  * Properties a DelegationCredential `credentialSubject` may carry. Anything
@@ -233,11 +234,12 @@ export async function verifySignature(
       };
     }
 
-    const publicKeyJwk = verificationMethod.publicKeyJwk;
+    const publicKeyJwk = verificationMethodJwk(verificationMethod);
     if (!publicKeyJwk) {
       return {
         valid: false,
-        reason: "Verification method missing publicKeyJwk",
+        reason:
+          "Verification method has no usable public key (publicKeyJwk / publicKeyMultibase / publicKeyBase58)",
         durationMs: Date.now() - startTime,
       };
     }

--- a/src/delegation/verification-method-key.ts
+++ b/src/delegation/verification-method-key.ts
@@ -1,0 +1,66 @@
+/**
+ * Verification-method key extraction — one place that answers "what Ed25519
+ * public key does this verification method publish?".
+ *
+ * The `VerificationMethod` type has always declared `publicKeyMultibase` and
+ * `publicKeyBase58` alongside `publicKeyJwk`, but both signature paths read
+ * only the JWK — so a did:cheqd issuer (which publishes multibase keys) could
+ * never verify end-to-end. This helper converts at the point of use; resolvers
+ * keep reporting DID documents exactly as published.
+ *
+ * FAIL-CLOSED: anything that is not provably a 32-byte Ed25519 key —
+ * non-`z` multibase, wrong multicodec, wrong length, malformed base58 —
+ * returns `undefined`, and the caller denies with its usual reason.
+ */
+import { base58Decode } from '../utils/base58.js';
+import {
+  publicKeyToJwk,
+  ED25519_MULTICODEC_PREFIX,
+  ED25519_PUBLIC_KEY_LENGTH,
+} from './did-key-resolver.js';
+import type { VerificationMethod } from './vc-verifier.types.js';
+
+/** Multibase prefix for base58btc. */
+const MULTIBASE_BASE58BTC = 'z';
+
+/**
+ * The verification method's public key as an Ed25519 OKP JWK: an existing
+ * `publicKeyJwk` is returned untouched (byte-for-byte — zero behavior change
+ * for documents that already publish JWKs); otherwise one is synthesized from
+ * `publicKeyMultibase` (base58btc, with or without the 0xed01 multicodec
+ * prefix) or legacy `publicKeyBase58`. `undefined` when no usable Ed25519 key
+ * is present (fail-closed).
+ */
+export function verificationMethodJwk(
+  method: VerificationMethod,
+): { kty: string; crv: string; x: string } | undefined {
+  if (method.publicKeyJwk) {
+    return method.publicKeyJwk as { kty: string; crv: string; x: string };
+  }
+
+  const raw = rawEd25519Key(method);
+  return raw ? publicKeyToJwk(raw) : undefined;
+}
+
+/** Decode multibase/base58 key material to raw bytes; `undefined` unless it is exactly a 32-byte Ed25519 key. */
+function rawEd25519Key(method: VerificationMethod): Uint8Array | undefined {
+  try {
+    if (method.publicKeyMultibase?.startsWith(MULTIBASE_BASE58BTC)) {
+      const decoded = base58Decode(method.publicKeyMultibase.slice(1));
+      const stripped =
+        decoded.length === ED25519_PUBLIC_KEY_LENGTH + ED25519_MULTICODEC_PREFIX.length &&
+        decoded[0] === ED25519_MULTICODEC_PREFIX[0] &&
+        decoded[1] === ED25519_MULTICODEC_PREFIX[1]
+          ? decoded.slice(ED25519_MULTICODEC_PREFIX.length)
+          : decoded;
+      return stripped.length === ED25519_PUBLIC_KEY_LENGTH ? stripped : undefined;
+    }
+    if (method.publicKeyBase58) {
+      const decoded = base58Decode(method.publicKeyBase58);
+      return decoded.length === ED25519_PUBLIC_KEY_LENGTH ? decoded : undefined;
+    }
+  } catch {
+    return undefined; // malformed base58 → fail-closed
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Description

Both delegation signature paths (Data Integrity and VC-JWT) refuse any verification method lacking `publicKeyJwk` — but did:cheqd DID documents publish `publicKeyMultibase` (and some legacy documents `publicKeyBase58`), so a did:cheqd issuer can never verify end-to-end against the shipped verifier. The `VerificationMethod` type has always declared both fields; only the check code ignored them. (Surfaced while building the DEF CON 34 "REVOKED" demo, which had to ship a JWK-rewriting resolver wrapper to work around it.)

This PR adds one small module and swaps two access sites:

- **`verificationMethodJwk(method)`** (`src/delegation/verification-method-key.ts`): an existing `publicKeyJwk` passes through untouched (byte-for-byte, zero behavior change for documents that already publish JWKs); otherwise an Ed25519 OKP JWK is synthesized from `publicKeyMultibase` (base58btc, with or without the `0xed01` multicodec prefix) or legacy `publicKeyBase58`, reusing the existing `publicKeyToJwk` / `base58Decode` primitives and the multicodec constants now exported from `did-key-resolver.ts`.
- Both consumption sites (`vc-verification-checks.ts`, `vc-jwt-verify.ts`) call the helper; the deny reason widens to name all three encodings.
- **Fail-closed:** non-`z` multibase, wrong multicodec, wrong key length, malformed base58, or no key material → `undefined` → the same deny path as before. jose's `algorithms: ["EdDSA"]` pin is unchanged.
- Conversion happens at the point of use — resolvers keep reporting DID documents exactly as published.

Coverage: 9-case unit matrix on the helper; end-to-end with real Ed25519 on both wire formats against a multibase-only DID document; keyless-method regression. 12 new tests; full suite 2003 passed / 1 pre-existing skip.

This unblocks the next step of the upstreaming arc (an on-chain cheqd StatusList resolver), which is unusable end-to-end without it. Changes are under `[Unreleased]`; version cut planned with the resolver PR.

## Spec Impact

None to SPEC.md. The implementation now honors what the `VerificationMethod` type (and W3C DID Core) already declare. Fail-closed posture unchanged.

## Checklist

- [x] Tests pass (`npm test`)
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable