### PR TITLE
fix(deps): pin json-canonicalize 2.0.0 exactly - fresh installs are broken; release 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning: https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-08-15
+
+### Fixed
+
+- **Fresh installs no longer break on `json-canonicalize`.** The dependency is
+  now pinned to `2.0.0` exactly. The upstream `2.0.1` publish ships raw
+  TypeScript sources with no compiled JavaScript (its `main` points at a
+  nonexistent path), so any install resolving `^2.0.0` without a lockfile -
+  every new adopter - got a package that cannot be imported. Pinning restores
+  installability for `@kya-os/mcp` and everything downstream of it. The pin
+  can be relaxed once upstream publishes a corrected release.
+
 ## [1.14.0] - 2026-08-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kya-os/mcp",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Reference implementation of the KYA-OS protocol for Model Context Protocol servers: identity, delegation, proofs, sessions, and verifiable audit trails",
   "license": "MIT",
   "type": "module",
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "jose": "^6.2.8",
-    "json-canonicalize": "^2.0.0",
+    "json-canonicalize": "2.0.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^6.2.8
         version: 6.2.8
       json-canonicalize:
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0
       zod:
         specifier: ^4.4.3


### PR DESCRIPTION
**P0.** `json-canonicalize@2.0.1` (currently `latest`) is a broken upstream publish: raw TS sources, no compiled JS, `main` pointing at a nonexistent path. Every dependency range of `^2.0.0` - which this package has declared since 1.11.0 - resolves to it on any fresh, lockfile-less install. **New adopters cannot import @kya-os/mcp today.**

This PR exact-pins `2.0.0` and preps **1.14.1** (version bump + CHANGELOG). Verified locally: install + typecheck clean, the dependency imports.

**Publish checklist after merge** (this repo has no publish workflow - manual):
1. redeploy demo-mcp.kya-os.ai on 1.14.1 (it currently runs 1.12.0, pre-dating the 1.13.0 revocation security fix), and @kya-os/cli's next publish should wait for this release (its fix PR is separate)