### PR TITLE
docs: drop the dangling code-of-conduct reference from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,3 @@ Protocol changes should be discussed in DIF TAAWG before implementation. Open an
 
 Do NOT open public GitHub issues for security vulnerabilities. See SECURITY.md.
 
----
-
-## Code of Conduct
-
-This project follows the Contributor Covenant Code of Conduct. See CODE_OF_CONDUCT.md.


### PR DESCRIPTION
Replaces closed #177 per owner direction: instead of adding a repo-local CODE_OF_CONDUCT.md, remove the dangling reference - this repo is DIF-hosted and conduct procedures are DIF's to define, not this repo's to specify. One section (3 lines) removed from CONTRIBUTING.md; nothing else changes. The #177 branch has been deleted.