### PR TITLE
feat(cheqd): StatusListCredential DLR artifact type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Versioning: https://semver.org/spec/v2.0.0.html
   the point of use — did:cheqd issuers verify end-to-end without a
   JWK-rewriting resolver. Fail-closed: anything not provably a 32-byte
   Ed25519 key still denies.
+- **`StatusListCredential` DLR artifact type.** `prepareCheqdDlrResource`
+  now anchors status lists: the artifact's `content` is the WHOLE SIGNED
+  StatusList2021 credential (hash-what-you-publish — the canonical bytes
+  anchored on-chain are exactly the credential a verifier fetches), so
+  content hashes remain byte-compatible with resources already anchored via
+  the DEF CON demo's vendored publisher. Anchor-fitness is enforced by the
+  new method-agnostic `assertAnchorableStatusListCredential` guard in
+  `utils/statuslist-bits` (refuses unsigned or bitstring-less lists).
 
 ### Changed
 

--- a/src/integrations/cheqd/__tests__/dlr.test.ts
+++ b/src/integrations/cheqd/__tests__/dlr.test.ts
@@ -5,6 +5,7 @@ import {
   validateCheqdDlrArtifact,
 } from '../dlr.js';
 import type { CryptoProvider } from '../../../providers/base.js';
+import { canonicalizeJSON } from '../../../delegation/utils.js';
 
 const cryptoProvider: CryptoProvider = {
   sign: vi.fn(),
@@ -107,6 +108,66 @@ describe('cheqd DLR helpers', () => {
     expect(first.resource.type).toBe(second.resource.type);
     expect(first.resource.version).toBe('1');
     expect(second.resource.version).toBe('2');
+  });
+
+  it('anchors a signed StatusListCredential as its exact canonical bytes (demo-publisher compatible)', async () => {
+    const signedVc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      id: 'https://status.example/1',
+      type: ['VerifiableCredential', 'StatusList2021Credential'],
+      issuer: 'did:cheqd:testnet:11111111-1111-4111-8111-111111111111',
+      issuanceDate: '2026-08-13T00:00:00Z',
+      credentialSubject: {
+        id: 'https://status.example/1#list',
+        type: 'StatusList2021',
+        statusPurpose: 'revocation',
+        encodedList: 'uH4sIAAAAAAAA',
+      },
+      proof: { type: 'Ed25519Signature2020', proofValue: 'zsig' },
+    };
+
+    const prepared = await prepareCheqdDlrResource(
+      {
+        type: 'StatusListCredential',
+        subjectDid: 'did:cheqd:testnet:11111111-1111-4111-8111-111111111111',
+        name: 'kya-statuslist',
+        resourceType: 'StatusListCredential',
+        version: '2026-08-13T00-00-00Z',
+        content: signedVc,
+      },
+      cryptoProvider,
+    );
+
+    // Compatibility pin: content is the WHOLE SIGNED VC, so the canonical
+    // bytes (and therefore the contentHash and on-chain resource body) equal
+    // the hash-what-you-publish computation the vendored demo publisher used
+    // — resources already anchored on cheqd testnet stay reproducible.
+    expect(prepared.canonicalContent).toBe(canonicalizeJSON(signedVc));
+    expect(prepared.resource.data).toBe(
+      Buffer.from(new TextEncoder().encode(prepared.canonicalContent)).toString('base64'),
+    );
+    expect(prepared.resource.name).toBe('kya-statuslist');
+    expect(prepared.resource.version).toBe('2026-08-13T00-00-00Z');
+  });
+
+  it('refuses an UNSIGNED StatusListCredential artifact', () => {
+    expect(
+      validateCheqdDlrArtifact({
+        type: 'StatusListCredential',
+        subjectDid: 'did:cheqd:testnet:11111111-1111-4111-8111-111111111111',
+        content: { credentialSubject: { encodedList: 'uH4sI' } },
+      }).reason,
+    ).toContain('UNSIGNED');
+  });
+
+  it('refuses a StatusListCredential without an encodedList', () => {
+    expect(
+      validateCheqdDlrArtifact({
+        type: 'StatusListCredential',
+        subjectDid: 'did:cheqd:testnet:11111111-1111-4111-8111-111111111111',
+        content: { proof: {}, credentialSubject: {} },
+      }).reason,
+    ).toContain('encodedList');
   });
 
   it('builds resolver references by resource id or name/type query', () => {

--- a/src/integrations/cheqd/dlr.ts
+++ b/src/integrations/cheqd/dlr.ts
@@ -2,13 +2,23 @@ import { canonicalize } from 'json-canonicalize';
 import type { CryptoProvider } from '../../providers/base.js';
 import { bytesToBase64 } from '../../utils/base64.js';
 import { isRecord, stripTrailingSlashes } from '../../utils/index.js';
+import { assertAnchorableStatusListCredential } from '../../utils/statuslist-bits.js';
 import type { CheqdCreateResourceBody } from './registrar.js';
 
+/**
+ * Artifact kinds KYA-OS anchors as DID-Linked Resources. The taxonomy — and
+ * the JCS-canonicalize → sha256 content addressing in
+ * {@link prepareCheqdDlrResource} — is protocol-level rather than
+ * cheqd-specific: the day a SECOND anchoring integration lands, both graduate
+ * to a central module with deprecated aliases kept here (rule-of-two,
+ * recorded now so that PR is mechanical).
+ */
 export const CHEQD_DLR_ARTIFACT_TYPES = [
   'CapabilityManifest',
   'ConformanceManifest',
   'AccessHashManifest',
   'TrustConfigManifest',
+  'StatusListCredential',
 ] as const;
 
 export type CheqdDlrArtifactType = (typeof CHEQD_DLR_ARTIFACT_TYPES)[number];
@@ -62,6 +72,21 @@ export function validateCheqdDlrArtifact(
 
   if (artifact['content'] === undefined) {
     return { valid: false, reason: 'DLR artifact content is required' };
+  }
+
+  // A status list's content is the WHOLE SIGNED VC (hash-what-you-publish:
+  // the canonical bytes anchored on-chain are exactly the credential a
+  // verifier fetches). The shared guard enforces anchor-fitness — signed,
+  // bitstring present — method-agnostically.
+  if (artifact['type'] === 'StatusListCredential') {
+    try {
+      assertAnchorableStatusListCredential(artifact['content']);
+    } catch (error) {
+      return {
+        valid: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   if (

--- a/src/utils/__tests__/statuslist-bits.test.ts
+++ b/src/utils/__tests__/statuslist-bits.test.ts
@@ -5,6 +5,7 @@ import {
   parseStatusListIndex,
   decodeStatusListPayload,
   readStatusBit,
+  assertAnchorableStatusListCredential,
 } from '../statuslist-bits.js';
 import { base64urlEncodeFromBytes } from '../base64.js';
 
@@ -79,4 +80,38 @@ describe('readStatusBit', () => {
       expect(() => readStatusBit(bits, index)).toThrow(/out of range/);
     },
   );
+});
+
+describe('assertAnchorableStatusListCredential', () => {
+  const anchorable = {
+    type: ['VerifiableCredential', 'StatusList2021Credential'],
+    credentialSubject: { statusPurpose: 'revocation', encodedList: 'uH4sIAAAAAAAA' },
+    proof: { type: 'Ed25519Signature2020', proofValue: 'zsig' },
+  };
+
+  it('accepts a signed credential with a bitstring', () => {
+    expect(() => assertAnchorableStatusListCredential(anchorable)).not.toThrow();
+  });
+
+  it('refuses an unsigned credential (fail-closed for every future holder)', () => {
+    const { proof: _proof, ...unsigned } = anchorable;
+    expect(() => assertAnchorableStatusListCredential(unsigned)).toThrow(/UNSIGNED/);
+  });
+
+  it('refuses a missing or empty encodedList', () => {
+    expect(() =>
+      assertAnchorableStatusListCredential({ ...anchorable, credentialSubject: {} }),
+    ).toThrow(/encodedList/);
+    expect(() =>
+      assertAnchorableStatusListCredential({
+        ...anchorable,
+        credentialSubject: { encodedList: '' },
+      }),
+    ).toThrow(/encodedList/);
+  });
+
+  it('refuses non-object content', () => {
+    expect(() => assertAnchorableStatusListCredential(null)).toThrow(/must be an object/);
+    expect(() => assertAnchorableStatusListCredential('vc')).toThrow(/must be an object/);
+  });
 });

--- a/src/utils/statuslist-bits.ts
+++ b/src/utils/statuslist-bits.ts
@@ -1,8 +1,8 @@
 /**
- * Status-list reading primitives — the ONE home for the mechanics every W3C
- * status-list reader in this package shares (StatusList2021 / Bitstring
- * Status List v1.0): canonical index parsing, bounded payload inflation, and
- * the MSB-first bit read.
+ * Status-list primitives — the ONE home for the mechanics every W3C
+ * status-list reader AND publisher in this package shares (StatusList2021 /
+ * Bitstring Status List v1.0): canonical index parsing, bounded payload
+ * inflation, the MSB-first bit read, and the anchor-fitness guard.
  *
  * Consumers: `delegation/bitstring.ts` (+ `statuslist-manager.ts`) and
  * `card/revocation.ts` — previously each carried its own copy of exactly this
@@ -15,6 +15,7 @@
  * an unreadable bit throws rather than reading as "not revoked".
  */
 import { base64urlDecodeToBytes } from './base64.js';
+import { isRecord } from './guards.js';
 
 /**
  * Hard ceiling on an INFLATED status bitstring (16 MiB ≈ 134M entries — far
@@ -93,4 +94,32 @@ export function readStatusBit(bits: Uint8Array, index: number): boolean {
     );
   }
   return (byte & (0x80 >> index % 8)) !== 0;
+}
+
+/**
+ * Assert a status-list credential is fit to ANCHOR (publish) — signed, and
+ * actually carrying a bitstring. Method-agnostic on purpose: the cheqd DLR
+ * publisher enforces it today; any future anchoring integration (another
+ * DLR-bearing DID method, a different chain) imports the same guard rather
+ * than re-deriving "what makes a status list publishable". An unsigned or
+ * bitstring-less list anchored on-chain would be an unverifiable — and
+ * therefore fail-closed-unusable — revocation source for every holder.
+ */
+export function assertAnchorableStatusListCredential(content: unknown): void {
+  if (!isRecord(content)) {
+    throw new Error('Status list credential must be an object');
+  }
+  if (!content.proof) {
+    throw new Error('Refusing to publish an UNSIGNED status list credential');
+  }
+  const subject = content.credentialSubject;
+  if (
+    !isRecord(subject) ||
+    typeof subject.encodedList !== 'string' ||
+    subject.encodedList.length === 0
+  ) {
+    throw new Error(
+      'Status list credential is missing credentialSubject.encodedList',
+    );
+  }
 }


### PR DESCRIPTION
## Description

`prepareCheqdDlrResource` ships four manifest artifact types but not `StatusListCredential` — which is why the [DEF CON 34 "REVOKED](https://www.loom.com/share/f32b82a292f14a6c952dba3a0a246e45)" demo had to vendor its own DLR preparation (a file whose header literally says "Upstream plan: add `StatusListCredential` … this file then deletes"). This PR keeps that promise.

- **`'StatusListCredential'`** joins `CHEQD_DLR_ARTIFACT_TYPES`. The artifact's `content` is the **whole signed** StatusList2021 credential — hash-what-you-publish: the canonical bytes anchored on-chain are exactly the credential a verifier later fetches, and the anchor commits to the signature itself (an issuer cannot republish a re-signed variant under the same hash).
- **Byte-compatibility with already-anchored resources, pinned by test:** upstream's `canonicalize(artifact.content)` and the demo's `canonicalizeJSON(signedVc)` use the same JCS implementation, so with `content = the signed VC` the canonical bytes, `contentHash`, and resource body are identical to what the vendored publisher produced. A canonical-bytes equality test locks this permanently — resources on cheqd testnet stay reproducible.
- **Anchor-fitness is enforced centrally:** the new `assertAnchorableStatusListCredential` guard (refuses unsigned or bitstring-less lists) lives in `utils/statuslist-bits`, takes `unknown`, and imports nothing cheqd — deliberately method-agnostic, so a future second anchoring integration reuses the guard instead of re-deriving it. The artifact taxonomy's graduation path to a central module (rule-of-two) is recorded in a comment on `CHEQD_DLR_ARTIFACT_TYPES` so that extraction is mechanical when a second integration exists — and not speculative before then.
- Existing four artifact types: untouched, their tests unchanged.

Coverage: guard matrix (signed-accepted / unsigned-refused / missing-and-empty-`encodedList` / non-object) + validator refusals + the compatibility pin. Full suite: 2031 passed / 1 pre-existing skip.

Third PR of the arc (after #166 multibase keys, #167 primitives consolidation); the cheqd StatusList resolver lands next and cuts 1.14.0.

## Spec Impact

None to SPEC.md — extends the cheqd integration's artifact taxonomy; W3C StatusList2021 semantics unchanged.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable