### PR TITLE
fix(deps): lift brace-expansion to 5.0.9 in the pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,8 +653,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   bytes@3.1.2:
@@ -2039,7 +2039,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2519,7 +2519,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
Follow-through on the brace-expansion advisory emails: the reported alert (CVE-2026-13149) was already fixed in July, and the alerts dashboard is clean today - but auditing the lockfiles against the full advisory history turned up one residue. The npm lockfile picked up 5.0.9 in the August 13 sweep, while the pnpm lockfile stayed on 5.0.8, which sits inside CVE-2026-69152's affected range (>= 4.0.0, < 5.0.9). Its alert (#229) was auto-dismissed as development-scope rather than fixed, so nothing ever bumped it.

The exposure is dev-tooling only (`minimatch@10.2.6 -> brace-expansion`), so the auto-dismissal was defensible - but the two lockfiles should not disagree about a version with an open advisory against it.

Lockfile-only change (resolution + integrity + the one dependent reference); no manifest edits, no runtime dependency touched, no release required.