### PR TITLE
feat(cheqd): CheqdStatusListResolver — on-chain StatusList2021 revocation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-13
+
 ### Added
 
+- **`CheqdStatusListResolver`** (`@kya-os/mcp/cheqd`) — on-chain StatusList2021
+  revocation checks against a cheqd DID-Linked Resource, upstreamed from the
+  DEF CON 34 "REVOKED" demo as a thin consumer of the shared primitives. The
+  only status-list reader that verifies the LIST itself: issuer pinned to
+  `expectedIssuerDid` and the Ed25519Signature2020 proof checked against the
+  issuer's on-chain DID document ("the resolver returned it" is never
+  sufficient). Fail-closed on every unprovable path (the delegation verifier
+  denies as `status_unresolvable`); internal verified-document `TtlCache`
+  (default 10 s, `invalidateCache()` busts upstream HTTP caches) composable
+  with `withStatusCache` for per-bit staleness SLAs; version-independent
+  resolver URLs with header-only cache-busting (the cheqd resolver 400s on
+  query params — verified live).
 - **Multibase verification-method keys.** Both delegation signature paths
   (Data Integrity and VC-JWT) now accept verification methods that publish
   `publicKeyMultibase` (base58btc Ed25519, with or without the 0xed01

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kya-os/mcp",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: identity, delegation, proofs, sessions, and verifiable audit trails",
   "license": "MIT",
   "type": "module",

--- a/src/integrations/cheqd/__tests__/statuslist-resolver.test.ts
+++ b/src/integrations/cheqd/__tests__/statuslist-resolver.test.ts
@@ -1,0 +1,286 @@
+/**
+ * CheqdStatusListResolver — the DEF CON demo's 18-case fail-closed matrix,
+ * ported onto upstream-native fixtures: a REAL signed status list minted by
+ * `StatusList2021Manager` (real Ed25519, real gzip), served through a stub
+ * `FetchProvider`, with the issuer's key published MULTIBASE-ONLY in the DID
+ * document — the cheqd-realistic shape `verificationMethodJwk` exists for.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import {
+  CheqdStatusListResolver,
+  createCheqdStatusListResolver,
+} from '../statuslist-resolver.js';
+import {
+  createRealCryptoProvider,
+  createRealIdentity,
+  createRealStatusListManager,
+  nodeDecompressor,
+  type RealStatusListSetup,
+} from '../../../__tests__/audit/helpers/crypto-helpers.js';
+import { createDidKeyResolver } from '../../../delegation/did-key-resolver.js';
+import { base58Encode } from '../../../utils/base58.js';
+import { base64urlDecodeToBytes } from '../../../utils/base64.js';
+import type { AgentIdentity } from '../../../providers/base.js';
+import type { FetchProvider } from '../../../providers/base.js';
+import type { DIDResolver } from '../../../delegation/vc-verifier.types.js';
+import type { NodeCryptoProvider } from '../../../__tests__/utils/node-crypto-provider.js';
+import type {
+  CredentialStatus,
+  StatusList2021Credential,
+} from '../../../types/protocol.js';
+
+describe('CheqdStatusListResolver (real crypto, stubbed transport)', () => {
+  let crypto: NodeCryptoProvider;
+  let issuerIdentity: AgentIdentity;
+  let setup: RealStatusListSetup;
+  let clearEntry: CredentialStatus;
+  let revokedEntry: CredentialStatus;
+  let listUrl: string;
+  let signedList: StatusList2021Credential;
+  let didResolver: DIDResolver;
+
+  let fetchLog: Array<{ url: string; headers: Record<string, string> }> = [];
+  let serveOverride: (() => unknown) | null = null;
+  let serveStatus = 200;
+
+  const fetchProvider = {
+    async fetch(url: string, init?: { headers?: Record<string, string> }) {
+      fetchLog.push({ url, headers: init?.headers ?? {} });
+      const body = serveOverride
+        ? serveOverride()
+        : await setup.storage.getStatusList(url);
+      return {
+        ok: serveStatus === 200 && body != null,
+        status: body == null && serveStatus === 200 ? 404 : serveStatus,
+        json: async () => body,
+      } as unknown as Response;
+    },
+  } as unknown as FetchProvider;
+
+  const makeResolver = (
+    overrides?: Partial<ConstructorParameters<typeof CheqdStatusListResolver>[0]>,
+  ) =>
+    new CheqdStatusListResolver({
+      fetchProvider,
+      didResolver,
+      cryptoProvider: crypto,
+      expectedIssuerDid: issuerIdentity.did,
+      decompressor: nodeDecompressor,
+      cacheTtlMs: 0, // test isolation; caching cases opt in explicitly
+      ...overrides,
+    });
+
+  beforeAll(async () => {
+    crypto = createRealCryptoProvider();
+    issuerIdentity = await createRealIdentity(crypto);
+    setup = createRealStatusListManager(crypto, issuerIdentity, {
+      statusListBaseUrl: 'https://status.example',
+    });
+
+    clearEntry = await setup.manager.allocateStatusEntry('revocation');
+    revokedEntry = await setup.manager.allocateStatusEntry('revocation');
+    await setup.manager.updateStatus(revokedEntry, true);
+
+    listUrl = clearEntry.statusListCredential;
+    const stored = await setup.storage.getStatusList(listUrl);
+    if (!stored) throw new Error('fixture: status list not stored');
+    signedList = stored;
+
+    // Publish the issuer's key MULTIBASE-ONLY (cheqd DID documents publish
+    // publicKeyMultibase, not JWKs) under the kid the signing function names.
+    const didKeyDoc = await createDidKeyResolver().resolve(issuerIdentity.did);
+    const jwk = didKeyDoc?.verificationMethod?.[0]?.publicKeyJwk as { x: string };
+    const raw = base64urlDecodeToBytes(jwk.x);
+    const multibase = `z${base58Encode(new Uint8Array([0xed, 0x01, ...raw]))}`;
+    didResolver = {
+      async resolve(did: string) {
+        if (did !== issuerIdentity.did) return null;
+        return {
+          id: did,
+          verificationMethod: [
+            {
+              id: issuerIdentity.kid,
+              type: 'Ed25519VerificationKey2020',
+              controller: did,
+              publicKeyMultibase: multibase,
+            },
+          ],
+        };
+      },
+    };
+  });
+
+  beforeEach(() => {
+    fetchLog = [];
+    serveOverride = null;
+    serveStatus = 200;
+  });
+
+  // ── Verdicts ──────────────────────────────────────────────────
+
+  it('returns false for a clear index', async () => {
+    expect(await makeResolver().checkStatus(clearEntry)).toBe(false);
+  });
+
+  it('returns true for a revoked index', async () => {
+    expect(await makeResolver().checkStatus(revokedEntry)).toBe(true);
+  });
+
+  it('factory returns a working instance', () => {
+    expect(
+      createCheqdStatusListResolver({
+        fetchProvider,
+        didResolver,
+        cryptoProvider: crypto,
+        expectedIssuerDid: issuerIdentity.did,
+        decompressor: nodeDecompressor,
+      }),
+    ).toBeInstanceOf(CheqdStatusListResolver);
+  });
+
+  // ── Fail-closed matrix ────────────────────────────────────────
+
+  it('rejects a non-https statusListCredential URL', async () => {
+    await expect(
+      makeResolver().checkStatus({ ...clearEntry, statusListCredential: 'http://x' }),
+    ).rejects.toThrow(/https URL/);
+  });
+
+  it.each(['0x2A', ' 42', '+42', '1e1', '4.2', 'abc', ''])(
+    'rejects non-canonical statusListIndex %j',
+    async (bad) => {
+      await expect(
+        makeResolver().checkStatus({ ...clearEntry, statusListIndex: bad }),
+      ).rejects.toThrow(/canonical non-negative decimal/);
+    },
+  );
+
+  it('rejects an index beyond the safe integer range', async () => {
+    await expect(
+      makeResolver().checkStatus({ ...clearEntry, statusListIndex: '9007199254740992' }),
+    ).rejects.toThrow(/safe integer range/);
+  });
+
+  it('fail-closes on an out-of-range index (beyond the bitstring)', async () => {
+    await expect(
+      makeResolver().checkStatus({ ...clearEntry, statusListIndex: '99999999' }),
+    ).rejects.toThrow(/out of range/);
+  });
+
+  it('fail-closes on an HTTP error', async () => {
+    serveStatus = 500;
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('fail-closes when the resource is not a StatusList2021Credential', async () => {
+    serveOverride = () => ({ ...signedList, type: ['VerifiableCredential'] });
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(
+      /not a StatusList2021Credential/,
+    );
+  });
+
+  it('fail-closes on a malformed credentialSubject', async () => {
+    serveOverride = () => ({
+      ...signedList,
+      credentialSubject: { ...signedList.credentialSubject, encodedList: '' },
+    });
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(/malformed/);
+  });
+
+  it('fail-closes on an UNSIGNED list', async () => {
+    serveOverride = () => {
+      const { proof: _proof, ...unsigned } = signedList as unknown as Record<string, unknown>;
+      return unsigned;
+    };
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(/unsigned/);
+  });
+
+  it('fail-closes when the issuer is not the pinned issuer', async () => {
+    await expect(
+      makeResolver({ expectedIssuerDid: 'did:cheqd:testnet:attacker' })
+        .checkStatus(clearEntry),
+    ).rejects.toThrow(/not the expected issuer/);
+  });
+
+  it('fail-closes on a statusPurpose mismatch', async () => {
+    await expect(
+      makeResolver().checkStatus({ ...clearEntry, statusPurpose: 'suspension' }),
+    ).rejects.toThrow(/statusPurpose mismatch/);
+  });
+
+  it('fail-closes when the proof is missing proofValue', async () => {
+    serveOverride = () => ({ ...signedList, proof: { type: 'Ed25519Signature2020' } });
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(
+      /missing proofValue/,
+    );
+  });
+
+  it('fail-closes when the issuer DID cannot be resolved', async () => {
+    const noDoc: DIDResolver = { resolve: async () => null };
+    await expect(
+      makeResolver({ didResolver: noDoc }).checkStatus(clearEntry),
+    ).rejects.toThrow(/Could not resolve issuer DID/);
+  });
+
+  it('fail-closes when no verification method matches the proof kid', async () => {
+    const wrongKid: DIDResolver = {
+      resolve: async () => ({
+        id: issuerIdentity.did,
+        verificationMethod: [
+          {
+            id: `${issuerIdentity.did}#other-key`,
+            type: 'Ed25519VerificationKey2020',
+            controller: issuerIdentity.did,
+            publicKeyBase58: base58Encode(new Uint8Array(32)),
+          },
+        ],
+      }),
+    };
+    await expect(
+      makeResolver({ didResolver: wrongKid }).checkStatus(clearEntry),
+    ).rejects.toThrow(/no verification method matching/);
+  });
+
+  it('fail-closes on a TAMPERED list (signature no longer covers the bytes)', async () => {
+    serveOverride = () => ({
+      ...signedList,
+      credentialSubject: {
+        ...signedList.credentialSubject,
+        statusPurpose: 'suspension', // any post-signing mutation
+      },
+    });
+    await expect(makeResolver().checkStatus(clearEntry)).rejects.toThrow(
+      /signature verification FAILED/,
+    );
+  });
+
+  // ── Caching + transport discipline ────────────────────────────
+
+  it('serves from the verified-document cache within TTL, with clean URLs', async () => {
+    const cachingResolver = makeResolver({ cacheTtlMs: 60_000 });
+    await cachingResolver.checkStatus(clearEntry);
+    await cachingResolver.checkStatus(revokedEntry);
+    expect(fetchLog.length).toBe(1); // one list, two credentials, one fetch
+    expect(fetchLog[0]!.url).toBe(listUrl);
+    expect(fetchLog[0]!.url).not.toContain('?'); // cheqd 400s on query params
+    expect(fetchLog[0]!.headers['Accept']).toBe('application/json');
+    expect(fetchLog[0]!.headers['Cache-Control']).toBeUndefined();
+  });
+
+  it('invalidateCache() refetches with upstream cache-busting headers', async () => {
+    const cachingResolver = makeResolver({ cacheTtlMs: 60_000 });
+    await cachingResolver.checkStatus(clearEntry);
+    cachingResolver.invalidateCache();
+    await cachingResolver.checkStatus(clearEntry);
+    expect(fetchLog.length).toBe(2);
+    expect(fetchLog[1]!.headers['Cache-Control']).toBe('no-cache');
+    expect(fetchLog[1]!.headers['Pragma']).toBe('no-cache');
+  });
+
+  it('cacheTtlMs: 0 disables document caching (every call fetches)', async () => {
+    const uncached = makeResolver();
+    await uncached.checkStatus(clearEntry);
+    await uncached.checkStatus(clearEntry);
+    expect(fetchLog.length).toBe(2);
+  });
+});

--- a/src/integrations/cheqd/index.ts
+++ b/src/integrations/cheqd/index.ts
@@ -43,3 +43,9 @@ export {
   type CheqdDlrReference,
   type PreparedCheqdDlrResource,
 } from './dlr.js';
+
+export {
+  CheqdStatusListResolver,
+  createCheqdStatusListResolver,
+  type CheqdStatusListResolverOptions,
+} from './statuslist-resolver.js';

--- a/src/integrations/cheqd/statuslist-resolver.ts
+++ b/src/integrations/cheqd/statuslist-resolver.ts
@@ -1,0 +1,235 @@
+/**
+ * CheqdStatusListResolver — StatusList2021 revocation checks against a cheqd
+ * DID-Linked Resource (the on-chain status list the DEF CON 34 "REVOKED" demo
+ * ran, upstreamed as a thin consumer of the shared primitives).
+ *
+ * Implements the delegation `StatusListResolver` seam: `checkStatus` returns
+ * TRUE when the credential's bit is set (revoked) and THROWS on anything
+ * unprovable — `DelegationCredentialVerifier` then denies fail-closed
+ * (`status_unresolvable`). Unlike the package's other status-list readers,
+ * this one also verifies the LIST itself: issuer pinned to
+ * `expectedIssuerDid`, and the Ed25519Signature2020 proof checked against the
+ * issuer's (on-chain) DID document. The chain provides availability and
+ * append-only history; the cryptographic root stays the issuer's signature —
+ * "the resolver returned it" is never sufficient on its own.
+ *
+ * Fail-closed matrix (all throw → verifier denies as `status_unresolvable`):
+ * non-https URL, malformed index, network error / non-200, malformed VC,
+ * unsigned VC, wrong issuer, purpose mismatch, missing proofValue,
+ * unresolvable issuer DID, no usable verification method, bad signature,
+ * out-of-range index.
+ *
+ * Freshness: an internal {@link TtlCache} holds the VERIFIED document
+ * (default 10 s — one fetch amortizes across every credential on a list;
+ * `cacheTtlMs: 0` disables). Compose `withStatusCache` on top for a
+ * declared per-bit staleness SLA. `invalidateCache()` drops the document and
+ * defeats upstream HTTP caches on the next fetch.
+ */
+import type { FetchProvider, CryptoProvider } from '../../providers/base.js';
+import type {
+  DIDResolver,
+  StatusListResolver,
+} from '../../delegation/vc-verifier.types.js';
+import type { DecompressionFunction } from '../../delegation/bitstring.js';
+import type {
+  CredentialStatus,
+  StatusList2021Credential,
+} from '../../types/protocol.js';
+import { verificationMethodJwk } from '../../delegation/verification-method-key.js';
+import { canonicalizeJSON } from '../../delegation/utils.js';
+import {
+  decodeStatusListPayload,
+  parseStatusListIndex,
+  readStatusBit,
+} from '../../utils/statuslist-bits.js';
+import { assertStatusPurpose } from '../../utils/statuslist-purpose.js';
+import { base64urlDecodeToBytes, bytesToBase64 } from '../../utils/base64.js';
+import { TtlCache } from '../../utils/ttl-cache.js';
+
+export interface CheqdStatusListResolverOptions {
+  /**
+   * Transport for fetching the status-list resource. The resolver enforces
+   * `https://` on the URL; SSRF guarding beyond the scheme (private-range
+   * blocking, redirects) is the injected provider's duty —
+   * `RuntimeFetchProvider` provides it.
+   */
+  fetchProvider: FetchProvider;
+  /** Resolves the status list ISSUER's DID document (did:cheqd, on-chain). */
+  didResolver: DIDResolver;
+  /** Verifies the list's Ed25519 signature (raw bytes + base64 public key). */
+  cryptoProvider: CryptoProvider;
+  /** Only status lists issued (and signed) by this DID are trusted. */
+  expectedIssuerDid: string;
+  /** Inflates the gzip `encodedList` (same seam as `BitstringManager`). */
+  decompressor: DecompressionFunction;
+  /** In-memory TTL for the fetched VERIFIED list; 0 disables. Default 10s. */
+  cacheTtlMs?: number;
+}
+
+export class CheqdStatusListResolver implements StatusListResolver {
+  private readonly opts: CheqdStatusListResolverOptions;
+  private readonly cacheTtlMs: number;
+  private cache: TtlCache<StatusList2021Credential>;
+  private bustNextFetch = false;
+
+  constructor(options: CheqdStatusListResolverOptions) {
+    this.opts = options;
+    this.cacheTtlMs = options.cacheTtlMs ?? 10_000;
+    // A single issuer realistically publishes a handful of lists; 16 entries
+    // is generous without being unbounded.
+    this.cache = new TtlCache<StatusList2021Credential>({
+      ttlMs: this.cacheTtlMs,
+      maxEntries: 16,
+    });
+  }
+
+  /** Drop the cached list and defeat upstream HTTP caches on the next fetch. */
+  invalidateCache(): void {
+    this.cache.clear();
+    this.bustNextFetch = true;
+  }
+
+  /** TRUE = revoked. Throws on anything unprovable — the verifier fails closed. */
+  async checkStatus(status: CredentialStatus): Promise<boolean> {
+    const url = status.statusListCredential;
+    if (typeof url !== 'string' || !/^https:\/\//.test(url)) {
+      throw new Error('credentialStatus.statusListCredential must be an https URL');
+    }
+
+    const index = parseStatusListIndex(status.statusListIndex);
+    const credential = await this.fetchAndVerifyList(url);
+
+    // Purpose parity, fail-closed (shared validator): a clear bit on the WRONG
+    // KIND of list would report "not revoked" from a list that never tracked
+    // revocation.
+    assertStatusPurpose(
+      credential.credentialSubject.statusPurpose,
+      status.statusPurpose,
+    );
+
+    const bits = await decodeStatusListPayload(
+      credential.credentialSubject.encodedList,
+      (bytes) => this.opts.decompressor.decompress(bytes),
+    );
+    return readStatusBit(bits, index);
+  }
+
+  private async fetchAndVerifyList(url: string): Promise<StatusList2021Credential> {
+    const cached = this.cache.get(url);
+    if (cached) {
+      return cached;
+    }
+
+    // NEVER append query params here: the cheqd resolver parses the query as
+    // DID URL dereferencing input and 400s (invalidDidUrl) on unknown params
+    // (verified live). The endpoint is served cf-cache-status DYNAMIC, so
+    // post-revocation freshness only needs a no-cache header.
+    const response = await this.opts.fetchProvider.fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...(this.bustNextFetch
+          ? { 'Cache-Control': 'no-cache', Pragma: 'no-cache' }
+          : {}),
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Status list fetch failed: HTTP ${response.status} for ${url}`);
+    }
+
+    const body = (await response.json()) as StatusList2021Credential;
+    this.assertShape(body);
+    this.assertIssuer(body);
+    await this.assertSignature(body);
+
+    this.bustNextFetch = false;
+    this.cache.set(url, body);
+    return body;
+  }
+
+  private assertShape(vc: StatusList2021Credential): void {
+    const types = Array.isArray(vc?.type) ? vc.type : [];
+    if (!types.includes('StatusList2021Credential')) {
+      throw new Error('Fetched resource is not a StatusList2021Credential');
+    }
+    const subject = vc.credentialSubject;
+    if (
+      subject?.type !== 'StatusList2021' ||
+      typeof subject.encodedList !== 'string' ||
+      subject.encodedList.length === 0
+    ) {
+      throw new Error(
+        'Status list credentialSubject is malformed (missing StatusList2021 encodedList)',
+      );
+    }
+    if (!vc.proof || typeof vc.proof !== 'object') {
+      throw new Error('Status list credential is unsigned');
+    }
+  }
+
+  private assertIssuer(vc: StatusList2021Credential): void {
+    const issuer = typeof vc.issuer === 'string' ? vc.issuer : vc.issuer?.id;
+    if (issuer !== this.opts.expectedIssuerDid) {
+      throw new Error(
+        `Status list issuer "${issuer}" is not the expected issuer "${this.opts.expectedIssuerDid}"`,
+      );
+    }
+  }
+
+  /**
+   * Verify the Ed25519Signature2020 proof over the JCS-canonicalized VC
+   * (minus `proof`) against the issuer's on-chain DID document. Key material
+   * arrives however the DID method publishes it — `verificationMethodJwk`
+   * accepts `publicKeyJwk`, `publicKeyMultibase` (cheqd's format), or legacy
+   * `publicKeyBase58`.
+   */
+  private async assertSignature(vc: StatusList2021Credential): Promise<void> {
+    const proof = vc.proof as Record<string, unknown>;
+    const proofValue = proof['proofValue'];
+    if (typeof proofValue !== 'string' || proofValue.length === 0) {
+      throw new Error('Status list proof is missing proofValue');
+    }
+
+    const unsigned: Record<string, unknown> = { ...vc };
+    delete unsigned['proof'];
+    const data = new TextEncoder().encode(canonicalizeJSON(unsigned));
+    const signature = base64urlDecodeToBytes(proofValue);
+
+    const didDoc = await this.opts.didResolver.resolve(this.opts.expectedIssuerDid);
+    if (!didDoc) {
+      throw new Error(`Could not resolve issuer DID ${this.opts.expectedIssuerDid}`);
+    }
+
+    const verificationMethodId =
+      typeof proof['verificationMethod'] === 'string'
+        ? proof['verificationMethod']
+        : undefined;
+    const methods = didDoc.verificationMethod ?? [];
+    const candidates = verificationMethodId
+      ? methods.filter((m) => m.id === verificationMethodId)
+      : methods;
+    if (candidates.length === 0) {
+      throw new Error(
+        `Issuer DID document has no verification method matching "${verificationMethodId ?? '(any)'}"`,
+      );
+    }
+
+    for (const method of candidates) {
+      const jwk = verificationMethodJwk(method);
+      if (!jwk) continue;
+      const publicKeyBase64 = bytesToBase64(base64urlDecodeToBytes(jwk.x));
+      if (await this.opts.cryptoProvider.verify(data, signature, publicKeyBase64)) {
+        return;
+      }
+    }
+    throw new Error(
+      'Status list signature verification FAILED against the issuer DID document',
+    );
+  }
+}
+
+export function createCheqdStatusListResolver(
+  options: CheqdStatusListResolverOptions,
+): CheqdStatusListResolver {
+  return new CheqdStatusListResolver(options);
+}


### PR DESCRIPTION
## Description

The finale of the [DEF CON 34 "REVOKED"](https://www.loom.com/share/f32b82a292f14a6c952dba3a0a246e45) upstreaming arc (#165 → #166 → #167 → #168): the on-chain status-list resolver itself, landing as `CheqdStatusListResolver` in `@kya-os/mcp/cheqd`.

It implements the delegation `StatusListResolver` seam:
- `checkStatus` returns TRUE for a set (revoked) bit and **throws on anything unprovable**, which `DelegationCredentialVerifier` denies fail-closed as `status_unresolvable`. 
- It is the only status-list reader in the package that verifies the **list itself**: the issuer is pinned to `expectedIssuerDid`, and the `Ed25519Signature2020` proof is checked against the issuer's on-chain DID document. The chain provides availability and append-only history; the cryptographic root stays the issuer's signature; "the resolver returned it" is never sufficient.

**Why it's a thin PR:**
- Index parse / payload decode / bit read → `utils/statuslist-bits` (#167). The demo's ~60 lines of mechanics are 3 imports.
- Purpose parity → the existing `assertStatusPurpose` single source of truth.
- Issuer key extraction → `verificationMethodJwk` (#166) — cheqd publishes `publicKeyMultibase`; the demo's bespoke extractor and JWK-rewriting resolver shim are both dead.
- Verified-document cache → `TtlCache` (#165). No new cache implementation; `cacheTtlMs: 0` disables, `invalidateCache()` busts upstream HTTP caches. Composable with `withStatusCache` for a declared per-bit staleness SLA — two explicit layers, no silent verdict caching anywhere.
- Transport = `FetchProvider` (house convention; `https://` enforced here, deeper SSRF guarding is the injected provider's duty — `RuntimeFetchProvider` provides it). Version-independent resolver URLs with **header-only** cache-busting: the cheqd resolver parses query params as DID-URL dereferencing input and 400s (verified live at the event).

Coverage: the demo's fail-closed matrix ported and extended — **26 cases** on real Ed25519 + real gzip fixtures minted by `StatusList2021Manager`, with the issuer's key published multibase-only (the cheqd-realistic shape). Full suite: 2057 passed / 1 pre-existing skip.

**Cuts `1.14.0`**: the `[Unreleased]` entries from #166/#167/#168 roll into the dated release section with this feature. A gated live-testnet test (`statuslist.live.test.ts`, same pattern as `registrar.live.test.ts`) is a named follow-up.

## Spec Impact

None to SPEC.md — implements the existing `StatusListResolver` seam; revocation semantics (SPEC §4.3 fail-closed) unchanged. StatusList2021 read semantics shared with the other readers via `utils/statuslist-bits`.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Spec impact noted
- [x] CHANGELOG.md updated if applicable