### PR TITLE
feat(conformance): suite-hash tooling + CI-enforced vector immutability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Vector suite bytes are the conformance pin: no checkout-time eol conversion.
+conformance/vectors/*.json -text
+conformance/SUITE-MANIFEST.json -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,14 @@ jobs:
       - name: Run conformance vectors
         run: pnpm run conformance
 
+      # The committed vector set is immutable at a suiteVersion: recompute the
+      # suite hash from the raw vector bytes and fail if it drifts from
+      # conformance/SUITE-MANIFEST.json without a suiteVersion bump. The vitest
+      # suite enforces the same invariant; this step keeps it visible as its
+      # own CI line.
+      - name: Verify vector-set immutability
+        run: node conformance/suite-hash.mjs --check
+
       # Independently re-verify the org.kya-os/proof@1 card-proof vector in a second
       # language (pure Python stdlib, shares no code with the TS reference) — proves
       # cross-language JCS (RFC 8785) + Ed25519 signature parity. Exits non-zero on mismatch.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -457,6 +457,16 @@ pnpm run conformance:generate
 
 Re-running mints fresh keys but preserves every positive/negative relationship by
 construction.
+Because fresh keys change the committed bytes, regenerated output MUST NOT be committed over an existing `suiteVersion` (see [Suite versioning and immutability](#suite-versioning-and-immutability)).
+
+### Suite versioning and immutability
+
+The committed vector set is immutable at a given `suiteVersion`: the vector bytes may only change together with a `suiteVersion` bump.
+`conformance/SUITE-MANIFEST.json` pins the current set (`suiteVersion`, `vectorSetHash`, `vectorCount`, per-file hashes) and is the anchor CI verifies against.
+The hash recipe: SHA-256 each vector file's raw committed bytes, sort the `[filename, hex]` pairs by filename, canonicalize the array with RFC 8785 (JCS), SHA-256 that, prefix with `sha256:`.
+CI enforces the invariant twice: a vitest guard (`conformance/__tests__/suite-immutability.test.ts`) and a dedicated step running `node conformance/suite-hash.mjs --check`.
+To change vectors intentionally, bump `suiteVersion` (including the in-file `version` fields), regenerate the manifest with `node conformance/suite-hash.mjs --json`, and keep `pinnedAt` current.
+The SIGNED public suite manifest published by the Conformance Attestation Program is a separate artifact built on this committed one.
 
 ### Running the harness against YOUR implementation
 

--- a/conformance/SUITE-MANIFEST.json
+++ b/conformance/SUITE-MANIFEST.json
@@ -1,0 +1,20 @@
+{
+  "suiteVersion": "1.0.0",
+  "vectorSetHash": "sha256:81d537d4574d3f66d651a03ca41c0b18493b67ea6f3e61aba47d1bda4f3cf49b",
+  "vectorCount": 44,
+  "files": [
+    ["audit-integrity.json", "e0611dae5b4d93fb9f3bfa4f661eb34b34ef88a753d34d8f9866c1538c858bdd"],
+    ["card-proof.json", "b84aa690d2f893e709c25ee4c362573967c0fef85df9444fca74e2cf9921e0a2"],
+    ["delegation-chain.json", "fe735155c6ebace03f167d86d988d3b79988f7fcdfe48b964428eaf3871637b3"],
+    ["did-key-resolution.json", "edef894fdb3ee89f81bf05ea56f398f8f1e89979cab7d41c2aa06a7da1566f1b"],
+    ["did-web-resolution.json", "315833469a01c1c53ae91f72492a18bc2e648ef95b58dec19fdfbab25aeb24c6"],
+    ["entity-card.json", "a3a45e8786868f8ab898baee261d0106c89716d75657da9677eec62e2fa7c949"],
+    ["negotiation.json", "e512bb962a8c1e7119537b591dbe91087c8c623fe5c42e9956ed24e60b0adc49"],
+    ["signed-proof.json", "695196e1ff4f42e1c09337bf4fdae856b585cffd5f678ae0cd5c8b96353d44f9"],
+    ["status-list.json", "1559aa415c1004473d72a4e8f1478aa99a2072f8cc80e203eb31570f05d537df"]
+  ],
+  "pinnedAt": {
+    "package": "@kya-os/mcp",
+    "packageVersion": "1.14.2"
+  }
+}

--- a/conformance/__tests__/suite-immutability.test.ts
+++ b/conformance/__tests__/suite-immutability.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Vector-set immutability invariant.
+ *
+ * The committed conformance vectors are pinned by conformance/SUITE-MANIFEST.json:
+ * per-file SHA-256 over the raw committed bytes, [filename, hex] pairs sorted by
+ * filename, RFC 8785 (JCS) canonicalization of the array, SHA-256 of that,
+ * "sha256:" prefix. This test recomputes the hash from disk through the
+ * library's real `canonicalizeJSON` (the standalone `conformance/suite-hash.mjs`
+ * uses a JCS-equivalent JSON.stringify shortcut, so this doubles as a guard on
+ * that equivalence) and fails on ANY drift: a changed byte, an added file, or a
+ * deleted file. `pnpm run conformance:generate` mints fresh keys, so its output
+ * must never be committed over an existing suiteVersion.
+ */
+
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { canonicalizeJSON } from '../../src/delegation/utils.js';
+import { VECTORS_DIR } from '../loader.js';
+
+const INVARIANT =
+  'conformance vectors are immutable at a suiteVersion; bump suiteVersion in ' +
+  'SUITE-MANIFEST.json (and regenerate the manifest with suite-hash.mjs --json) ' +
+  'if this change is intentional.';
+
+interface SuiteManifest {
+  suiteVersion: string;
+  vectorSetHash: string;
+  vectorCount: number;
+  files: [string, string][];
+  pinnedAt: { package: string; packageVersion: string };
+}
+
+const sha256 = (bytes: Buffer | string): string =>
+  createHash('sha256').update(bytes).digest('hex');
+
+const manifest = JSON.parse(
+  readFileSync(join(VECTORS_DIR, '..', 'SUITE-MANIFEST.json'), 'utf8'),
+) as SuiteManifest;
+
+const committedNames = readdirSync(VECTORS_DIR)
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+const committedFiles: [string, string][] = committedNames.map((name) => [
+  name,
+  sha256(readFileSync(join(VECTORS_DIR, name))),
+]);
+
+describe('conformance vector-set immutability (SUITE-MANIFEST.json)', () => {
+  it('recomputed vectorSetHash matches the committed manifest', () => {
+    const recomputed = `sha256:${sha256(canonicalizeJSON(committedFiles))}`;
+    expect(recomputed, INVARIANT).toBe(manifest.vectorSetHash);
+  });
+
+  it('every committed vector file appears in the manifest (no untracked additions)', () => {
+    const pinned = new Set(manifest.files.map(([name]) => name));
+    const added = committedNames.filter((name) => !pinned.has(name));
+    expect(added, INVARIANT).toEqual([]);
+  });
+
+  it('every manifest file exists in vectors/ (no untracked deletions)', () => {
+    const onDisk = new Set(committedNames);
+    const deleted = manifest.files.map(([name]) => name).filter((name) => !onDisk.has(name));
+    expect(deleted, INVARIANT).toEqual([]);
+  });
+
+  it('per-file hashes match the manifest', () => {
+    expect(committedFiles, INVARIANT).toEqual(manifest.files);
+  });
+
+  it('vectorCount matches the vectors committed on disk', () => {
+    const count = committedNames.reduce((total, name) => {
+      const parsed = JSON.parse(readFileSync(join(VECTORS_DIR, name), 'utf8')) as {
+        vectors: unknown[];
+      };
+      return total + parsed.vectors.length;
+    }, 0);
+    expect(count, INVARIANT).toBe(manifest.vectorCount);
+  });
+
+  it('every vector file carries the manifest suiteVersion', () => {
+    for (const name of committedNames) {
+      const parsed = JSON.parse(readFileSync(join(VECTORS_DIR, name), 'utf8')) as {
+        version: string;
+      };
+      expect(parsed.version, `${name}: ${INVARIANT}`).toBe(manifest.suiteVersion);
+    }
+  });
+});

--- a/conformance/suite-hash.mjs
+++ b/conformance/suite-hash.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Suite-hash tool for the KYA-OS conformance vector set.
+ *
+ * Recipe (KYA-OS Conformance Attestation Program):
+ *   1. SHA-256 of each vector file's raw committed bytes.
+ *   2. Array of [filename, hex] pairs, sorted by filename.
+ *   3. RFC 8785 (JCS) canonicalization of that array.
+ *   4. vectorSetHash = "sha256:" + SHA-256 hex of the canonical form.
+ *
+ * JCS note: this script must run under plain `node` in CI, so it cannot import
+ * the repo's TypeScript `canonicalizeJSON`. For an array of [string, string]
+ * pairs, `JSON.stringify` IS the JCS serialization: RFC 8785 preserves array
+ * order and defines string serialization exactly as ECMAScript
+ * `JSON.stringify` (RFC 8785 section 3.2.2.2), and the only constructs where
+ * JCS can differ from a naive serializer (object member sorting, number
+ * formatting) cannot occur in this shape. The vitest immutability test
+ * recomputes the hash through the library's real `canonicalizeJSON`, so any
+ * divergence here would fail CI.
+ *
+ * Usage:
+ *   node conformance/suite-hash.mjs           # print the vectorSetHash
+ *   node conformance/suite-hash.mjs --json    # print {suiteVersion, vectorSetHash, vectorCount, files}
+ *   node conformance/suite-hash.mjs --check   # exit non-zero if SUITE-MANIFEST.json does not match
+ */
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = join(HERE, 'SUITE-MANIFEST.json');
+
+const sha256 = (bytes) => createHash('sha256').update(bytes).digest('hex');
+
+export function computeSuite(vectorsDir = join(HERE, 'vectors')) {
+  const names = readdirSync(vectorsDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+  let vectorCount = 0;
+  const versions = new Set();
+  const files = names.map((name) => {
+    const bytes = readFileSync(join(vectorsDir, name));
+    const parsed = JSON.parse(bytes.toString('utf8'));
+    vectorCount += parsed.vectors.length;
+    versions.add(parsed.version);
+    return [name, sha256(bytes)];
+  });
+  if (versions.size !== 1) {
+    throw new Error(`vector files disagree on version: ${[...versions].join(', ')}`);
+  }
+  // JCS-equivalent for an array of string pairs; see header comment.
+  const vectorSetHash = `sha256:${sha256(JSON.stringify(files))}`;
+  return { suiteVersion: [...versions][0], vectorSetHash, vectorCount, files };
+}
+
+const mode = process.argv[2] ?? '';
+const computed = computeSuite();
+if (mode === '--json') {
+  console.log(JSON.stringify(computed, null, 2));
+} else if (mode === '--check') {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  const mismatched = ['suiteVersion', 'vectorSetHash', 'vectorCount', 'files'].filter(
+    (key) => JSON.stringify(manifest[key]) !== JSON.stringify(computed[key]),
+  );
+  if (mismatched.length > 0) {
+    console.error(`suite-hash: MISMATCH with SUITE-MANIFEST.json on: ${mismatched.join(', ')}`);
+    console.error(`  committed: ${manifest.vectorSetHash} (${manifest.vectorCount} vectors)`);
+    console.error(`  computed:  ${computed.vectorSetHash} (${computed.vectorCount} vectors)`);
+    console.error(
+      'Conformance vectors are immutable at a suiteVersion. If this change is intentional,',
+    );
+    console.error(
+      'bump suiteVersion and regenerate the manifest with `node conformance/suite-hash.mjs --json`.',
+    );
+    process.exit(1);
+  }
+  console.log(
+    `suite-hash: OK ${computed.vectorSetHash} matches SUITE-MANIFEST.json ` +
+      `(suiteVersion ${computed.suiteVersion}, ${computed.vectorCount} vectors)`,
+  );
+} else if (mode === '') {
+  console.log(computed.vectorSetHash);
+} else {
+  console.error(`suite-hash: unknown flag "${mode}" (expected --json or --check)`);
+  process.exit(2);
+}


### PR DESCRIPTION
Committee pre-flight #6 for the KYA-OS Conformance Attestation Program: make vector-set immutability a CI-enforced invariant, with the suite-hash tooling the program design specifies.

## The invariant

The committed conformance vectors are immutable at a given `suiteVersion` (currently `1.0.0`, carried in every vector file).
The vector bytes may only change together with a `suiteVersion` bump.
In particular, `pnpm run conformance:generate` mints fresh keys on every run, so incidental regeneration must never be silently committed over an existing `suiteVersion`; CI now fails if it is.

## The hash recipe (program design)

1. SHA-256 of each vector file's raw committed bytes.
2. Array of `[filename, hex]` pairs, sorted by filename.
3. RFC 8785 (JCS) canonicalization of that array.
4. SHA-256 of the canonical form, prefixed with `sha256:`.

Current pin: `sha256:81d537d4574d3f66d651a03ca41c0b18493b67ea6f3e61aba47d1bda4f3cf49b` over 9 vector files / 44 vectors.

## What's in the PR

- `conformance/suite-hash.mjs`: plain-node tool. Bare invocation prints the hash; `--json` prints `{suiteVersion, vectorSetHash, vectorCount, files}`; `--check` exits non-zero on any drift from the manifest. It runs without a TS loader, so it serializes the pair array with `JSON.stringify`, which is byte-identical to JCS for an array of string pairs (no object keys to sort, no numbers to format); the vitest guard recomputes through the library's real `canonicalizeJSON`, so any divergence would fail CI.
- `conformance/SUITE-MANIFEST.json`: the committed manifest and CI anchor, pinning `suiteVersion`, `vectorSetHash`, `vectorCount`, per-file hashes, and `pinnedAt` (`@kya-os/mcp` 1.14.2).
- `conformance/__tests__/suite-immutability.test.ts`: recomputes the hash from the committed bytes and asserts it matches the manifest, plus vectorCount, per-file hashes, file-set equality in both directions (catches additions and deletions), and that every vector file carries the manifest `suiteVersion`. Failure messages state the invariant and the intentional-change procedure.
- CI: the Protocol Conformance Harness job gains a dedicated `node conformance/suite-hash.mjs --check` step (the vitest guard also runs in the normal `pnpm test` line).
- `CONFORMANCE.md`: new "Suite versioning and immutability" section with the recipe and the regeneration policy.

## Relationship to the program

The SIGNED public suite manifest the Conformance Attestation Program publishes (the artifact credentials pin to) is separate; this committed manifest is the in-repo CI anchor that makes that signature meaningful, because the bytes it signs can no longer drift unnoticed.

## Validation

- Full suite green (150 files, 2071 tests) including the new guard; `conformance:typecheck` and lint clean.
- Mutation-tested: a single-byte change to a vector fails both `--check` (exit 1, mismatch on `vectorSetHash`/`files`) and the vitest guard; an in-file `version` edit additionally trips the version-coherence assertions. Reverted after proof.
- `suite-hash.mjs --json` output cross-checked byte-for-byte against the repo's RFC 8785 `canonicalizeJSON`.