### PR TITLE
refactor(statuslist): consolidate reading primitives into utils/statuslist-bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Versioning: https://semver.org/spec/v2.0.0.html
   JWK-rewriting resolver. Fail-closed: anything not provably a 32-byte
   Ed25519 key still denies.
 
+### Changed
+
+- **Status-list reading mechanics consolidated into `utils/statuslist-bits`.**
+  Canonical index parsing, the 16 MiB inflation cap, multibase/base64url
+  payload decoding, and the MSB-first bit read previously existed as separate
+  copies in the delegation readers (`bitstring.ts`, `statuslist-manager.ts`)
+  and the card revocation reader (`card/revocation.ts`) — held in sync only by
+  source comments. One shared implementation now serves both seams; each
+  seam's policy (throw → `status_unresolvable` vs `FAIL_CLOSED`, freshness)
+  is unchanged. Behavior-preserving: every existing test passes unmodified.
+
+### Deprecated
+
+- **`RevocationChecker` (card module).** Renamed to
+  `BitstringRevocationChecker` — the old name collided with the
+  delegation-side `RevocationChecker` interface (`chain-enforcement.ts`), two
+  identically named exports answering different questions. The old name
+  remains as a deprecated alias until 2.0.
+
 ## [1.13.0] - 2026-08-12
 
 ### Security

--- a/src/card/delegation.ts
+++ b/src/card/delegation.ts
@@ -14,7 +14,7 @@
  * {@link MAX_DELEGATION_DEPTH}; ROOT `parentCapability` = the resource, `issuer`/`invocationTarget`
  * = (optional) resource owner / resource. THE JOIN (recomputed, asserted nowhere):
  * {@link responsiblePartyOf} = `issuer(rootVC)`, {@link leafInvokerOf} = the leaf delegate a verifier
- * asserts equals `proof.did`. Revocation reuses the injected {@link RevocationChecker} seam from
+ * asserts equals `proof.did`. Revocation reuses the injected {@link BitstringRevocationChecker} seam from
  * `./revocation` (no status-list churn reaches callers; NO `mcp-i-core` runtime dep). Per-hop
  * signature verification is a SEPARATE injected concern; this module owns the CRISP + continuity recompute.
  */
@@ -23,7 +23,7 @@ import { z } from 'zod';
 import { Did, type BitstringStatusListEntry } from './schema.js';
 import {
   evaluateRevocationChain,
-  type RevocationChecker,
+  type BitstringRevocationChecker,
   type RevocationChainResult,
 } from './revocation.js';
 
@@ -315,11 +315,11 @@ export interface DelegationChainEvaluation extends DelegationChainResult {
 }
 
 /** Validate structure AND revocation: run {@link validateDelegationChain}, then (only if it passes —
- *  fail-closed) cascade the injected {@link RevocationChecker} root→leaf via
+ *  fail-closed) cascade the injected {@link BitstringRevocationChecker} root→leaf via
  *  {@link evaluateRevocationChain}. A revoked ancestor invalidates the subtree. */
 export async function evaluateDelegationChain(
   chain: DelegationChain,
-  check: RevocationChecker,
+  check: BitstringRevocationChecker,
   ctx: DelegationChainContext = {},
 ): Promise<DelegationChainEvaluation> {
   const structural = validateDelegationChain(chain, ctx);

--- a/src/card/revocation.ts
+++ b/src/card/revocation.ts
@@ -26,9 +26,14 @@
  * `fresh` (a live status check). NOT wired into `verifyCard` here — a later step injects it.
  */
 
-import { base64urlDecodeToBytes } from '../utils/base64.js';
 import { isRecord } from '../utils/guards.js';
 import { assertStatusPurpose } from '../utils/statuslist-purpose.js';
+import {
+  MAX_STATUS_LIST_BYTES,
+  decodeStatusListPayload,
+  parseStatusListIndex,
+  readStatusBit,
+} from '../utils/statuslist-bits.js';
 import type { SafeFetch } from '../utils/safe-fetch.js';
 import type { BitstringStatusListEntry } from './schema.js';
 
@@ -43,17 +48,12 @@ export const STATUS_PURPOSE_REVOCATION = 'revocation';
  */
 export type Decompress = (bytes: Uint8Array) => Uint8Array | Promise<Uint8Array>;
 
-/** Multibase prefix for an unpadded base64url payload (W3C Bitstring Status List `encodedList`). */
-const MULTIBASE_BASE64URL = 'u';
-
-/**
- * Hard ceiling on the INFLATED status bitstring (16 MiB ⇒ ~134M entries — far beyond any
- * herd-privacy list). A status bitstring is fixed-size, so a generous fixed cap costs nothing
- * legitimate while stopping a decompression bomb: without it, the ~786 KB of GZIP that fits
- * inside SafeFetch's 1 MiB body cap inflates to ~800 MB, blocking the event loop on a synchronous
- * `gunzipSync`. Exceeding the cap makes `gunzipSync` throw, which the checker converts to
- * FAIL_CLOSED — preserving the module's uniform fail-closed posture. */
-const MAX_STATUS_LIST_BYTES = 16 * 1024 * 1024;
+// The 16 MiB inflation cap and the multibase/base64url/bit-read mechanics live in
+// `utils/statuslist-bits` — ONE implementation shared with the delegation readers, so the two
+// paths can no longer drift. Exceeding the cap (or any malformed input) throws, which this
+// checker converts to FAIL_CLOSED — the module's uniform posture. Without the cap, the ~786 KB
+// of GZIP that fits inside SafeFetch's 1 MiB body cap inflates to ~800 MB on a synchronous
+// `gunzipSync`, blocking the event loop.
 
 /** Verdict for ONE status entry. */
 export interface RevocationStatus {
@@ -68,7 +68,16 @@ export interface RevocationStatus {
  * A runtime supplies an implementation (the default is {@link createRevocationChecker}); a
  * caller may inject a cache-backed or offline variant. Implementations MUST fail closed.
  */
-export type RevocationChecker = (entry: BitstringStatusListEntry) => Promise<RevocationStatus>;
+export type BitstringRevocationChecker = (
+  entry: BitstringStatusListEntry,
+) => Promise<RevocationStatus>;
+
+/**
+ * @deprecated Use {@link BitstringRevocationChecker}. This alias collided with the
+ * delegation-side `RevocationChecker` interface (`delegation/chain-enforcement.ts`) — two
+ * identically named exports answering different questions. Alias removed at 2.0.
+ */
+export type RevocationChecker = BitstringRevocationChecker;
 
 /** Result of a cascading root→leaf chain walk. */
 export interface RevocationChainResult {
@@ -107,7 +116,9 @@ const FAIL_CLOSED: RevocationStatus = { revoked: true, fresh: false };
  * request rides the injected {@link SafeFetch}; any failure on the path (unreachable, non-2xx,
  * malformed, wrong purpose, out-of-range index) resolves {@link FAIL_CLOSED}.
  */
-export function createRevocationChecker(deps: RevocationCheckerDeps): RevocationChecker {
+export function createRevocationChecker(
+  deps: RevocationCheckerDeps,
+): BitstringRevocationChecker {
   const clock = deps.now ?? (() => Date.now());
   const wantedPurpose = deps.statusPurpose ?? STATUS_PURPOSE_REVOCATION;
   const decompress = deps.decompress ?? defaultNodeGunzip;
@@ -116,7 +127,7 @@ export function createRevocationChecker(deps: RevocationCheckerDeps): Revocation
       const credential = await fetchStatusList(entry.statusListCredential, deps.fetch);
       assertStatusPurpose(statusListSubject(credential).statusPurpose, wantedPurpose);
       const bits = await decodeStatusList(credential, decompress);
-      const revoked = readBit(bits, parseIndex(entry.statusListIndex));
+      const revoked = readStatusBit(bits, parseStatusListIndex(entry.statusListIndex));
       return { revoked, fresh: isLive(credential, clock()) };
     } catch {
       return FAIL_CLOSED;
@@ -136,7 +147,7 @@ export function createRevocationChecker(deps: RevocationCheckerDeps): Revocation
  */
 export async function evaluateRevocationChain(
   entries: readonly BitstringStatusListEntry[],
-  check: RevocationChecker,
+  check: BitstringRevocationChecker,
 ): Promise<RevocationChainResult> {
   let fresh = entries.length > 0; // no entries ⇒ no live signal ⇒ not fresh (fail-closed for L3)
   for (const [hop, entry] of entries.entries()) {
@@ -187,9 +198,9 @@ async function defaultNodeGunzip(bytes: Uint8Array): Promise<Uint8Array> {
 }
 
 /**
- * Inflate the multibase / GZIP `encodedList` into the raw status bitstring bytes through the
- * injected {@link Decompress} seam. The 16 MiB cap is re-checked here as a POST-inflation backstop:
- * the default gunzip caps mid-stream, but an injected (edge) decompressor that does not bound its
+ * Inflate the multibase / GZIP `encodedList` into the raw status bitstring bytes via the shared
+ * `decodeStatusListPayload` primitive (strip + decode + POST-inflation 16 MiB backstop): the
+ * default gunzip caps mid-stream, but an injected (edge) decompressor that does not bound its
  * own output is still fail-closed against an oversized bitstring at this seam.
  */
 async function decodeStatusList(
@@ -200,48 +211,7 @@ async function decodeStatusList(
   if (typeof encoded !== 'string' || encoded.length === 0) {
     throw new Error('revocation: status-list has no encodedList');
   }
-  const base64url = encoded[0] === MULTIBASE_BASE64URL ? encoded.slice(1) : encoded;
-  const inflated = await decompress(base64urlDecodeToBytes(base64url));
-  if (inflated.length > MAX_STATUS_LIST_BYTES) {
-    throw new Error(
-      `revocation: status list too large: ${inflated.length} bytes exceeds ${MAX_STATUS_LIST_BYTES}`,
-    );
-  }
-  return inflated instanceof Uint8Array ? inflated : new Uint8Array(inflated);
-}
-
-/**
- * Parse the decimal `statusListIndex` (a non-negative integer expressed as a string), fail-closed.
- * MUST be canonical decimal only: `Number()` alone would coerce whitespace (`" "` → 0), hex
- * (`"0x2A"` → 42), octal, `"+42"`, and `"1e1"` → 10 — silently reading a DIFFERENT (often clear) bit
- * than the credential names, so a revoked credential could read as live. Reject anything that is not
- * `[0-9]+`.
- */
-function parseIndex(raw: string): number {
-  if (!/^[0-9]+$/.test(raw)) {
-    throw new Error(`revocation: statusListIndex must be a canonical non-negative decimal (got "${raw}")`);
-  }
-  const index = Number(raw);
-  if (!Number.isSafeInteger(index) || index < 0) {
-    throw new Error(`revocation: statusListIndex out of range "${raw}"`);
-  }
-  return index;
-}
-
-/**
- * Read the status bit at `index` — MSB-first within each byte (W3C Bitstring encoding).
- * Uses FULL-PRECISION arithmetic (`Math.floor(index / 8)`, `index % 8`) rather than the 32-bit
- * bitwise ops `>>>`/`&`, which coerce their operand to uint32 first: an index ≥ 2^32 would
- * silently wrap onto a low byte (e.g. 2^32+5 ⇒ byte 0, bit 5) and read the WRONG — often clear —
- * bit, turning an out-of-range index that MUST fail-closed into a fail-OPEN "not revoked". With
- * full-precision arithmetic an out-of-range byte offset indexes past the bitstring, yielding
- * `undefined` ⇒ throw ⇒ FAIL_CLOSED. */
-function readBit(bits: Uint8Array, index: number): boolean {
-  const byte = bits[Math.floor(index / 8)];
-  if (byte === undefined) {
-    throw new Error(`revocation: statusListIndex ${index} is out of range for the status list`);
-  }
-  return (byte & (0x80 >> (index % 8))) !== 0;
+  return decodeStatusListPayload(encoded, decompress);
 }
 
 /** True iff `nowMs` falls inside the credential's `[validFrom, validUntil]` window (if declared). */

--- a/src/card/verify.ts
+++ b/src/card/verify.ts
@@ -24,7 +24,7 @@ import {
   type Capability,
   type Attestation,
 } from './schema.js';
-import type { RevocationChecker } from './revocation.js';
+import type { BitstringRevocationChecker } from './revocation.js';
 import type { ProofAssurance, ProofVerifyResult } from './proof/index.js';
 import type { ToolRequest } from '../proof/generator.js';
 
@@ -109,7 +109,7 @@ export interface VerifyCardDeps {
   /** Recomputes `proof` against `request` (pre-bound ./proof `verifyCardProof`). Lifts L2 → L3. */
   proofVerifier?: CardProofVerifier;
   /** Live W3C Bitstring Status List v1.0 check for `card.revocation` (fail-closed). */
-  statusListChecker?: RevocationChecker;
+  statusListChecker?: BitstringRevocationChecker;
   /** True iff the caller independently proved CIMD L1 key possession (private_key_jwt ↔ jwks_uri). */
   cimdKeyProven?: boolean;
   /** Trusted issuer allowlist. Default: `DEFAULT_TRUSTED_ISSUERS`. */
@@ -263,7 +263,7 @@ interface CardRevocationVerdict {
 /** Live-check `card.revocation` via the injected seam; fail-closed (unreachable ⇒ revoked). */
 async function checkCardRevocation(
   card: EntityCard,
-  checker: RevocationChecker | undefined,
+  checker: BitstringRevocationChecker | undefined,
 ): Promise<CardRevocationVerdict> {
   if (!checker || !card.revocation) return { checked: false, revoked: false, fresh: true };
   try {

--- a/src/delegation/bitstring.ts
+++ b/src/delegation/bitstring.ts
@@ -14,6 +14,12 @@
  * Related Spec: W3C Bitstring Status List v1.0 (successor to StatusList2021)
  */
 
+import {
+  MULTIBASE_BASE64URL,
+  decodeStatusListPayload,
+  readStatusBit,
+} from '../utils/statuslist-bits.js';
+
 export interface CompressionFunction {
   compress(data: Uint8Array): Promise<Uint8Array>;
 }
@@ -21,17 +27,6 @@ export interface CompressionFunction {
 export interface DecompressionFunction {
   decompress(data: Uint8Array): Promise<Uint8Array>;
 }
-
-/** Fixed ceiling on an inflated status bitstring (16 MiB ≈ 134M entries) — fail-closed against a
- *  decompression bomb. Mirrors the cap in the card revocation reader (src/card/revocation.ts). */
-const MAX_STATUS_LIST_BYTES = 16 * 1024 * 1024;
-
-/** The W3C Bitstring Status List `encodedList` multibase prefix (base64url, no padding). `encode`
- *  emits it and `base64urlDecode` strips it, so this reader is interoperable with the card
- *  revocation reader (src/card/revocation.ts) and any conformant issuer. A gzip stream's fixed
- *  magic byte (0x1f) makes its base64url start with `H`, never `u`, so a leading `u` is
- *  unambiguously the multibase code rather than payload. */
-const MULTIBASE_BASE64URL = 'u';
 
 export class BitstringManager {
   private bits: Uint8Array;
@@ -100,7 +95,9 @@ export class BitstringManager {
     compressor: CompressionFunction,
     decompressor: DecompressionFunction
   ): Promise<BitstringManager> {
-    const decompressed = await inflateStatusList(encodedList, decompressor);
+    const decompressed = await decodeStatusListPayload(encodedList, (bytes) =>
+      decompressor.decompress(bytes)
+    );
 
     const size = decompressed.length * 8;
     const manager = new BitstringManager(size, compressor, decompressor);
@@ -143,55 +140,18 @@ export class BitstringManager {
 }
 
 /**
- * Decode a base64url `encodedList`, stripping an optional leading W3C multibase `u` prefix so this
- * module's own `encode` output and a conformant issuer's `encodedList` decode identically (matches
- * src/card/revocation.ts). Standalone so both {@link BitstringManager.decode} and {@link isIndexSet}
- * share ONE reader (no private-visibility casts).
+ * Read one status bit straight off an `encodedList` (decode + bounded inflate +
+ * MSB-first read via `utils/statuslist-bits`). Fail-CLOSED: an out-of-range or
+ * NaN index cannot be proven clear, so `readStatusBit` throws rather than
+ * reading as "not set".
  */
-function decodeBase64urlMultibase(encoded: string): Uint8Array {
-  const payload = encoded[0] === MULTIBASE_BASE64URL ? encoded.slice(1) : encoded;
-  let standard = payload.replace(/-/g, '+').replace(/_/g, '/');
-  standard += '='.repeat((4 - (standard.length % 4)) % 4);
-  const binary = atob(standard);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
-
-/**
- * Decode + decompress a status-list `encodedList`, FAIL-CLOSED against a decompression bomb via a
- * post-inflation size cap. The single reader path shared by {@link BitstringManager.decode} and
- * {@link isIndexSet}, so both bound inflation identically. (Production decompressors SHOULD also
- * bound output DURING inflation.)
- */
-async function inflateStatusList(
-  encodedList: string,
-  decompressor: DecompressionFunction
-): Promise<Uint8Array> {
-  const decompressed = await decompressor.decompress(decodeBase64urlMultibase(encodedList));
-  if (decompressed.length > MAX_STATUS_LIST_BYTES) {
-    throw new Error(`Status list too large: ${decompressed.length} bytes exceeds ${MAX_STATUS_LIST_BYTES}`);
-  }
-  return decompressed;
-}
-
 export async function isIndexSet(
   encodedList: string,
   index: number,
   decompressor: DecompressionFunction
 ): Promise<boolean> {
-  const decompressed = await inflateStatusList(encodedList, decompressor);
-
-  const byteIndex = Math.floor(index / 8);
-  const bitIndex = index % 8;
-
-  if (!Number.isInteger(index) || index < 0 || byteIndex >= decompressed.length) {
-    // Fail-CLOSED: an out-of-range/NaN index cannot be proven clear, so it must NOT read as "not
-    // set". `!Number.isInteger` is required because `byteIndex >= length` is FALSE for a NaN index
-    // (any comparison with NaN is false), which would otherwise slip past and read bits[NaN] =
-    // undefined = live (the fail-open getBit already rejects, but this standalone reader did not).
-    throw new Error(`Bit index ${index} out of range for the status list`);
-  }
-
-  return (decompressed[byteIndex]! & (0x80 >> bitIndex)) !== 0; // MSB-first (W3C)
+  const decompressed = await decodeStatusListPayload(encodedList, (bytes) =>
+    decompressor.decompress(bytes)
+  );
+  return readStatusBit(decompressed, index);
 }

--- a/src/delegation/statuslist-manager.ts
+++ b/src/delegation/statuslist-manager.ts
@@ -11,6 +11,7 @@ import type {
   CredentialStatus,
 } from '../types/protocol.js';
 import { BitstringManager, type CompressionFunction, type DecompressionFunction } from './bitstring.js';
+import { parseStatusListIndex } from '../utils/statuslist-bits.js';
 import type { VCSigningFunction } from './vc-issuer.js';
 import { canonicalizeJSON } from './utils.js';
 import { assertStatusPurpose } from '../utils/statuslist-purpose.js';
@@ -155,17 +156,9 @@ export class StatusList2021Manager {
       this.decompressor
     );
 
-    // Strict decimal, fail-closed: lenient parseInt would read "0x2A" as 0 / "42abc" as 42, and a
-    // whitespace/NaN index used to slip past getBit's guard and read as "not revoked" (fail-open).
-    if (!/^[0-9]+$/.test(statusListIndex)) {
-      throw new Error(`Invalid statusListIndex "${statusListIndex}" — must be a canonical non-negative decimal`);
-    }
-    const index = Number(statusListIndex);
-    // A canonical-decimal string can still exceed 2^53-1 and lose precision; reject it explicitly at
-    // the parse layer (matches revocation.ts parseIndex) rather than leaning only on getBit's bounds.
-    if (!Number.isSafeInteger(index)) {
-      throw new Error(`statusListIndex "${statusListIndex}" exceeds the safe integer range`);
-    }
+    // Strict canonical-decimal parse, fail-closed (shared primitive — a lenient parse would read a
+    // DIFFERENT, often clear, bit than the credential names: a revocation bypass).
+    const index = parseStatusListIndex(statusListIndex);
     return manager.getBit(index);
   }
 

--- a/src/utils/__tests__/statuslist-bits.test.ts
+++ b/src/utils/__tests__/statuslist-bits.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_STATUS_LIST_BYTES,
+  MULTIBASE_BASE64URL,
+  parseStatusListIndex,
+  decodeStatusListPayload,
+  readStatusBit,
+} from '../statuslist-bits.js';
+import { base64urlEncodeFromBytes } from '../base64.js';
+
+/** Identity "decompressor" — the payload IS the bitstring (mechanics tests need no gzip). */
+const identity = (bytes: Uint8Array): Uint8Array => bytes;
+
+describe('parseStatusListIndex', () => {
+  it('parses a canonical non-negative decimal', () => {
+    expect(parseStatusListIndex('0')).toBe(0);
+    expect(parseStatusListIndex('94')).toBe(94);
+    expect(parseStatusListIndex('131071')).toBe(131071);
+  });
+
+  it.each(['0x2A', ' 42', '42 ', '+42', '-1', '1e1', '4.2', '', 'abc'])(
+    'rejects non-canonical input %j (fail-closed)',
+    (raw) => {
+      expect(() => parseStatusListIndex(raw)).toThrow(
+        /canonical non-negative decimal/,
+      );
+    },
+  );
+
+  it('rejects values beyond the safe integer range', () => {
+    expect(() => parseStatusListIndex('9007199254740992')).toThrow(
+      /safe integer range/,
+    );
+  });
+});
+
+describe('decodeStatusListPayload', () => {
+  const raw = new Uint8Array([0b10100000, 0b00000001]);
+
+  it('decodes with the multibase u prefix', async () => {
+    const encoded = MULTIBASE_BASE64URL + base64urlEncodeFromBytes(raw);
+    expect(await decodeStatusListPayload(encoded, identity)).toEqual(raw);
+  });
+
+  it('decodes without the prefix (issuer interop)', async () => {
+    const encoded = base64urlEncodeFromBytes(raw);
+    expect(await decodeStatusListPayload(encoded, identity)).toEqual(raw);
+  });
+
+  it('supports an async decompressor', async () => {
+    const encoded = base64urlEncodeFromBytes(raw);
+    const asyncIdentity = async (bytes: Uint8Array) => bytes;
+    expect(await decodeStatusListPayload(encoded, asyncIdentity)).toEqual(raw);
+  });
+
+  it('fail-closes on an inflated payload above the cap', async () => {
+    const bomb = () => new Uint8Array(MAX_STATUS_LIST_BYTES + 1);
+    const encoded = base64urlEncodeFromBytes(new Uint8Array([1]));
+    await expect(decodeStatusListPayload(encoded, bomb)).rejects.toThrow(
+      /too large/,
+    );
+  });
+});
+
+describe('readStatusBit', () => {
+  const bits = new Uint8Array([0b10100000, 0b00000001]);
+
+  it('reads MSB-first within each byte (W3C order)', () => {
+    expect(readStatusBit(bits, 0)).toBe(true);
+    expect(readStatusBit(bits, 1)).toBe(false);
+    expect(readStatusBit(bits, 2)).toBe(true);
+    expect(readStatusBit(bits, 15)).toBe(true);
+    expect(readStatusBit(bits, 14)).toBe(false);
+  });
+
+  it.each([NaN, -1, 16, 2 ** 32 + 5, 0.5])(
+    'fail-closes (throws "out of range") on unreadable index %p',
+    (index) => {
+      expect(() => readStatusBit(bits, index)).toThrow(/out of range/);
+    },
+  );
+});

--- a/src/utils/statuslist-bits.ts
+++ b/src/utils/statuslist-bits.ts
@@ -1,0 +1,96 @@
+/**
+ * Status-list reading primitives — the ONE home for the mechanics every W3C
+ * status-list reader in this package shares (StatusList2021 / Bitstring
+ * Status List v1.0): canonical index parsing, bounded payload inflation, and
+ * the MSB-first bit read.
+ *
+ * Consumers: `delegation/bitstring.ts` (+ `statuslist-manager.ts`) and
+ * `card/revocation.ts` — previously each carried its own copy of exactly this
+ * knowledge, with the drift risk the source comments could only pledge away.
+ * The seams' POLICIES stay where they are (the delegation path throws and the
+ * caller maps to `status_unresolvable`; the card path catches everything into
+ * `FAIL_CLOSED` and models freshness) — only the mechanics live here.
+ *
+ * FAIL-CLOSED throughout: a non-canonical index, an oversized inflation, or
+ * an unreadable bit throws rather than reading as "not revoked".
+ */
+import { base64urlDecodeToBytes } from './base64.js';
+
+/**
+ * Hard ceiling on an INFLATED status bitstring (16 MiB ≈ 134M entries — far
+ * beyond any herd-privacy list). A fixed cap costs nothing legitimate while
+ * stopping a decompression bomb; exceeding it throws (fail-closed).
+ */
+export const MAX_STATUS_LIST_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The W3C Bitstring Status List `encodedList` multibase prefix (base64url,
+ * no padding). A gzip stream's fixed magic byte (0x1f) makes its base64url
+ * start with `H`, never `u`, so a leading `u` is unambiguously the multibase
+ * code rather than payload.
+ */
+export const MULTIBASE_BASE64URL = 'u';
+
+/**
+ * Parse a decimal `statusListIndex` (a non-negative integer expressed as a
+ * string), fail-closed. Canonical decimal ONLY: `Number()` alone would coerce
+ * whitespace (`" "` → 0), hex (`"0x2A"` → 42), `"+42"`, and `"1e1"` → 10 —
+ * silently reading a DIFFERENT (often clear) bit than the credential names,
+ * so a revoked credential could read as live.
+ */
+export function parseStatusListIndex(raw: string): number {
+  if (!/^[0-9]+$/.test(raw)) {
+    throw new Error(
+      `Invalid statusListIndex "${raw}" — must be a canonical non-negative decimal`,
+    );
+  }
+  const index = Number(raw);
+  if (!Number.isSafeInteger(index)) {
+    throw new Error(`statusListIndex "${raw}" exceeds the safe integer range`);
+  }
+  return index;
+}
+
+/**
+ * Decode a status-list `encodedList` to the raw bitstring: strip the optional
+ * multibase `u` prefix, base64url-decode, run the injected decompressor, and
+ * re-check the {@link MAX_STATUS_LIST_BYTES} cap POST-inflation as a backstop
+ * (a production decompressor SHOULD also bound output during inflation).
+ * The decompressor is the bare-function common denominator — an
+ * object-shaped `DecompressionFunction` adapts inline:
+ * `(b) => decompressor.decompress(b)`.
+ */
+export async function decodeStatusListPayload(
+  encodedList: string,
+  decompress: (bytes: Uint8Array) => Uint8Array | Promise<Uint8Array>,
+): Promise<Uint8Array> {
+  const payload =
+    encodedList[0] === MULTIBASE_BASE64URL ? encodedList.slice(1) : encodedList;
+  const inflated = await decompress(base64urlDecodeToBytes(payload));
+  if (inflated.length > MAX_STATUS_LIST_BYTES) {
+    throw new Error(
+      `Status list too large: ${inflated.length} bytes exceeds ${MAX_STATUS_LIST_BYTES}`,
+    );
+  }
+  return inflated instanceof Uint8Array ? inflated : new Uint8Array(inflated);
+}
+
+/**
+ * Read the status bit at `index` — MSB-first within each byte (W3C Bitstring
+ * encoding). Uses FULL-PRECISION arithmetic (`Math.floor(index / 8)`) rather
+ * than 32-bit bitwise ops, which coerce to uint32 first: an index ≥ 2^32
+ * would silently wrap onto a low byte and read the WRONG — often clear — bit,
+ * turning an out-of-range index that MUST fail-closed into a fail-OPEN "not
+ * revoked". NaN/negative/fractional/out-of-buffer indexes throw.
+ */
+export function readStatusBit(bits: Uint8Array, index: number): boolean {
+  const byte = Number.isInteger(index) && index >= 0
+    ? bits[Math.floor(index / 8)]
+    : undefined;
+  if (byte === undefined) {
+    throw new Error(
+      `Bit index ${index} out of range for the status list`,
+    );
+  }
+  return (byte & (0x80 >> index % 8)) !== 0;
+}


### PR DESCRIPTION
## Description

The package carries two independent W3C status-list readers — the delegation path (`bitstring.ts` + `statuslist-manager.ts`) and the card revocation path (`card/revocation.ts`) — and each carried its own copy of the same mechanics: canonical `statusListIndex` parsing (regex + safe-integer), the 16 MiB decompression-bomb cap, multibase-`u`/base64url payload decoding, and the MSB-first (full-precision) bit read. The copies were held in sync only by source comments pledging they "must not drift" — and a third reader (the upcoming cheqd on-chain StatusList resolver) is about to arrive.

This PR gives the mechanics one home, **`src/utils/statuslist-bits.ts`** (`parseStatusListIndex`, `decodeStatusListPayload`, `readStatusBit`, `MAX_STATUS_LIST_BYTES`, `MULTIBASE_BASE64URL`), and points both readers at it. `utils/` is already the sanctioned shared layer — the card module imports `utils/base64`, `utils/guards`, and `utils/statuslist-purpose` today, so no isolation boundary is crossed.

**What deliberately does NOT change:**
- Each seam's *policy*: the delegation path still throws (mapped to `status_unresolvable` by its caller); the card path still catches everything into `FAIL_CLOSED` and models `fresh`.
- `BitstringManager.getBit`/`setBit` — they bound by logical list *size*, not buffer length; a different contract, not a duplicate.
- Bonus dedup: `bitstring.ts` hand-rolled its own base64url decoder; the shared primitive uses the existing `utils/base64` implementation.

**Naming collision resolved:** the card module's `RevocationChecker` function type collided with the delegation-side `RevocationChecker` interface (`chain-enforcement.ts`) — two identically named exports answering different questions. Card's is renamed **`BitstringRevocationChecker`** (it checks a `BitstringStatusListEntry`); in-repo references updated; the old name survives as a documented `@deprecated` alias until 2.0, so nothing breaks.

Behavior-preserving by construction and by evidence: **every pre-existing test passes unmodified** (the suites are the regression harness), plus a 21-case unit matrix on the shared primitives. Full suite: 2024 passed / 1 pre-existing skip. Net −136/+256 (the + is the new module's docs and tests; both readers shrank).

Changes under `[Unreleased]`; version cut planned with the cheqd resolver PR.

## Spec Impact

None to SPEC.md — internal consolidation; W3C Bitstring Status List read semantics (MSB-first, fail-closed bounds, canonical index) unchanged and now provably identical across seams.

## Checklist

- [x] Tests pass (`npm test`)
- [x] DCO signed (`git commit -s`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable