### PR TITLE
fix(delegation): verify VC-JWT envelope signatures + did:cheqd docs move (1.15.0)

### DIFF
--- a/src/middleware/__tests__/delegation-verify.verification-cache.test.ts
+++ b/src/middleware/__tests__/delegation-verify.verification-cache.test.ts
@@ -77,15 +77,15 @@ async function setup(
 describe('verificationCache config threading', () => {
   it('serves the signature from cache on the second call by default', async () => {
     const { verification, vc, resolveCount } = await setup();
-    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
-    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect((await verification.verifyDelegation(vc)).valid).toBe(true);
+    expect((await verification.verifyDelegation(vc)).valid).toBe(true);
     expect(resolveCount()).toBe(1);
   });
 
   it('ttlMs: 0 disables signature caching (resolver consulted every call)', async () => {
     const { verification, vc, resolveCount } = await setup({ ttlMs: 0 });
-    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
-    expect((await verification.validateDelegationChain(vc)).valid).toBe(true);
+    expect((await verification.verifyDelegation(vc)).valid).toBe(true);
+    expect((await verification.verifyDelegation(vc)).valid).toBe(true);
     expect(resolveCount()).toBe(2);
   });
 });

--- a/src/middleware/__tests__/with-kya-os.test.ts
+++ b/src/middleware/__tests__/with-kya-os.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 import {
   createKyaOsMiddleware,
   type KyaOsAuditTrail,
@@ -16,6 +17,8 @@ import type {
 import {
   base64ToBytes,
   base64urlEncodeFromBytes,
+  base64urlDecodeToBytes,
+  bytesToBase64,
 } from '../../utils/base64.js';
 import { AuditLogProvider, MemoryAuditLogProvider } from '../../providers/audit-log.js';
 import { cheqdResolver } from '../../integrations/cheqd/index.js';
@@ -1343,5 +1346,134 @@ describe('withPolicyGate', () => {
     const result = await handler({ table: 'users', _kyaos_approvals: [grant] });
     expect(result.isError).toBe(true);
     expect(JSON.parse(text(result)).error).toBe('needs_approval');
+  });
+});
+
+describe('wrapWithDelegation — VC-JWT (compact JWS) string form', () => {
+  // A VC-JWT carries its signature in the compact-JWS ENVELOPE, not an embedded
+  // `proof` block. The gate must verify that envelope against the issuer's
+  // published key before authorizing the call — otherwise a hand-forged string
+  // naming any subject/scope executes the tool. did:key issuers resolve to their
+  // own key material, so the built-in did:key resolver covers these tests.
+
+  const b64url = (obj: unknown): string =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+
+  let uniqueCounter = 0;
+  const uniqueId = (): string => `${Date.now()}-${uniqueCounter++}`;
+
+  async function didKeyAgent(): Promise<{ did: string; privateKey: CryptoKey }> {
+    const { publicKey, privateKey } = await generateKeyPair('EdDSA', {
+      extractable: true,
+    });
+    const jwk = await exportJWK(publicKey);
+    if (!jwk.x) throw new Error('exported JWK is missing x');
+    const did = generateDidKeyFromBase64(bytesToBase64(base64urlDecodeToBytes(jwk.x)));
+    return { did, privateKey };
+  }
+
+  function delegationClaim(did: string, scopes: string[]): Record<string, unknown> {
+    return {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      id: `urn:uuid:jwt-${uniqueId()}`,
+      type: ['VerifiableCredential', 'DelegationCredential'],
+      issuer: did,
+      issuanceDate: '2026-01-01T00:00:00.000Z',
+      expirationDate: '2099-01-01T00:00:00.000Z',
+      credentialSubject: {
+        id: did,
+        delegation: {
+          id: `del-jwt-${uniqueId()}`,
+          issuerDid: did,
+          subjectDid: did,
+          status: 'active',
+          constraints: {
+            scopes,
+            notAfter: Math.floor(Date.now() / 1000) + 3600,
+          },
+        },
+      },
+    };
+  }
+
+  async function mintVcJwt(
+    signer: CryptoKey,
+    issuerDid: string,
+    scopes: string[],
+  ): Promise<string> {
+    return new SignJWT({ vc: delegationClaim(issuerDid, scopes) })
+      .setProtectedHeader({ alg: 'EdDSA', typ: 'JWT' })
+      .setIssuer(issuerDid)
+      .setSubject(issuerDid)
+      .setIssuedAt()
+      .sign(signer);
+  }
+
+  it('accepts a correctly-signed VC-JWT string and runs the handler', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const agent = await didKeyAgent();
+    const jwt = await mintVcJwt(agent.privateKey, agent.did, ['test:scope']);
+
+    const handler = kyaos.wrapWithDelegation(
+      'my-tool',
+      { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+      async (args) => ({
+        content: [{ type: 'text', text: `Called: ${JSON.stringify(args)}` }],
+      }),
+    );
+
+    const result = await handler({ _kyaos_delegation: jwt, name: 'DIF' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text.replace('Called: ', ''));
+    expect(parsed['_kyaos_delegation']).toBeUndefined();
+    expect(parsed['name']).toBe('DIF');
+  });
+
+  it('SECURITY: rejects a hand-forged VC-JWT string (real issuer DID, bogus signature) and never runs the handler', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    // A resolvable did:key issuer, a structurally-complete delegation carrying
+    // the exact scope the tool requires, and a signature that is pure garbage.
+    const agent = await didKeyAgent();
+    const forged =
+      `${b64url({ alg: 'EdDSA', typ: 'JWT' })}.` +
+      `${b64url({ iss: agent.did, sub: agent.did, vc: delegationClaim(agent.did, ['test:scope']) })}.` +
+      'not-a-real-signature';
+
+    let handlerRan = false;
+    const handler = kyaos.wrapWithDelegation(
+      'my-tool',
+      { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+      async () => {
+        handlerRan = true;
+        return { content: [{ type: 'text', text: 'should not reach' }] };
+      },
+    );
+
+    const result = await handler({ _kyaos_delegation: forged, name: 'attacker' });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe('delegation_invalid');
+    expect(handlerRan).toBe(false);
+  });
+
+  it('SECURITY: rejects a VC-JWT signed by a key that is NOT the issuer DID key', async () => {
+    const { middleware: kyaos } = await createTestMiddleware();
+    const issuer = await didKeyAgent();
+    const attacker = await didKeyAgent();
+    // Names `issuer.did` as issuer/subject but signs with the attacker's key —
+    // the envelope must be checked against the RESOLVED issuer key.
+    const jwt = await mintVcJwt(attacker.privateKey, issuer.did, ['test:scope']);
+
+    const handler = kyaos.wrapWithDelegation(
+      'my-tool',
+      { scopeId: 'test:scope', consentUrl: 'https://example.com/consent' },
+      async () => ({ content: [{ type: 'text', text: 'should not reach' }] }),
+    );
+
+    const result = await handler({ _kyaos_delegation: jwt });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe('delegation_invalid');
   });
 });

--- a/src/middleware/with-kya-os.delegation-gate.ts
+++ b/src/middleware/with-kya-os.delegation-gate.ts
@@ -14,11 +14,7 @@ import {
   toHolderBindingRequest,
 } from "../delegation/holder-binding.js";
 import { scopeSatisfies } from "../delegation/scope-matcher.js";
-import { parseVCJWT } from "../delegation/utils.js";
-import {
-  type DelegationCredential,
-  type DetachedProof,
-} from "../types/protocol.js";
+import { type DetachedProof } from "../types/protocol.js";
 import { logger } from "../logging/index.js";
 import { KYA_OS_ERROR_CODES } from "../errors.js";
 import type {
@@ -75,7 +71,7 @@ export function createDelegationGate(
   const { attachOutcomeProof, resolveExistingGrant, bindGrantOnSuccess } =
     wiring;
   const {
-    validateDelegationChain,
+    verifyDelegation,
     buildDelegationErrorResponse,
     buildNeedsAuthorizationChallenge,
   } = createDelegationVerification(deps);
@@ -149,67 +145,15 @@ export function createDelegationGate(
         );
       }
 
-      // Accept delegation as either a JSON object (embedded proof) or a
-      // VC-JWT string (compact JWT). The Cloudflare consent service issues
-      // VC-JWTs; examples use embedded proofs. Support both transparently.
-      let vc: DelegationCredential;
-      let isVCJWT = false;
-      if (typeof delegationArg === "string") {
-        const parsed = parseVCJWT(delegationArg);
-        if (!parsed || !parsed.payload.vc) {
-          return attachOutcomeProof(
-            buildDelegationErrorResponse(
-              KYA_OS_ERROR_CODES.delegation_invalid,
-              "Invalid VC-JWT format",
-            ),
-            toolName,
-            args,
-            sessionId,
-            "Invalid VC-JWT format",
-          );
-        }
-        vc = parsed.payload.vc as DelegationCredential;
-        // VC-JWTs don't have an embedded proof — the JWT signature is the
-        // proof. Add a marker so basic validation (which checks for proof
-        // presence) passes. The actual signature is in the JWT envelope.
-        if (!vc.proof) {
-          vc = { ...vc, proof: { type: 'JwtProof2020', jwt: delegationArg } };
-        }
-        isVCJWT = true;
-      } else {
-        vc = delegationArg as DelegationCredential;
-      }
-
-      // For VC-JWTs the embedded-signature check is skipped (the JWT envelope
-      // signature is the proof); schema/expiry/status/scope checks still apply.
-      // validateDelegationChain performs the shape check and returns
-      // { valid, reason } for malformed input, never throwing on normal or
-      // structurally-malformed credentials. This try/catch is therefore a PURE
-      // BACKSTOP — it fires only on a truly unexpected throw (e.g. a hostile
-      // getter/Proxy accessor or a provider fault): it logs the detail
-      // server-side and returns a GENERIC reason, so no internal/implementation
-      // detail (stack, raw error text) leaks to the client or the signed proof.
-      const verificationResult = await (async (): Promise<{
-        valid: boolean;
-        reason?: string;
-      }> => {
-        try {
-          return await validateDelegationChain(vc, { skipSignature: isVCJWT });
-        } catch (error) {
-          logger.error("[kya-os] Unexpected error verifying delegation", {
-            tool: toolName,
-            error: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-          return { valid: false, reason: "Delegation credential could not be verified" };
-        }
-      })();
-
-      if (!verificationResult.valid) {
-        const reason = verificationResult.reason ?? "Unknown delegation validation error";
+      // Authenticate the presented delegation (object embedded-proof OR VC-JWT
+      // string) and normalize it to a verified credential. verifyDelegation owns
+      // the wire-form-specific signature checks — the gate never sets
+      // skipSignature itself, so a JWT envelope can't be silently skipped.
+      const check = await verifyDelegation(delegationArg);
+      if (!check.valid) {
         try {
           await audit?.delegation('rejected', {
-            delegationRef: rejectedDelegationRef(vc),
+            delegationRef: rejectedDelegationRef(check.vc),
             outcome: 'failed',
             reasonCode: 'DELEGATION_VERIFICATION_FAILED',
           });
@@ -220,16 +164,17 @@ export function createDelegationGate(
           });
         }
         logger.warn(
-          `[kya-os] Delegation verification failed for "${toolName}": ${sanitizeForMessage(reason)}`,
+          `[kya-os] Delegation verification failed for "${toolName}": ${sanitizeForMessage(check.reason)}`,
         );
         return attachOutcomeProof(
-          buildDelegationErrorResponse(KYA_OS_ERROR_CODES.delegation_invalid, reason),
+          buildDelegationErrorResponse(KYA_OS_ERROR_CODES.delegation_invalid, check.reason),
           toolName,
           args,
           sessionId,
-          reason,
+          check.reason,
         );
       }
+      const { vc, isJwt } = check;
 
       // Holder binding (spec §11.8): the delegation is valid, but a valid
       // *credential* is a bearer token until we also prove the caller holds the
@@ -328,7 +273,7 @@ export function createDelegationGate(
         );
       }
 
-      const serializedCredential = isVCJWT
+      const serializedCredential = isJwt
         ? new TextEncoder().encode(delegationArg as string)
         : canonicalizeJsonBytes(vc);
       const credentialDigest = await cryptoProvider.hash(serializedCredential) as Digest;
@@ -373,7 +318,7 @@ export function createDelegationGate(
 
       // Mint a durable grant from this verified delegation so the next call —
       // on any instance — resolves via resolveExistingGrant with no re-paste.
-      await bindGrantOnSuccess(vc, delegationArg, isVCJWT, sessionId, config.scopeId);
+      await bindGrantOnSuccess(vc, delegationArg, isJwt, sessionId, config.scopeId);
 
       logger.debug(
         `[kya-os] Delegation verified for "${toolName}", scope "${config.scopeId}"`,

--- a/src/middleware/with-kya-os.delegation-verify.ts
+++ b/src/middleware/with-kya-os.delegation-verify.ts
@@ -20,7 +20,7 @@ import {
 } from "../delegation/vc-verifier.js";
 import { validateDelegationChain as validateDelegationChainCore } from "../delegation/chain-enforcement.js";
 import { RuntimeFetchProvider } from "../providers/runtime-fetch.js";
-import { canonicalizeJSON } from "../delegation/utils.js";
+import { canonicalizeJSON, parseVCJWT } from "../delegation/utils.js";
 import { base64urlDecodeToBytes, bytesToBase64 } from "../utils/base64.js";
 import {
   createNeedsAuthorizationError,
@@ -42,17 +42,27 @@ export interface DelegationGateConfig {
   ) => Array<{ type: "text"; text: string }>;
 }
 
+/**
+ * Outcome of authenticating a presented delegation. On success the caller gets
+ * the normalized credential and its wire form; on failure a sanitizable reason
+ * plus the best-effort parsed credential (for audit references), if any.
+ */
+export type DelegationCheck =
+  | { valid: true; vc: DelegationCredential; isJwt: boolean }
+  | { valid: false; reason: string; vc?: DelegationCredential };
+
 export interface DelegationVerification {
   /**
-   * Thin adapter over the framework-agnostic core (chain-enforcement.ts): binds
-   * the host's injected verifier + server DID + resolver + the optional
-   * graph-backed RevocationChecker. Returns `{ valid, reason }`, never throws on
-   * normal or structurally-malformed credentials.
+   * Authenticate and normalize a presented `_kyaos_delegation`, in either wire
+   * form, into a single verified credential. A VC-JWT **string** is verified by
+   * its compact-JWS ENVELOPE signature against the issuer's published key; an
+   * **object** is verified by its embedded Data-Integrity proof. Both then run
+   * the full chain / scope-superset / expiry / status / revocation walk. Owning
+   * the `skipSignature` decision here (never at the call site) is what stops a
+   * JWT envelope from being silently skipped. Returns a {@link DelegationCheck},
+   * never throws on normal or structurally-malformed input.
    */
-  validateDelegationChain(
-    leafCredential: DelegationCredential,
-    options?: { skipSignature?: boolean },
-  ): Promise<{ valid: boolean; reason?: string }>;
+  verifyDelegation(delegationArg: unknown): Promise<DelegationCheck>;
   /** A structured `{ error, reason }` tool response with a sanitized reason. */
   buildDelegationErrorResponse(
     error: string,
@@ -206,6 +216,76 @@ export function createDelegationVerification(
       options,
     );
 
+  async function verifyDelegation(
+    delegationArg: unknown,
+  ): Promise<DelegationCheck> {
+    // Normalize to a DelegationCredential, authenticating by wire form. A VC-JWT
+    // string carries its signature in the compact-JWS ENVELOPE; an object carries
+    // an embedded Data-Integrity proof (verified inside validateDelegationChain).
+    let vc: DelegationCredential;
+    let isJwt = false;
+
+    if (typeof delegationArg === "string") {
+      const parsed = parseVCJWT(delegationArg);
+      if (!parsed || !parsed.payload.vc) {
+        return { valid: false, reason: "Invalid VC-JWT format" };
+      }
+      // Envelope-first: verify the JWT signature against the issuer's published
+      // key BEFORE the chain runs with skipSignature. Reuses the vetted verifier
+      // (EdDSA-pinned compact-JWS + iss/issuer consistency; fail-closed). Status
+      // is checked once by the chain walk below, so skip it here.
+      const envelope = await verifier.verifyDelegationJwt(delegationArg, {
+        skipStatus: true,
+      });
+      if (!envelope.valid) {
+        return {
+          valid: false,
+          reason: envelope.reason ?? "VC-JWT envelope signature is not valid",
+          vc: parsed.payload.vc as DelegationCredential,
+        };
+      }
+      vc = parsed.payload.vc as DelegationCredential;
+      // A JWT has no embedded `proof`; add a marker so basic validation (which
+      // requires proof presence) passes. The already-verified envelope is the
+      // real proof, so the chain walk runs with skipSignature (below).
+      if (!vc.proof) {
+        vc = { ...vc, proof: { type: "JwtProof2020", jwt: delegationArg } };
+      }
+      isJwt = true;
+    } else {
+      vc = delegationArg as DelegationCredential;
+    }
+
+    // Chain / scope-superset / expiry / status / revocation. skipSignature is
+    // true ONLY for a JWT (its envelope, verified above, is the proof); an object
+    // keeps it false so validateDelegationChain verifies the embedded proof.
+    // That call never throws on normal/malformed input; this backstop catches
+    // only a truly unexpected throw (hostile getter/Proxy, provider fault) and
+    // returns a GENERIC reason so no internal detail leaks to the client/proof.
+    let chain: { valid: boolean; reason?: string };
+    try {
+      chain = await validateDelegationChain(vc, { skipSignature: isJwt });
+    } catch (error) {
+      logger.error("[kya-os] Unexpected error verifying delegation", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      chain = {
+        valid: false,
+        reason: "Delegation credential could not be verified",
+      };
+    }
+
+    if (!chain.valid) {
+      return {
+        valid: false,
+        reason: chain.reason ?? "Unknown delegation validation error",
+        vc,
+      };
+    }
+    return { valid: true, vc, isJwt };
+  }
+
   async function buildNeedsAuthorizationChallenge(
     toolName: string,
     config: DelegationGateConfig,
@@ -256,7 +336,7 @@ export function createDelegationVerification(
   }
 
   return {
-    validateDelegationChain,
+    verifyDelegation,
     buildDelegationErrorResponse,
     buildNeedsAuthorizationChallenge,
   };


### PR DESCRIPTION
Ships as **1.15.0** (non-breaking). Three commits: the security fix, a docs move, and the release bump.

## Fix — VC-JWT envelope verification

A `_kyaos_delegation` in the compact **VC-JWT (string)** form was accepted with **no signature check**: the gate ran `validateDelegationChain` with `skipSignature: true` and nothing verified the JWT envelope, so a hand-forged `header.payload.garbage` naming any subject/scope executed the tool. The **object** (embedded-proof) form was always verified and is unchanged.

The wire-form-specific authentication now lives in one place: `createDelegationVerification` exposes **`verifyDelegation(arg)`**, which verifies a JWT by its **envelope** (reusing `DelegationCredentialVerifier` — EdDSA-pinned compact-JWS + `iss`/`issuer` consistency) before the chain walk, and an object by its embedded proof. The gate calls it once and **never sets `skipSignature` itself**, so the envelope can't be silently skipped again — the gate sheds ~55 lines and the foot-gun.

**Non-breaking:** every demo and all example suites present the object form or a genuinely-signed did:key VC-JWT — all still verify. Only unsigned/forged/unresolvable-issuer JWTs, never legitimately accepted, are now rejected.

## Docs — did:cheqd reference moved out of the README

The did:cheqd + DID-Linked Resources section was 176 lines (~40% of the README) for an opt-in, operator-focused integration. Moved the full reference to **`src/integrations/cheqd/README.md`** (co-located with the code that implements it); the README keeps a short pointer + enable snippet. README 453 → 298 lines. Docs only.

## Tests / validation

Three gate-level VC-JWT cases (correctly-signed runs; forged and non-issuer-key rejected as `delegation_invalid`, handler never invoked), each **proven to fail without the fix**. Full suite **2065 passed**; example suites **consent-full 43 / consent-basic 36 / authz-inspector 17 / revoked 5** (against a rebuilt `dist/`); lint, typecheck, coverage (above ratchet), and `npm publish --dry-run` all green.