### PR TITLE
fix(delegation): mint a sessionId for sessionless request proofs

### DIFF
--- a/src/delegation/__tests__/holder-binding.test.ts
+++ b/src/delegation/__tests__/holder-binding.test.ts
@@ -209,6 +209,32 @@ describe('generateRequestProof + toHolderBindingRequest (client mint <-> PEP ass
     expect(result.status).toBe('bound');
   });
 
+  it('a proof minted WITHOUT a sessionId still binds (sessionless request proof)', async () => {
+    // `sessionId` is optional on GenerateRequestProofInput - a request proof can
+    // precede any handshake, which is the normal case for a stateless MCP core.
+    // But `meta.sessionId` is a required NON-EMPTY string in the proof schema,
+    // so defaulting it to '' minted a proof that could never verify: the
+    // legitimate holder came back `unbound`/INVALID_PROOF_STRUCTURE, exactly
+    // like a thief. Every other test here passes a sessionId explicitly, which
+    // is why that never surfaced.
+    const args = { path: '/secret' };
+    const proof = await generateRequestProof({
+      identity: agent,
+      crypto,
+      toolName: 'read_vault',
+      args,
+      audience: AUDIENCE,
+    });
+    expect(proof.meta.sessionId).not.toBe('');
+    const result = await assertHolderBinding({
+      proof,
+      subjectDid: agent.did,
+      request: toHolderBindingRequest('read_vault', args),
+      proofVerifier: makeVerifier(),
+    });
+    expect(result.status).toBe('bound');
+  });
+
   it('a proof minted for one call does not bind a different call (content binding)', async () => {
     const proof = await generateRequestProof({
       identity: agent,

--- a/src/delegation/holder-binding.ts
+++ b/src/delegation/holder-binding.ts
@@ -98,8 +98,15 @@ export async function generateRequestProof(
   const request = toHolderBindingRequest(toolName, args);
   const nonce = base64urlEncodeFromBytes(await crypto.randomBytes(16));
   const now = Math.floor(Date.now() / 1000);
+  // `sessionId` is optional on the way in (a request proof can precede any
+  // handshake), but `meta.sessionId` is a REQUIRED non-empty string in the
+  // proof schema. Defaulting to '' therefore minted a proof that could never
+  // verify: `assertHolderBinding` rejected the LEGITIMATE holder as
+  // INVALID_PROOF_STRUCTURE, indistinguishably from a thief. Mint a per-proof
+  // id instead, so the sessionless case (the stateless MCP core) works.
+  const boundSessionId = sessionId ?? `req-${base64urlEncodeFromBytes(await crypto.randomBytes(9))}`;
   return generator.generateProof(request, undefined, {
-    sessionId: sessionId ?? '',
+    sessionId: boundSessionId,
     audience,
     nonce,
     timestamp: now,


### PR DESCRIPTION
## The bug

`generateRequestProof` defaults `meta.sessionId` to `''` when the caller omits it:

```ts
sessionId: sessionId ?? '',
```

But `sessionId` is a **required non-empty string** in the proof meta schema (`src/types/protocol.ts`):

```ts
const requiredStrings = ['did', 'kid', 'nonce', 'audience', 'sessionId'];
if (typeof m[field] !== 'string' || m[field].length < 1) { … }
```

So a sessionless request proof fails validation as `INVALID_PROOF_STRUCTURE`, and `assertHolderBinding` returns `unbound` for the **legitimate holder** — indistinguishable from the thief the gate exists to catch.

`sessionId` is documented as optional on `GenerateRequestProofInput` ("The handshake session id, when one exists"), and a request proof routinely precedes any handshake on a stateless core, so the sessionless path is the normal case rather than an edge case.

## Severity

Availability, not a vulnerability — it fails **closed**. Nothing is wrongly admitted. But phase-1 holder binding is unusable without passing a `sessionId` that the signature never said was mandatory, and the failure surfaces as the same `holder_binding_failed` a real theft produces, so it is easy to misread as working.

## Why the tests did not catch it

Every existing case in `holder-binding.test.ts` passes `sessionId` explicitly (`'sess-1'`, `'s'`). The omitted-argument path had no coverage. This PR adds it.

## The fix

Mint a per-proof id when none is supplied. Verification, the schema, and the conformance vectors are untouched — this only changes what a client puts in a field the schema already required.

## Verification

- New test `a proof minted WITHOUT a sessionId still binds (sessionless request proof)` fails on `main` and passes with the fix (confirmed by reverting the one-line change and re-running).
- Full suite green: **150 files, 2072 passed, 1 skipped**.

Found while building an adversarial demo against the hosted PoC server, where the beat asserting that a stolen credential fails holder binding could not first show the honest holder succeeding.
